### PR TITLE
Expose writeCoordinateURL function in MMGIS API

### DIFF
--- a/docs/pages/markdowns/JavaScript_API.md
+++ b/docs/pages/markdowns/JavaScript_API.md
@@ -341,3 +341,15 @@ The following is an example of how to call the `getVisibleLayers` function:
 ```javascript
 window.mmgisAPI.getVisibleLayers()
 ```
+
+## Miscellaneous Features
+
+### writeCoordinateURL
+
+This function writes out the current view as a URL. This programmatically returns the long form of the 'Copy Link' feature and does not save a short URL to the database.
+
+The following is an example of how to call the `writeCoordinateURL` function:
+
+```javascript
+window.mmgisAPI.writeCoordinateURL()
+```

--- a/src/essence/Ancillary/QueryURL.js
+++ b/src/essence/Ancillary/QueryURL.js
@@ -230,6 +230,7 @@ var QueryURL = {
       "tools=camp$1.3.4,"
     */
     writeCoordinateURL: function (
+        shortenURL = true,
         mapLon,
         mapLat,
         mapZoom,
@@ -340,25 +341,28 @@ var QueryURL = {
         if (urlTools !== false) urlAppendage += '&tools=' + urlTools
 
         var url = urlAppendage
+        if (shortenURL) {
+            calls.api(
+                'shortener_shorten',
+                {
+                    url: url,
+                },
+                function (s) {
+                    //Set and update the short url
+                    L_.url = window.location.href.split('?')[0] + '?s=' + s.body.url
+                    window.history.replaceState('', '', L_.url)
+                    if (typeof callback === 'function') callback()
+                },
+                function (e) {
+                    //Set and update the full url
+                    L_.url = window.location.href.split('?')[0] + url
+                    window.history.replaceState('', '', L_.url)
+                    if (typeof callback === 'function') callback()
+                }
+            )
+        }
 
-        calls.api(
-            'shortener_shorten',
-            {
-                url: url,
-            },
-            function (s) {
-                //Set and update the short url
-                L_.url = window.location.href.split('?')[0] + '?s=' + s.body.url
-                window.history.replaceState('', '', L_.url)
-                if (typeof callback === 'function') callback()
-            },
-            function (e) {
-                //Set and update the full url
-                L_.url = window.location.href.split('?')[0] + url
-                window.history.replaceState('', '', L_.url)
-                if (typeof callback === 'function') callback()
-            }
-        )
+        return window.location.href.split('?')[0] + url
     },
     writeSearchURL: function (searchStrs, searchFile) {
         return //!!!!!!!!!!!!!!!!

--- a/src/essence/Basics/UserInterface_/UserInterface_.js
+++ b/src/essence/Basics/UserInterface_/UserInterface_.js
@@ -121,7 +121,7 @@ var UserInterface = {
             .style('cursor', 'pointer')
             .on('click', function () {
                 const linkButton = $(this)
-                QueryURL.writeCoordinateURL(function () {
+                QueryURL.writeCoordinateURL(true, function () {
                     F_.copyToClipboard(L_.url)
 
                     linkButton.removeClass('mdi-open-in-new')

--- a/src/essence/mmgisAPI/mmgisAPI.js
+++ b/src/essence/mmgisAPI/mmgisAPI.js
@@ -1,5 +1,6 @@
 import L_ from '../Basics/Layers_/Layers_'
 import ToolController_ from '../Basics/ToolController_/ToolController_'
+import QueryURL from '../Ancillary/QueryURL'
 import TimeControl from '../Ancillary/TimeControl'
 let L = window.L
 
@@ -131,6 +132,9 @@ var mmgisAPI_ = {
             return 'click'
         }
         return null 
+    },
+    writeCoordinateURL: function() {
+        return QueryURL.writeCoordinateURL(false);
     },
 }
 
@@ -268,6 +272,12 @@ var mmgisAPI = {
      * @param {function} - functionReference - function reference to listener event callback function. null value removes all functions for a given eventName
      */
     removeEventListener: mmgisAPI_.removeEventListener,
+
+    /** writeCoordinateURL - writes out the current view as a url. This returns the long form of
+     * the 'Copy Link' feature and does not save a short url to the database.
+     * @returns {string} - a string containing the current view as a url
+     */
+    writeCoordinateURL: mmgisAPI_.writeCoordinateURL,
 }
 
 window.mmgisAPI = mmgisAPI


### PR DESCRIPTION
This exposes the `writeCoordinateURL` function (used by the "Save Link" feature) in the MMGIS API. This exposed function returns the long URL instead of a shortened URL and does not save the URL to the database.

How to call the function:
```javascript
window.mmgisAPI.writeCoordinateURL()
```

Example:
<img width="395" alt="Screen Shot 2021-06-30 at 11 55 45 AM" src="https://user-images.githubusercontent.com/8588858/124016121-242c3500-d99a-11eb-8fc7-37181d4e8e11.png">
