### PR TITLE
Improve handling Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:12
 
+# Install PHP and GDAL
+RUN apt-get update
+RUN apt-get install -y php7.0-cli php-db php-sqlite3 gdal-bin libgdal-dev python-pip python-gdal
+
 # Create app directory
 WORKDIR /usr/src/app
 
@@ -10,10 +14,6 @@ RUN npm install
 
 # Bundle app source
 COPY . .
-
-# Install PHP and GDAL
-RUN apt-get update
-RUN apt-get install -y php7.0-cli php-db php-sqlite3 gdal-bin libgdal-dev python-pip python-gdal
 
 # build
 RUN npm run build

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ To run MMGIS in a container, you need to create a directory on the host machine 
 
 `docker run -v /Missions:/usr/src/app/Missions <image tag>`
 
-If using `docker-compose`, map the volume and set all the env variables.
+This repo contains a `docker-compose.yml` file that defines a service for the application and a PostgreSQL database with PostGIS installed. Simply set all the env variables in `.env` and run:
+
+`docker-compose up`
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3"
+services:
+  mmgis:
+    build: .
+    depends_on:
+      - db
+    env_file: .env
+    ports:
+      - 8888:8888
+    restart: on-failure
+    volumes:
+      - ./Missions:/usr/src/app/Missions
+  db:
+    image: postgis/postgis:10-2.5-alpine
+    env_file: .env
+    ports:
+      - 5432:5432
+    restart: on-failure
+    volumes:
+      - mmgis-db:/var/lib/postgresql/data
+volumes:
+  mmgis-db:


### PR DESCRIPTION
After deploying MMGIS with Docker, here are a few little changes that should make it easier for folks to use Docker in the future.

1. Reorganizes the Dockerfile to take advantage of layer caching. With the new Dockerfile, you can rebuild the image when source code changes without reinstalling all dependencies. FYI, if you ever want to force Docker to rebuild all layers and reinstall the GDAL and PHP dependencies, you can use the `--no-cache` flag
2. Adds a docker-compose file that's ready to use. Includes instructions.