### PR TITLE
Clear selected feature when clicking on map areas with no features

### DIFF
--- a/src/essence/Ancillary/Description.js
+++ b/src/essence/Ancillary/Description.js
@@ -220,6 +220,9 @@ var Description = {
         // Clear the description
         $('#mainDescPointInner').empty()
         $('#mainDescPointLinks').empty()
+
+        // Reset the style
+        this.descCont.attr('style', null)
     },
 }
 


### PR DESCRIPTION
This clears the actively selected feature if an area on the map with no features is clicked. This does not clear anything if the user pans around the map.