### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/pages/markdowns/JavaScript_API.md
+++ b/docs/pages/markdowns/JavaScript_API.md
@@ -263,7 +263,7 @@ This function adds a map event listener added using the MMGIS API. This function
 - `eventName` - name of event to add listener to. Available events: `onPan`, `onZoom`, `onClick`
 - `functionReference` - function reference to listener event callback function. `null` value removes all functions for a given `eventName`
 
-The following is an example of how to call the `removeEventListener` function:
+The following is an example of how to call the `addEventListener` function:
 
 ```javascript
 function listener() {


### PR DESCRIPTION
This fixes a typo in the MMGIS API documentation.