### PR TITLE
Allow draw tool features to behave similar to layer features

### DIFF
--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -4,6 +4,7 @@ import Description from '../../Ancillary/Description'
 import Search from '../../Ancillary/Search'
 import ToolController_ from '../../Basics/ToolController_/ToolController_'
 import $ from 'jquery'
+import * as d3 from 'd3'
 
 var L_ = {
     url: window.location.href,
@@ -453,14 +454,20 @@ var L_ = {
         const color =
             (L_.configData.look && L_.configData.look.highlightcolor) || 'red'
         try {
-            if (layer.feature.geometry.type === 'Point')
-                layer.setStyle({
-                    fillColor: color,
-                })
-            else
+            if (layer.feature?.properties?.annotation) {
+                // Annotation
+                let id = '#DrawToolAnnotation_' + layer.feature.properties._.file_id + '_' + layer.feature.properties._.id
+                d3.select(id).style('color', color)
+            } else if (layer.hasOwnProperty('_layers')) {
+                // Arrow
+                var layers = layer._layers
+                layers[Object.keys(layers)[0]].setStyle({ color })
+                layers[Object.keys(layers)[1]].setStyle({ color })
+            } else {
                 layer.setStyle({
                     color: color,
                 })
+            }
         } catch (err) {
             if (layer._icon)
                 layer._icon.style.filter = `drop-shadow(${color}  2px 0px 0px) drop-shadow(${color}  -2px 0px 0px) drop-shadow(${color}  0px 2px 0px) drop-shadow(${color} 0px -2px 0px)`
@@ -515,11 +522,14 @@ var L_ = {
     },
     resetLayerFills: function () {
         for (let key in this.layersGroup) {
+            var s = key.split('_')
+            var onId = s[1] != 'master' ? parseInt(s[1]) : s[1]
             if (
-                this.layersNamed[key] &&
+                (this.layersNamed[key] &&
                 (this.layersNamed[key].type == 'point' ||
                     (key.toLowerCase().indexOf('draw') == -1 &&
-                        this.layersNamed[key].type == 'vector'))
+                        this.layersNamed[key].type == 'vector'))) ||
+                            (s[0] == 'DrawTool' && !Number.isNaN(onId))
             ) {
                 if (
                     this.layersGroup.hasOwnProperty(key) &&
@@ -545,6 +555,48 @@ var L_ = {
                             if (layer._icon) layer._icon.style.filter = ''
                         }
                     })
+                } else if (s[0] == 'DrawTool') {
+                    for (let k in this.layersGroup[key]) {
+                        if (!this.layersGroup[key][k]) continue
+                        if ('getLayers' in this.layersGroup[key][k]) {
+                            let layer = this.layersGroup[key][k]
+                            if (!layer?.feature?.properties?.arrow) {
+                                // Polygons and lines
+                                layer.eachLayer(function(l) {
+                                    setLayerStyle(l)
+                                })
+                            } else {
+                                // Arrow
+                                let layers = this.layersGroup[key][k]._layers
+                                const style = this.layersGroup[key][k].feature.properties.style
+                                const color = style.color
+                                layers[Object.keys(layers)[0]].setStyle({ color })
+                                layers[Object.keys(layers)[1]].setStyle({ color })
+                            }
+                        } else if (this.layersGroup[key][k].feature?.properties?.annotation) {
+                            // Annotation
+                            let layer = this.layersGroup[key][k]
+                            let id = '#DrawToolAnnotation_' + layer.feature.properties._.file_id + '_' + layer.feature.properties._.id
+                            d3.select(id).style('color', layer.feature.properties.style.fillColor)
+                        } else if ('feature' in this.layersGroup[key][k]) {
+                            // Points (that are not annotations)
+                            let layer = this.layersGroup[key][k]
+                            setLayerStyle(layer)
+                        }
+                    }
+
+                    function setLayerStyle(layer) {
+                        const style = layer.feature.properties.style
+                        const color = style.color
+                        if (layer.feature.geometry.type === 'Point')
+                            layer.setStyle({
+                                fillColor: color,
+                            })
+                        else
+                            layer.setStyle({
+                                color: color,
+                            })
+                    }
                 }
             }
         }

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -1498,34 +1498,56 @@ function clearOnMapClick(event) {
         let found = false
         // For all MMGIS layers
         for (let key in L_.layersGroup) {
-            if ('getLayers' in L_.layersGroup[key]) {
-                const layers = L_.layersGroup[key].getLayers()
-                for (let k in layers) {
-                    const layer = layers[k]
+            let layers;
 
-                    if ('getBounds' in layer) {
-                        // Use the pixel bounds because longitude/latitude conversions for bounds
-                        // may be odd in the case of polar projections
-                        if (
-                            layer._pxBounds &&
-                            layer._pxBounds.contains(event.layerPoint)
-                        ) {
-                            found = true
-                            break
-                        }
-                    } else if ('getLatLng' in layer) {
-                        // A latlng is a latlng, regardless of the projection type
-                        if (layer.getLatLng().equals(latlng)) {
-                            found = true
-                            break
-                        }
-                    }
-                }
+            // Layers can be a LayerGroup or an array of LayerGroup
+            if ('getLayers' in L_.layersGroup[key]) {
+                layers = L_.layersGroup[key].getLayers()
             }
+
+            if (Array.isArray(L_.layersGroup[key])) {
+                layers = L_.layersGroup[key]
+            }
+
+            for (let k in layers) {
+                const layer = layers[k]
+                if (!layer) continue
+                if ('getLayers' in layer) {
+                    const _layer = layer.getLayers()
+                    for (let x in _layer) {
+                        found = checkBounds(_layer[x])
+                        if (found) break
+                    }
+                } else {
+                    found = checkBounds(layer)
+                }
+
+                if (found) break
+            }
+
             if (found) {
                 // If a clicked feature is found, break out early because MMGIS can only select
                 // a single feature at a time (i.e. no group select)
                 break
+            }
+
+            function checkBounds(layer) {
+                if ('getBounds' in layer) {
+                    // Use the pixel bounds because longitude/latitude conversions for bounds
+                    // may be odd in the case of polar projections
+                    if (
+                        layer._pxBounds &&
+                        layer._pxBounds.contains(event.layerPoint)
+                    ) {
+                        return true
+                    }
+                } else if ('getLatLng' in layer) {
+                    // A latlng is a latlng, regardless of the projection type
+                    if (layer.getLatLng().equals(latlng)) {
+                        return true
+                    }
+                }
+                return false
             }
         }
 

--- a/src/essence/Tools/Draw/DrawTool_Files.js
+++ b/src/essence/Tools/Draw/DrawTool_Files.js
@@ -4,7 +4,6 @@ import F_ from '../../Basics/Formulae_/Formulae_'
 import L_ from '../../Basics/Layers_/Layers_'
 import Globe_ from '../../Basics/Globe_/Globe_'
 import Map_ from '../../Basics/Map_/Map_'
-import ToolController_ from '../../Basics/ToolController_/ToolController_'
 import CursorInfo from '../../Ancillary/CursorInfo'
 import Modal from '../../Ancillary/Modal'
 

--- a/src/essence/Tools/Draw/DrawTool_Files.js
+++ b/src/essence/Tools/Draw/DrawTool_Files.js
@@ -4,6 +4,7 @@ import F_ from '../../Basics/Formulae_/Formulae_'
 import L_ from '../../Basics/Layers_/Layers_'
 import Globe_ from '../../Basics/Globe_/Globe_'
 import Map_ from '../../Basics/Map_/Map_'
+import ToolController_ from '../../Basics/ToolController_/ToolController_'
 import CursorInfo from '../../Ancillary/CursorInfo'
 import Modal from '../../Ancillary/Modal'
 
@@ -1023,6 +1024,8 @@ var Files = {
         })
         $('.drawToolDrawFilesListElem').off('mouseleave')
         $('.drawToolDrawFilesListElem').on('mouseleave', function () {
+            const infoTool = ToolController_.getTool('InfoTool')
+
             $(this).find('.drawToolFileEdit').removeClass('shown')
             var fileId = parseInt($(this).attr('file_id'))
             var l = L_.layersGroup['DrawTool_' + fileId]
@@ -1039,21 +1042,35 @@ var Files = {
                                 .properties.style
                     else style = l[i].feature.properties.style
 
+                    let color = style.color;
+                    // Keep the active feature highlighted after mouseleave
+                    if (infoTool.currentLayer) {
+                        if (typeof l[i].setStyle === 'function' &&
+                                ((l[i].hasOwnProperty('_layers') && l[i].hasLayer(infoTool.currentLayer)) ||
+                                infoTool.currentLayer === l[i])) {
+                            color = (L_.configData.look && L_.configData.look.highlightcolor) || 'red'
+                        } else if (l[i].hasOwnProperty('_layers') && infoTool.currentLayer === l[i]) {
+                            color = (L_.configData.look && L_.configData.look.highlightcolor) || 'red'
+                        }
+                    }
+
                     if (typeof l[i].setStyle === 'function')
-                        l[i].setStyle(style)
+                        l[i].setStyle({ ...style, color } )
                     else if (l[i].hasOwnProperty('_layers')) {
                         //Arrow
                         var layers = l[i]._layers
-                        layers[Object.keys(layers)[0]].setStyle({
-                            color: style.color,
-                        })
-                        layers[Object.keys(layers)[1]].setStyle({
-                            color: style.color,
-                        })
-                    } else
+                        layers[Object.keys(layers)[0]].setStyle({ color })
+                        layers[Object.keys(layers)[1]].setStyle({ color })
+                    } else {
                         $('.DrawToolAnnotation_' + fileId).removeClass(
                             'highlight'
                         )
+                        if (infoTool.currentLayer === l[i]) {
+                            $('.DrawToolAnnotation_' + fileId).addClass(
+                                'hovered'
+                            )
+                        }
+                    }
                 }
             }
         })

--- a/src/essence/Tools/Draw/DrawTool_Shapes.js
+++ b/src/essence/Tools/Draw/DrawTool_Shapes.js
@@ -526,21 +526,31 @@ var Shapes = {
             else style = shape.feature.properties.style
             if (style == null) style = shape.options
 
-            let color = style.color;
+            let color = style.color
             // Keep the active feature highlighted after mouseleave
-            const infoTool = ToolController_.getTool('InfoTool')
-            if (infoTool.currentLayer) {
-                if (typeof shape.setStyle === 'function' &&
-                        ((shape.hasOwnProperty('_layers') && shape.hasLayer(infoTool.currentLayer)) ||
-                        infoTool.currentLayer === shape)) {
-                    color = (L_.configData.look && L_.configData.look.highlightcolor) || 'red'
-                } else if (shape.hasOwnProperty('_layers') && infoTool.currentLayer === shape) {
-                    color = (L_.configData.look && L_.configData.look.highlightcolor) || 'red'
+            if (Map_.activeLayer) {
+                if (
+                    typeof shape.setStyle === 'function' &&
+                    ((shape.hasOwnProperty('_layers') &&
+                        shape.hasLayer(Map_.activeLayer)) ||
+                        Map_.activeLayer === shape)
+                ) {
+                    color =
+                        (L_.configData.look &&
+                            L_.configData.look.highlightcolor) ||
+                        'red'
+                } else if (
+                    shape.hasOwnProperty('_layers') &&
+                    Map_.activeLayer === shape
+                ) {
+                    color =
+                        (L_.configData.look &&
+                            L_.configData.look.highlightcolor) ||
+                        'red'
                 }
             }
 
-            if (typeof shape.setStyle === 'function')
-                shape.setStyle({ color })
+            if (typeof shape.setStyle === 'function') shape.setStyle({ color })
             else if (shape.hasOwnProperty('_layers')) {
                 //Arrow
                 var layers = shape._layers
@@ -553,7 +563,7 @@ var Shapes = {
                         '_' +
                         $(this).attr('shape_id')
                 ).removeClass('highlight')
-                if (infoTool.currentLayer === l[i]) {
+                if (Map_.activeLayer === l[i]) {
                     $(
                         '#DrawToolAnnotation_' +
                             $(this).attr('layer_id') +

--- a/src/essence/Tools/Draw/DrawTool_Shapes.js
+++ b/src/essence/Tools/Draw/DrawTool_Shapes.js
@@ -3,7 +3,6 @@ import * as d3 from 'd3'
 import F_ from '../../Basics/Formulae_/Formulae_'
 import L_ from '../../Basics/Layers_/Layers_'
 import Map_ from '../../Basics/Map_/Map_'
-import ToolController_ from '../../Basics/ToolController_/ToolController_'
 import CursorInfo from '../../Ancillary/CursorInfo'
 
 var DrawTool = null

--- a/src/essence/mmgisAPI/mmgisAPI.js
+++ b/src/essence/mmgisAPI/mmgisAPI.js
@@ -133,7 +133,19 @@ var mmgisAPI_ = {
     },
     // Returns an object with the visiblity state of all layers
     getVisibleLayers: function () {
-        return L_.toggledArray
+        // Also return the visibility of the DrawTool layers
+        var drawToolVisibility = {}
+        for (let l in L_.layersGroup) {
+            if (!(l in L_.toggledArray)) {
+                var s = l.split('_')
+                var onId = s[1] != 'master' ? parseInt(s[1]) : s[1]
+                if (s[0] == 'DrawTool') {
+                    drawToolVisibility[l] = ToolController_.getTool('DrawTool').filesOn.indexOf(onId) != -1
+                }
+            }
+        }
+
+        return { ...L_.toggledArray, ...drawToolVisibility }
     },
     // Adds map event listener
     addEventListener: function (eventName, functionReference) {


### PR DESCRIPTION
This updates the features created via the draw tool to behave similar to layer features when the draw tool panel is hidden. All of the normal draw tool functions return when the draw tool panel is visible.

Once the draw tool panel is hidden, draw tool features that are currently visible:
- Can be selected by clicking the feature and the selected feature information is displayed in the InfoTools and in the description of the top toolbar 
- Can be deselected by clicking anywhere on the map or another feature
- If a feature is selected, it will be returned as the active feature with `window.mmgisAPI. getActiveFeature()`

Draw tool layers that were visible at least once will:
- Appear as one of the objects returned by `window.mmgisAPI.featuresContained()` if any of the layer's features are in the current map bounds
- Appear as one of the objects returned by `window.mmgisAPI.getVisibleLayers()`

If a draw tool feature is selected and then the draw tool panel is made visible, the selected draw tool feature will:
- Maintain its selected highlight color after hovering over the selected draw tool feature on the map
- Maintain its selected highlight color after hovering over the draw tool layer name in the draw tool panel (i.e. after all features in a draw tool layer are highlighted when hovering over a draw tool layer name)
- Be deselected by clicking anywhere on the map that is not a draw tool feature

Draw tool layers have unique names that starts with `DrawTool_` and an appended number. The user provided name for a given draw tool layer is saved under the feature object as the property `layerName`.
