### PR TITLE
Several improvements to time control

### DIFF
--- a/config/js/config.js
+++ b/config/js/config.js
@@ -412,9 +412,12 @@ function initialize() {
 
                 //time
                 if (typeof cData.time != "undefined") {
-                  $("#tab_time #time_enabled").prop("checked", cData.time.includes('enabled') ? true : false);
-                  $("#tab_time #time_visible").prop("checked", cData.time.includes('visible') ? true : false);
+                  $("#tab_time #time_enabled").prop("checked", cData.time.enabled ? true : false);
+                  $("#tab_time #time_visible").prop("checked", cData.time.visible ? true : false);
                 }
+                $("#tab_time #time_format").val(
+                  cData.time ? cData.time.format : "%Y-%m-%dT%H:%M:%SZ"
+                );
 
                 //tools
                 //uncheck all tools
@@ -1118,7 +1121,7 @@ if (typeof d.time != "undefined") {
               "<label>Time Type</label>" +
             "</div>" +
             "<div id='timeFormatEl' class='input-field col s5 push-s1' style='display: " + timeFormatEl + "'>" +
-              "<input id='TimeFormat" + n + "' type='text' class='validate' value='" + ((typeof d.time != "undefined") ? d.time.format : "YYYY-MM-DDThh:mm:ssZ") + "'>" +
+              "<input id='TimeFormat" + n + "' type='text' class='validate' value='" + ((typeof d.time != "undefined") ? d.time.format : "%Y-%m-%dT%H:%M:%SZ") + "'>" +
               "<label for='TimeFormat" + n + "'>Time Format</label>" +
             "</div>" +
             "<div id='timeRefreshEl' class='input-field col s2 push-s1' style='display: " + timeRefreshEl + "'>" +
@@ -1496,7 +1499,7 @@ function save() {
       panels: [],
       tools: [],
       layers: [],
-      time: [],
+      time: {},
     };
     var prevIndentations = [];
     var prevLayerObjects = [];
@@ -1572,10 +1575,18 @@ function save() {
     if ($("#tab_panels #panels_globe").prop("checked"))
       json.panels.push("globe");
     //Time
-    if ($("#tab_time #time_enabled").prop("checked"))
-      json.time.push("enabled");
-    if ($("#tab_time #time_visible").prop("checked"))
-      json.time.push("visible");
+    if ($("#tab_time #time_enabled").prop("checked")) {
+      json.time.enabled = true
+    }
+    else {
+      json.time.enabled = false
+    }
+    if ($("#tab_time #time_visible").prop("checked")) {
+      json.time.visible = true
+    } else {
+      json.time.visible = false
+    }
+    json.time.format = $("#tab_time #time_format").val();
     //Tools
     for (var i = 0; i < tData.length; i++) {
       if ($("#tab_tools #tools_" + tData[i].name).prop("checked")) {
@@ -1692,6 +1703,7 @@ function save() {
           .find("#timeTypeEl select option:selected")
           .text()
           .toLowerCase();
+        var modalTimeFormat = modal.find("#timeFormatEl input").val();
 
         layerObject.name = modalName;
         if (
@@ -1815,7 +1827,7 @@ function save() {
         layerObject.time.current = new Date().toISOString().split('.')[0]+'Z' // initial time
         layerObject.time.start = '' // initial start
         layerObject.time.end = '' // initial end
-        layerObject.time.format = 'YYYY-MM-DDTHH:mm:ssZ' // time string format
+        layerObject.time.format = modalTimeFormat // time string format
         layerObject.time.refresh = '1 hours' // refresh when the layer becomes stale
         layerObject.time.increment = '5 minutes' // time bar steps
 

--- a/docs/pages/markdowns/Layers_Tab.md
+++ b/docs/pages/markdowns/Layers_Tab.md
@@ -141,7 +141,7 @@ Whether the layer should use global time values or function independently with i
 #### Time Format
 
 _type:_ string _optional_  
-The string format to be used in the URL for `{time}`. Defaults to `YYYY-MM-DDTHH:mm:ssZ`.
+The string format to be used in the URL for `{time}`. Defaults to `%Y-%m-%dT%H:%M:%SZ`.
 
 # Vector Tile
 

--- a/docs/pages/markdowns/Time_Tab.md
+++ b/docs/pages/markdowns/Time_Tab.md
@@ -12,4 +12,6 @@ Whether or not the Time user interface should be visible.
 
 ## Time Format
 
-The time format to be displayed on the Time UI. Currently only works with `YYYY-MM-DDThh:mm:ssZ`.
+The time format to be displayed on the Time UI. Uses D3 time format specifiers: https://github.com/d3/d3-time-format
+
+Default: `%Y-%m-%dT%H:%M:%SZ`

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -318,11 +318,20 @@ let Map_ = {
         }
     },
     refreshLayer: function(layerObj) {
-        this.map.eachLayer( function (layer) {
-            // Need to overcome some weirdness with points not being removed
-            Map_.map.removeLayer( layer )
-            L_.layersLoaded[L_.layersOrdered.indexOf( layerObj.name )] = false
-        });
+        // We need to find and remove all points on the map that belong to the layer
+        // Not sure if there is a cleaner way of doing this
+        for (var i = L_.layersOrdered.length - 1; i >= 0; i--) {
+            if (Map_.hasLayer(L_.layersOrdered[i])) {
+                if (
+                    L_.layersNamed[L_.layersOrdered[i]] &&
+                    L_.layersNamed[L_.layersOrdered[i]].type == 'vector' &&
+                    L_.layersNamed[L_.layersOrdered[i]].name == layerObj.name
+                ) {
+                    Map_.map.removeLayer(L_.layersGroup[L_.layersOrdered[i]])
+                    L_.layersLoaded[L_.layersOrdered.indexOf( layerObj.name )] = false
+                }
+            }
+        }
         Map_.allLayersLoadedPassed = false
         makeLayer(layerObj)
         allLayersLoaded()
@@ -695,12 +704,14 @@ function makeLayer(layerObj) {
     function makeVectorLayer() {
         var layerUrl = layerObj.url
         // Give time enabled layers a default start and end time to avoid errors
-        var startTime = TimeControl.getStartTime()
-        var endTime = TimeControl.getEndTime()
+        var layerTimeFormat = (layerObj.time == null) ? '%Y-%m-%dT%H:%M:%SZ' : d3.utcFormat(layerObj.time.format)
+        var startTime = layerTimeFormat(Date.parse(TimeControl.getStartTime()))
+        var endTime = layerTimeFormat(Date.parse(TimeControl.getEndTime()))
         if (typeof layerObj.time != 'undefined') {
-            layerUrl = layerUrl
+            layerUrl = layerObj.url
                 .replace('{starttime}', startTime)
                 .replace('{endtime}', endTime)
+                .replace('{time}', endTime)
         }
         if (!F_.isUrlAbsolute(layerUrl)) layerUrl = L_.missionPath + layerUrl
         let urlSplit = layerObj.url.split(':')
@@ -837,10 +848,8 @@ function makeLayer(layerObj) {
                     allLayersLoaded()
                 })
                 if (typeof layerObj.time != 'undefined') {
-                    layerUrl = layerUrl
-                    .replace(startTime, '{starttime}')
-                    .replace(endTime, '{endtime}')
-                }               
+                    layerUrl = layerObj.url
+                }
             }
         }
 
@@ -1045,6 +1054,8 @@ function makeLayer(layerObj) {
             reuseTiles: true,
             bounds: bb,
             time: ((typeof layerObj.time === 'undefined') ? '' : layerObj.time.end),
+            starttime: ((typeof layerObj.time === 'undefined') ? '' : layerObj.time.start),
+            endtime: ((typeof layerObj.time === 'undefined') ? '' : layerObj.time.end),
         })
 
         L_.setLayerOpacity(layerObj.name, L_.opacityArray[layerObj.name])

--- a/views/configure.pug
+++ b/views/configure.pug
@@ -311,18 +311,16 @@ script(type='text/javascript' src='src/pre/RefreshAuth.js')
         ul#tab_time_rows
           li.row.title
             .col.s2.push-s2 User Interface 
-          li.row.checkboxRow
-            #time_enabled.input-field.col.s2.push-s2
+          li.row.checkboxRow.col.s2.push-s2
+            p
               input#time_enabled.filled-in.checkbox-color(type='checkbox')
               label(for='time_enabled' style='color: black;') Enabled
-            #time_visible.input-field.col.s2.push-s2
+            p
               input#time_visible.filled-in.checkbox-color(type='checkbox')
               label(for='time_visible' style='color: black;') Visible
-          li.row.title
-            .col.s4.push-s2 Time Format
           li.row
-            #time_format.input-field.col.s4.push-s2
-              input#time_format.validate(type='text' value='YYYY-MM-DDThh:mm:ssZ')
+            #time_format_row.input-field.col.s4.push-s2
+              input#time_format.validate(type='text' value='%Y-%m-%dT%H:%M:%SZ')
               label(for='time_format') Time Format
 
       #tab_tools.col.s12


### PR DESCRIPTION
- Custom global display and layer URL time formats now work (uses d3
time specifiers)
- Fixed Time Tab settings not working correctly
- time and endtime are now interchangeable in layer URLs
- refreshLayer will only redraw the specified layer