### PR TITLE
Clear the active layer when clicking on map area with no features

### DIFF
--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -1555,6 +1555,7 @@ function clearOnMapClick(event) {
 
         // If no feature was selected by this click event, clear the currently selected item
         if (!found) {
+            Map_.activeLayer = null
             L_.resetLayerFills()
             L_.clearVectorLayerInfo()
         }


### PR DESCRIPTION
This should fix the "small issue" mentioned in https://github.com/NASA-AMMOS/MMGIS/pull/82#pullrequestreview-716187777.