### PR TITLE
Bug fixes for DrawTool layers

### DIFF
--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -607,14 +607,9 @@ var L_ = {
                     function setLayerStyle(layer) {
                         const style = layer.feature.properties.style
                         const color = style.color
-                        if (layer.feature.geometry.type === 'Point')
-                            layer.setStyle({
-                                fillColor: color,
-                            })
-                        else
-                            layer.setStyle({
-                                color: color,
-                            })
+                        layer.setStyle({
+                            color: color,
+                        })
                     }
                 }
             }

--- a/src/essence/Tools/Draw/DrawTool.js
+++ b/src/essence/Tools/Draw/DrawTool.js
@@ -781,6 +781,12 @@ var DrawTool = {
                                         d
                                     )
 
+                                    // Fire a click event for the DrawTool text annotations
+                                    // to make sure the 'onClick' listener in the MMGIS API will be triggered
+                                    if (layer.feature?.properties?.annotation) {
+                                        Map_.map.fireEvent('click')
+                                    }
+
                                     Globe_.highlight(
                                         Globe_.findSpriteObject(
                                             layer.options.layerName,


### PR DESCRIPTION
This fixes 2 bugs:
1. The highlight for DrawTool points was not cleared when clicking on map areas where there are no features
2. Clicking DrawTool text annotations did not trigger the mmgisAPI `onClick` event listener 