### PR TITLE
Clear InfoTool and description if vector data cleared

### DIFF
--- a/src/essence/Ancillary/Description.js
+++ b/src/essence/Ancillary/Description.js
@@ -216,6 +216,11 @@ var Description = {
             Description.descPointLinks.html(links)
         }
     },
+    clearDescription: function () {
+        // Clear the description
+        $('#mainDescPointInner').empty()
+        $('#mainDescPointLinks').empty()
+    },
 }
 
 export default Description

--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -2,6 +2,7 @@
 import F_ from '../Formulae_/Formulae_'
 import Description from '../../Ancillary/Description'
 import Search from '../../Ancillary/Search'
+import ToolController_ from '../../Basics/ToolController_/ToolController_'
 import $ from 'jquery'
 
 var L_ = {
@@ -667,6 +668,7 @@ var L_ = {
     clearVectorLayer: function (layerName) {
         try {
             L_.layersGroup[layerName].clearLayers()
+            L_.clearVectorLayerInfo()
         } catch (e) {
             console.log(e)
             console.warn(
@@ -700,11 +702,22 @@ var L_ = {
                 )
             }
 
+            const infoTool = ToolController_.getTool('InfoTool');
+
             // Keep N elements if greater than 0 else keep all elements
             if (keepN && keepNum > 0) {
                 var layers = updateLayer.getLayers()
                 while (layers.length > keepNum) {
-                    updateLayer.removeLayer(layers[0])
+
+                    // If we remove a layer but its properties are displayed in the InfoTool
+                    // and description (i.e. it was clicked), clear the InfoTool and description
+                    const removeLayer = layers[0];
+                    if (infoTool.currentLayer === removeLayer) {
+                        L_.clearVectorLayerInfo()
+                    }
+
+                    // Remove the layer
+                    updateLayer.removeLayer(removeLayer)
                     layers = updateLayer.getLayers()
                 }
             }
@@ -714,6 +727,16 @@ var L_ = {
                     layerName
             )
         }
+    },
+    clearVectorLayerInfo: function () {
+        // Clear the InfoTools data
+        const infoTool = ToolController_.getTool('InfoTool')
+        if (infoTool.hasOwnProperty('clearInfo')) {
+            infoTool.clearInfo();
+        }
+
+        // Clear the description
+        Description.clearDescription()
     },
 }
 

--- a/src/essence/Tools/Info/InfoTool.js
+++ b/src/essence/Tools/Info/InfoTool.js
@@ -374,6 +374,20 @@ var InfoTool = {
             }
         })
     },
+    clearInfo: function () {
+        this.currentLayer = null
+        this.currentLayerName = null
+        this.info = null
+        this.variables = null
+        this.activeFeatureI = null
+
+        // Clear the InfoTools data
+        $('#infoToolData').empty()
+        $('#infoToolHeader > .right').css('display', 'none')
+        $('#infoToolSelected').css('display', 'none')
+        $('#infoToolFilter').css('display', 'none')
+        $('#infoToolNoneSelected').css('display', 'block')
+    },
 }
 
 //


### PR DESCRIPTION
This fixes a bug found in the feature #50, where the InfoTool and description is not cleared when calling functions from `window.API`.

The InfoTool and description is always cleared if `window.API.clearVectorLayer` is called.
For `window.API. updateVectorLayer `, the InfoTool and description is only cleared if the selected vector data layer (i.e. clicked vector data) is cleared by the function.