### PR TITLE
Add Isochrone tool

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -28,6 +28,7 @@ let tools = [
   "Draw",
   "Identifier",
   "Info",
+  "Isochrone",
   "Layers",
   "Legend",
   "Measure",

--- a/docs/pages/markdowns/Isochrone.md
+++ b/docs/pages/markdowns/Isochrone.md
@@ -1,0 +1,78 @@
+# Isochrone
+
+The Isochrone tool shades regions of the map based on traverse time (or other "costs") from user-defined source points. Analysis is done by one of several selectable models and based on user-defined constraints. Hover over the generated shape to view the least-cost path to any given point from the start point. Users may view multiple isochrones simultaneously, and change the size, resolution, color ramp, color steps, and opacity of each one.
+
+## Tool Configuration
+
+### Example
+
+```javascript
+{
+    "data": {
+        "DEM": [
+            {
+                "name": "Unique Name 1",
+                "tileurl": "Layers/Example/{z}/{x}/{y}.png",
+                "minZoom": 8,
+                "maxNativeZoom": 18,
+                "resolution": 256,
+                "interpolateSeams": true
+            },
+            { "...": "..." }
+        ],
+        "slope": [
+            { "...": "..." }
+        ],
+        "cost": [
+            { "...": "..." }
+        ]
+    },
+    "interpolateSeams": false,
+    "models": ["Traverse Time", "Isodistance", "..."]
+}
+```
+
+_**data**_ - Each key in the "data" field should be the name of a type of data to be used in analysis. Examples of data types may include "DEM", "slope", "obstacle", "cost", or "shade". Values are an array of data source objects.
+
+Data source objects must include a unique _**name**_, a _**tileurl**_, _**minZoom**_ and _**maxNativeZoom**_, and a _**resolution**_ indicating a power of 2 tile size between 32 and 256. Sources may also include an optional _**interpolateSeams**_ property, indicating per-source whether to correct tile seams (see global `interpolateSeams` property, below). Tiles should be in the same format as a DEM tileset (see `/auxiliary/1bto4b`). Note that the tool has no means of verifying that the tileset it is pointed to contains the right kind of data, so configure carefully.
+
+Each model may require one or more of these data types to operate. Users will be prompted to select one of the configured sources for each of these data types. If no valid sources are configured for a data type a model needs, the tool will display an error message.
+
+_**interpolateSeams**_ - Because `1bto4b` generates tiles with matching edges, data loaded and passed to models may have "seams," or regularly-spaced pairs of identical rows and columns. Depending on the data type and model, these seams may or may not cause inaccurate results. The default behavior of the tool is therefore to attempt to correct these seams. Set this property to false to disable this behavior for all sources that do not explicitly set their own `interpolateSeams` property to `true`.
+
+_**models**_ - An optional list of models to make available. If not configured, a default list will be used.
+
+## Tool Use
+
+With the isochrone tool active, click on the map to generate an isochrone starting from the clicked point. This isochrone will update dynamically as its properties are changed. Hover over the isochrone to view least-cost paths and total accumulated costs at any shaded point. Note that while many isochrones may be visible at once, only one "focused" isochrone will render least-cost paths. An isochrone may be brought into "focus" by clicking its marker on the map, its name in the toolbar, or by modifying any of its properties.
+
+### General Properties
+General display options available to all isochrones.
+
+_**Max Radius**_ - The radius of data to fetch around the start point. Note that, depending on the max cost setting, isochrones may run into this boundary. If the edge of the isochrone appears jagged, this property should be increased.
+
+_**Color**_ - Selects a color ramp for the isochrone.
+
+_**Opacity**_ - Changes the opacity of the isochrone.
+
+_**Steps**_ - Picks the number of color steps in the isochrone, to reveal contours inside the shape. Set to 0 for a continuous ramp.
+
+_**Model**_ - Selects which model to use to generate the isochrone. See `/src/essence/Tools/Isochrone/models` to create custom models.
+
+### Data Properties
+Options related to how data is retrieved and displayed.
+
+_**Resolution**_ - Changes the resolution of the isochrone. This number represents the zoom level at which the resulting layer will be rendered.
+
+**Data Sources** - Options to set the source for every data set required by the selected model. If no valid source has been listed for one or more required data set, an error message will appear and the isochrone will not render.
+
+### Model properties
+Options specific to the selected model.
+
+**Max Cost** - This section will always include a max cost option, in units relevant to the selected model. This represents the cost to reach the edges of the isochrone from the start point, and will thus determine the ultimate size of the shape.
+
+This section may have additional options specified by the selected model.
+
+## Technical
+
+The Isochrone tool runs a version of Dijkstra's algorithm on tiled data to generate results. In this implementation, every pixel is a vertex which is implicitly connected by an edge to 16 of its neighbors: its 8 immediate neighbors, plus neigbors that can be reached by the "knight's move" - i.e. the move a knight makes on a chessboard. Analysis is performed entirely in-browser in JavaScript.

--- a/src/essence/Tools/Isochrone/IsochroneTool.css
+++ b/src/essence/Tools/Isochrone/IsochroneTool.css
@@ -1,0 +1,206 @@
+#isochroneTool {
+    width: 100%;
+    height: 100%;
+    color: white;
+    background-color: var(--color-k);
+}
+
+#isochroneToolHeader {
+    display: flex;
+    justify-content: space-between;
+    height: 40px;
+    padding-left: 6px;
+    line-height: 40px;
+    font-size: 16px;
+    color: var(--color-l);
+    background-color: var(--color-a);
+    border-bottom: 1px solid var(--color-i);
+}
+
+#isochroneToolTitle {
+    font-family: lato-light;
+    text-transform: uppercase;
+}
+
+#isochroneToolHeader #iscNew {
+    display: flex;
+    cursor: pointer;
+    height: 40px;
+    line-height: 40px;
+    font-size: 14px;
+    padding-right: 6px;
+    transition: color 0.2s cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+#isochroneTool #iscNew:hover {
+    color: var(--color-mmgis);
+}
+
+#isochroneOptionsContainer {
+    height: calc(100% - 40px);
+    overflow-y: auto;
+    margin: 0;
+    padding: 0;
+}
+
+li.focused {
+    background: linear-gradient(180deg, var(--color-i), rgba(0, 0, 0, 0) 75%);
+}
+
+.isochroneHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items:center;
+    height: 28px;
+    border-bottom: 1px solid var(--color-e);
+}
+
+.isochroneHeader .checkbox.on {
+    background: white;
+    border: 0px solid #777;
+}
+.isochroneHeader .checkbox {
+    margin: 5px;
+    width: 14px;
+    height: 14px;
+    border: 2px solid #777;
+    border-radius: 3px;
+    cursor: pointer;
+    transition: background 0.2s cubic-bezier(0.39, 0.575, 0.565, 1),
+        border 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
+}
+.isochroneHeader .iscicon {
+    cursor: pointer;
+    margin-top: 2px;
+}
+
+.isochroneHeader .title {
+    flex: 1;
+}
+
+.focused .isochroneHeader {
+    background-color: var(--color-b);
+}
+.focused .isochroneOptions {
+    border-left-color: #e0e0e0;
+}
+.focused .isochroneOptions > div, .focused .isochroneOptions > section > div {
+    color: #cfcfcf;
+}
+
+.isochroneOptions {
+    position: relative;
+    border-left: 5px solid var(--color-e);
+    overflow: hidden;
+    transition: height 0.2s linear;
+}
+.isochroneOptions.collapsed {
+    height: 0px;
+}
+
+.isochroneOptions > div, .isochroneOptions > section > div {
+    display: flex;
+    justify-content: space-between;
+    height: 26px;
+    line-height: 26px;
+    padding-left: 5px;
+    border-bottom: 1px solid var(--color-e);
+    font-size: 15px;
+    overflow: clip;
+    color: #909090;
+}
+
+#isochroneTool .dropdown {
+    background-color: var(--color-i);
+    color: #ededed;
+    border: none;
+    border-radius: 0;
+    width: 120px;
+    height: 25px;
+    font-size: 14px;
+    transition: height 0.2s linear;
+}
+
+#isochroneTool .dropdown.color {
+    position: absolute;
+    right: 0;
+    border: none;
+}
+
+#isochroneTool .dropdown.color canvas {
+    vertical-align: top;
+}
+
+#isochroneTool .dropdown.color:hover canvas.selected {
+    outline: 3px solid #fff;
+    outline-offset: -3px;
+}
+
+#isochroneTool .dropdown.color:not(:hover) canvas:not(.selected) {
+    height: 0px;
+}
+
+#isochroneTool .unit {
+    width: 33px;
+    text-align: center;
+    background: var(--color-i);
+    border-left: 1px solid var(--color-e);
+    color: #bfbfbf;
+    font-size: 14px;
+    line-height: 26px;
+}
+
+#isochroneTool input[type='number'] {
+    border: none;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.3);
+    border-radius: 0;
+    padding: 0px 6px;
+    height: 26px;
+    width: 87px;
+    background: var(--color-i);
+    text-align: right;
+    color: #ededed;
+}
+
+#isochroneTool input[type='number'].nounit {
+    width: 120px;
+}
+
+#isochroneTool .slider2 {
+    width: 120px !important;
+    height: 25px;
+    background: var(--color-i);
+    opacity: 1 !important;
+    margin: 0;
+    border-radius: 0;
+}
+
+#isochroneTool .sectionhead {
+    font-variant: small-caps;
+    font-size: 16px;
+    height: 21px;
+    line-height: 20px;
+    background: linear-gradient(90deg, var(--color-b) 0%, rgba(0, 0, 0, 0) 100%);
+}
+
+#isochroneTool div.loading {
+    width: 100%;
+    overflow: visible;
+    padding-left: 0px;
+}
+
+#isochroneTool div.loading div {
+    width: 0%;
+    position: absolute;
+    left: 0;
+    height: 25px;
+    background: #486f9d;
+}
+#isochroneTool div.loading div.error {
+    width: 100%;
+    background: #c72323;
+}
+
+#isochroneTool div.loading span {
+    margin-left: 5px;
+    z-index: 100;
+}

--- a/src/essence/Tools/Isochrone/IsochroneTool.js
+++ b/src/essence/Tools/Isochrone/IsochroneTool.js
@@ -1,0 +1,588 @@
+import $ from 'jquery';
+import L_ from '../../Basics/Layers_/Layers_';
+import Map_ from '../../Basics/Map_/Map_';
+import CursorInfo from '../../Ancillary/CursorInfo';
+
+import IsochroneManager from './IsochroneTool_Manager';
+import models from './models';
+
+import './IsochroneTool.css';
+const L = window.L;
+
+/*
+Handles map events, sidebar management, drawing layers and markers.
+Individual isochrones, from data gathering to modeling to analysis,
+are handled in IsochroneTool_Manager and its imports.
+*/
+
+const markup =
+`<div id="isochroneTool">
+    <div id="isochroneToolHeader">
+        <span id="isochroneToolTitle">Isochrone</span>
+        <span id="iscNew">
+            New
+            <i class="mdi mdi-plus mdi-18px"></i>
+        </span>
+    </div>
+    <ul id="isochroneOptionsContainer"></ul>
+</div>`;
+
+//Legacy color mapping function
+function hueMap(val) {
+    const hueToChannel = h => {
+        h = (h + 1530) % 1530;
+        if (h < 255) return h;
+        if (h < 765) return 255;
+        if (h < 1020) return 255 - (h % 255);
+        return 0;
+    }
+    const hue = Math.floor(val * 1050);
+    const r = hueToChannel(hue + 510);
+    const g = hueToChannel(hue);
+    const b = hueToChannel(hue - 510);
+    return [r, g, b];
+}
+
+//https://leafletjs.com/reference-1.7.1.html#gridlayer
+L.IsochroneLayer = L.GridLayer.extend({
+    //Override to make layer accept Bounds in place of LatLngBounds
+    //  (cleaner, supports polar projections better)
+    _isValidTile(coords) {
+        const bounds = this.options.bounds;
+        return coords.x >= bounds.min.x
+            && coords.y >= bounds.min.y
+            && coords.x < bounds.max.x
+            && coords.y < bounds.max.y;
+    },
+    createTile: function(coords) {
+        const tile = L.DomUtil.create('canvas', 'leaflet-tile');
+
+        const size = this.getTileSize();
+        tile.width = size.x;
+        tile.height = size.y;
+
+        const ctx = tile.getContext('2d');
+        const img = ctx.getImageData(0, 0, size.x, size.y);
+
+        const bounds = this.options.bounds;
+        const tXOffset = coords.x - bounds.min.x;
+        const tYOffset = coords.y - bounds.min.y;
+
+        const alpha = Math.floor(this.options.opacity * 255);
+
+        let di = 0; //img data index
+        for (let y = 0; y < size.y; y++) {
+            const yIndex = tYOffset * size.y + y;
+            for (let x = 0; x < size.x; x++) {
+                const xIndex = tXOffset * size.x + x;
+                const currentData = this.options.data[yIndex][xIndex];
+                if (isFinite(currentData) && currentData <= this.options.maxCost) {
+                    const color = IsochroneTool.valueToColor(
+                        currentData / this.options.maxCost,
+                        this.options.color,
+                        this.options.steps
+                    );
+                    img.data[di] = color[0];
+                    img.data[di + 1] = color[1];
+                    img.data[di + 2] = color[2];
+                    img.data[di + 3] = alpha;
+                } else {
+                    img.data[di] = 0;
+                    img.data[di + 1] = 0;
+                    img.data[di + 2] = 0;
+                    img.data[di + 3] = 0;
+                }
+                di += 4;
+            }
+        }
+
+        ctx.putImageData(img, 0, 0);
+        return tile;
+    }
+});
+
+//See IsochroneTool_Algorithm.js
+const backlinkToMove = [
+    [0, 1],
+    [1, 2],
+    [1, 1],
+    [2, 1],
+    [1, 0],
+    [2, -1],
+    [1, -1],
+    [1, -2],
+    [0, -1],
+    [-1, -2],
+    [-1, -1],
+    [-2, -1],
+    [-1, 0],
+    [-2, 1],
+    [-1, 1],
+    [-1, 2]
+];
+
+
+
+
+const IsochroneTool = {
+    height: 0,
+    width: 250,
+    MMGISInterface: null,
+    vars: null,
+
+    dataSources: {},
+    enabledModels: [],
+    containerEl: null,
+
+    managers: [],
+    activeManager: null,
+    managerCounter: 0,
+
+    hovered: false,
+    lastHoverCall: 0,
+    hoverPolyline: null,
+
+    //https://developers.arcgis.com/javascript/latest/visualization/symbols-color-ramps/esri-color-ramps/
+    colorRamps: [
+        [ //Red 5
+            [254, 229, 217],
+            [252, 187, 161],
+            [252, 106, 74],
+            [222, 45, 38],
+            [165, 15, 21]
+        ],
+        [ //Orange 4
+            [255, 255, 178],
+            [254, 204, 92],
+            [253, 141, 60],
+            [240, 59, 32],
+            [189, 0, 38]
+        ],
+        [ //Green 1
+            [237, 248, 233],
+            [186, 228, 179],
+            [116, 196, 118],
+            [49, 163, 84],
+            [0, 109, 44]
+        ],
+        [ //Blue 4
+            [240, 249, 232],
+            [186, 228, 188],
+            [123, 204, 196],
+            [67, 162, 202],
+            [8, 104, 172]
+        ],
+        [ //Purple 4
+            [237, 248, 251],
+            [179, 205, 227],
+            [140, 150, 198],
+            [136, 86, 167],
+            [129, 15, 124]
+        ]
+    ],
+
+    initialize: function() {
+        this.vars = L_.getToolVars('isochrone');
+        const globalIS = this.vars.interpolateSeams !== false;
+
+        //add info for scaling low-res tiles
+        for (const dataType in this.vars.data) {
+            const lcDataType = dataType.toLowerCase();
+            this.dataSources[lcDataType] = [];
+            for (const src of this.vars.data[dataType]) {
+                const {name, tileurl, minZoom, maxNativeZoom, resolution} = src;
+                
+                const sourceIS = src.interpolateSeams;
+                const interpolateSeams = sourceIS === undefined ? globalIS : sourceIS;
+
+                let zoomOffset = null;
+                switch (resolution) {
+                    case 256:
+                        zoomOffset = 0;
+                    break;
+                    case 128:
+                        zoomOffset = 1;
+                    break;
+                    case 64:
+                        zoomOffset = 2;
+                    break;
+                    case 32:
+                        zoomOffset = 3;
+                    break;
+                    case undefined:
+                        console.warn(`IsochroneTool: ${dataType} source "${name}" has no defined resolution!`);
+                    break;
+                    default:
+                        console.warn(`IsochroneTool: ${dataType} source "${name}" has nonstandard resolution: ${resolution}!`);
+                }
+
+                const minResolution = Math.max(minZoom - zoomOffset, 0);
+                const maxResolution = maxNativeZoom - zoomOffset;
+
+                if (zoomOffset !== null) {
+                    //Data source interface
+                    this.dataSources[lcDataType].push({
+                        name, //string
+                        tileurl, //string
+                        minZoom, //number
+                        maxNativeZoom, //number
+                        resolution, //number
+                        minResolution, //number
+                        maxResolution, //number
+                        zoomOffset, //number
+                        interpolateSeams //boolean
+                    });
+                }
+            }
+        }
+
+        if (this.vars.models) {
+            const lcModelNames = this.vars.models.map(m => m.toLowerCase());
+            const modelIndex = m => lcModelNames.indexOf(m.nameString.toLowerCase());
+            this.enabledModels = models.filter(m => modelIndex(m) > -1);
+            this.enabledModels.sort((a, b) => modelIndex(a) - modelIndex(b));
+        } else {
+            this.enabledModels = models.filter(m => m.enabledByDefault);
+        }
+    },
+
+    make: function() {
+        this.MMGISInterface = new interfaceWithMMGIS();
+
+        $('#iscNew').on('click', () => this.addIsochrone());
+        this.containerEl = $('#isochroneOptionsContainer');
+        this.addIsochrone();
+    },
+
+    destroy: function() {
+        for (const {marker, layerName} of this.managers) {
+            Map_.rmNotNull(marker);
+            Map_.rmNotNull(L_.layersGroup[layerName]);
+        }
+
+        if (this.hoverPolyline !== null) {
+            this.hoverPolyline.remove(Map_.map);
+        }
+
+        this.managers = [];
+        this.activeManager = null;
+        this.managerCounter = 0;
+        this.MMGISInterface.separateFromMMGIS();
+    },
+
+    /**
+     * Applies a color ramp to a value, using one of the ramps from `IsochroneTool.colorRamps`
+     * @param {number} val Value to convert, between 0 and 1
+     * @param {number} rampIndex Index of color ramp to use
+     * @param {number} steps Optional number of discrete color steps to apply to the ramp
+     * @returns {number[]} Array `[r, g, b]` of color channels
+     */
+    valueToColor: function(val, rampIndex, steps = 0) {
+        val = Math.min(val, 1);
+        if (steps) {
+            val = Math.floor(val * steps) / steps;
+        }
+
+        const ramp = this.colorRamps[rampIndex];
+        const color = val * (ramp.length - 1);
+        const i = Math.min(Math.floor(color), ramp.length - 2);
+        const off = color % 1;
+        const getChan = chan => Math.floor(ramp[i][chan] * (1 - off) + ramp[i + 1][chan] * off);
+        return [getChan(0), getChan(1), getChan(2)];
+    },
+
+    /** Create canvases for use in color ramp dropdown */
+    makeGradientEls: function() {
+        const C_WIDTH = 120, C_HEIGHT = 25;
+        const numRamps = this.colorRamps.length;
+        let colorEls = [];
+        for (let i = 0; i < numRamps; i++) {
+            let canvas = document.createElement('canvas');
+            canvas.width = C_WIDTH;
+            canvas.height = C_HEIGHT;
+            let ctx = canvas.getContext('2d');
+            let image = ctx.getImageData(0, 0, C_WIDTH, C_HEIGHT);
+            let data = image.data;
+            for (let x = 0; x < C_WIDTH; x++) {
+                const color = this.valueToColor(x / C_WIDTH, i);
+                for (let y = 0; y < C_HEIGHT; y++) {
+                    const di = (y * C_WIDTH * 4) + (x * 4);
+                    data[di] = color[0];
+                    data[di + 1] = color[1];
+                    data[di + 2] = color[2];
+                    data[di + 3] = 255;
+                }
+            }
+            ctx.putImageData(image, 0, 0);
+            colorEls.push(canvas);
+        }
+        return colorEls;
+    },
+
+    managerOnChange: function(manager) {
+        this.makeMarker(manager);
+        manager.marker.dragging.enable();
+        this.makeDataLayer(manager);
+    },
+    managerOnFocus: function(manager) {
+        if (this.activeManager === manager) return;
+        if (this.activeManager !== null) {
+            this.activeManager.unfocus();
+        }
+        this.activeManager = manager;
+        this.activeManager.focus();
+    },
+    managerOnDelete: function(manager) {
+        manager.optionEls.root.remove();
+        Map_.rmNotNull(L_.layersGroup[manager.layerName]);
+        Map_.rmNotNull(manager.marker);
+
+        const managerIndex = this.managers.indexOf(manager);
+        this.managers.splice(managerIndex, 1);
+        if (this.activeManager === manager) {
+            if (this.managers.length === 0) {
+                this.activeManager = null;
+            } else {
+                const newIndex = Math.min(managerIndex, this.managers.length - 1);
+                this.activeManager = this.managers[newIndex];
+                this.activeManager.focus();
+            }
+        }
+    },
+
+    addIsochrone: function() {
+        const newManager = new IsochroneManager(
+            this.managerCounter + 1,
+            this.dataSources,
+            this.enabledModels,
+            {color: this.managerCounter % this.colorRamps.length}
+        );
+        this.managerCounter++;
+
+        newManager.onChange = () => this.managerOnChange(newManager);
+        newManager.onFocus = () => this.managerOnFocus(newManager);
+        newManager.onDelete = () => this.managerOnDelete(newManager);
+
+        this.managers.push(newManager);
+
+        const optionsEl = newManager.makeElement(this.makeGradientEls());
+        this.containerEl.append(optionsEl);
+        this.managerOnFocus(newManager);
+
+        return newManager;
+    },
+
+    /** Create an isochrone data layer for a given isochrone manager */
+    makeDataLayer: function(manager) {
+        const {layerName, cost, tileBounds, options} = manager;
+
+        Map_.rmNotNull(L_.layersGroup[layerName]);
+
+        if (!manager.options.visible) return;
+
+        L_.layersGroup[layerName] = new L.IsochroneLayer({
+            className: 'nofade', //Borrowed from viewshed... but is it actually doing anything?
+            minZoom: Math.min(options.resolution, Map_.map.getMinZoom()),
+            maxZoom: Map_.map.getMaxZoom(),
+            minNativeZoom: options.resolution,
+            maxNativeZoom: options.resolution,
+            bounds: tileBounds,
+            tileSize: 256,
+            opacity: options.opacity,
+            color: options.color,
+            maxCost: options.maxCost,
+            steps: options.steps,
+            data: cost
+        });
+
+        L_.layersGroup[layerName].setZIndex(1000);
+        Map_.map.addLayer(L_.layersGroup[layerName]);
+    },
+
+    /** Create a start point marker for a given isochrone manager */
+    makeMarker: function(manager) { //ViewshedTool.js, function viewshed
+        const {start, options} = manager;
+        let canvas = document.createElement('canvas');
+        canvas.width = 16;
+        canvas.height = 16;
+        let ctx = canvas.getContext('2d');
+
+        const radius = 7
+        const strokeWeight = 2
+        const ramp = IsochroneTool.colorRamps[options.color];
+        const c = ramp[ramp.length - 1];
+
+        ctx.fillStyle = `rgba(${c[0]}, ${c[1]}, ${c[2]}, 255)`;
+
+        ctx.strokeStyle = 'rgba(255, 255, 255, 255)';
+        ctx.beginPath();
+        ctx.arc(
+            canvas.width / 2,
+            canvas.height / 2,
+            radius,
+            0,
+            2 * Math.PI
+        );
+
+        ctx.fill();
+        ctx.lineWidth = strokeWeight;
+        ctx.stroke();
+        ctx.strokeStyle = 'rgba(0, 0, 0, 255)';
+        ctx.beginPath();
+        ctx.arc(
+            canvas.width / 2,
+            canvas.height / 2,
+            radius - strokeWeight,
+            0,
+            2 * Math.PI
+        );
+
+        ctx.fill();
+        ctx.lineWidth = strokeWeight;
+        ctx.stroke();
+
+        let isochroneIcon = L.icon({
+            iconUrl: canvas.toDataURL(),
+            iconSize: [canvas.width, canvas.height],
+            iconAnchor: [canvas.width / 2, canvas.height / 2],
+            popupAnchor: [-3, -76],
+            shadowSize: [68, 95],
+            shadowAnchor: [22, 94],
+        });
+
+        Map_.rmNotNull(manager.marker);
+        manager.marker = new L.marker([start.lat, start.lng], {icon: isochroneIcon});
+
+        manager.marker.on('click', e => this.managerOnFocus(manager));
+        manager.marker.on('dragend', e => {
+            manager.marker.dragging.disable();
+            manager.start = e.target._latlng;
+            manager.setBounds();
+            this.managerOnFocus(manager);
+        });
+
+        manager.marker.addTo(Map_.map);
+    },
+
+    //Click event handler
+    handleClick: function(e) {
+        if (e && e.latlng && this.activeManager.currentStage < 4) {
+            this.activeManager.start = e.latlng;
+            this.makeMarker(this.activeManager);
+            this.activeManager.setBounds();
+        }
+    },
+
+    //Mouse move event handler
+    handleMouseMove: function(e) {
+        const MAX_STEPS = 5000;
+        const manager = this.activeManager;
+
+        if (!e || !manager || !manager.backlink || manager.currentStage > 0 || !manager.options.visible) {
+            return;
+        }
+
+        const now = Date.now();
+        if (this.lastHoverCall + 65 > now) return;
+        this.lastHoverCall = now;
+
+        Map_.rmNotNull(this.hoverPolyline);
+
+        const toLinePoint = (x, y) => {
+            const point = manager.tileBounds.min
+                .multiplyBy(256)
+                .add([x + 0.5, y + 0.5]);
+            const latlng = Map_.map.unproject(point, manager.options.resolution);
+            return [latlng.lat, latlng.lng];
+        }
+
+        let hoveredPx, width, height, startVal = 0;
+        if (e.latlng) {
+            hoveredPx = Map_.map
+                .project(e.latlng, manager.options.resolution)
+                .subtract(manager.tileBounds.min.multiplyBy(256))
+                .floor();
+            width = manager.backlink[0].length;
+            height = manager.backlink.length;
+            if (hoveredPx.x >= 0 && hoveredPx.y >= 0 && hoveredPx.x < width && hoveredPx.y < height) {
+                startVal = manager.backlink[hoveredPx.y][hoveredPx.x];
+            }
+        }
+
+        if (startVal !== 0) {
+            this.hovered = true;
+            const hoveredCost = manager.cost[hoveredPx.y][hoveredPx.x];
+            const tooltipMsg = manager.modelProto.costToString(hoveredCost);
+            CursorInfo.update(tooltipMsg, null, false);
+
+            let cx = hoveredPx.x;
+            let cy = hoveredPx.y;
+            let step = startVal;
+            let line = [toLinePoint(cx, cy)];
+            let lastStep = 0;
+            let count = 0;
+            while (step !== 0 && count < MAX_STEPS) {
+                let move = backlinkToMove[step - 1];
+                cx += move[1];
+                cy += move[0];
+                if(step === lastStep) { //Extend line
+                    line[line.length - 1] = toLinePoint(cx, cy);
+                } else { //Begin new line
+                    line.push(toLinePoint(cx, cy));
+                }
+                lastStep = step;
+                step = manager.backlink[cy][cx];
+                count++;
+            }
+            this.hoverPolyline = L.polyline(line, {interactive: false});
+            this.hoverPolyline.addTo(Map_.map);
+        } else if (this.hovered) {
+            this.hovered = false;
+            CursorInfo.hide();
+        }
+    },
+
+    //Mouse out event container
+    handleMouseOut: function(e) {
+        if (this.hovered) {
+            this.hovered = false;
+            Map_.rmNotNull(this.hoverPolyline);
+            CursorInfo.hide();
+        }
+    }
+}
+
+
+
+function interfaceWithMMGIS() {
+    this.separateFromMMGIS = function() {
+        separateFromMMGIS()
+    }
+
+    const tools = $('#toolPanel');
+    tools.empty();
+    const toolContainer = $('<div></div>')
+        .attr('class', 'center aligned ui padded grid')
+        .css({'height': '100%'});
+    tools.append(toolContainer)
+    toolContainer.html(markup);
+
+    const clickEventContainer = e => IsochroneTool.handleClick(e);
+    Map_.map.on('click', clickEventContainer);
+
+    const moveEventContainer = e => IsochroneTool.handleMouseMove(e);
+    Map_.map.on('mousemove', moveEventContainer);
+
+    const outEventContainer = e => IsochroneTool.handleMouseOut(e);
+    Map_.map.on('mouseout', outEventContainer);
+
+    //Share everything. Don't take things that aren't yours.
+    // Put things back where you found them.
+    function separateFromMMGIS() {
+        Map_.map.off('click', clickEventContainer);
+        Map_.map.off('mousemove', moveEventContainer);
+        Map_.map.off('mouseout', outEventContainer);
+    }
+}
+
+export default IsochroneTool;

--- a/src/essence/Tools/Isochrone/IsochroneTool_Algorithm.js
+++ b/src/essence/Tools/Isochrone/IsochroneTool_Algorithm.js
@@ -1,0 +1,232 @@
+
+import Map_ from "../../Basics/Map_/Map_";
+
+/*
+Runs Dijkstra's Algorithm on a given subsection of the map
+
+Dijkstra's Algorithm operates on a weighted graph, and finds the lowest-weight path between a given
+starting vertex and all other vertices. 
+
+In this implementation, values in a 2D array (representing pixels of a raster) are treated as
+vertices of the graph and are considered to be implicitly connected to their immediate neighbors.
+A cost function is run between connected pixels to determine edge weights. The result of the
+algorithm is returned as two arrays: a cost array which stores the minimum cost of reaching every
+pixel, and a backlink array whose values encode which of a pixel's neighbors is its parent in the
+shortest-path tree. Informally, the backlink saves the final "step" in the path from the start to 
+that pixel. The backlink array may thus be followed recursively to reconstruct the shortest path
+from any given pixel back to the starting point.
+
+Note that connecting pixels in this way limits directions of movement, and thus the final shape
+will be biased towards these directions (see queenMoves and knightMoves, below).
+*/
+
+//Indexes of X and Y values within px coordinate tuples
+const X = 1, Y = 0;
+
+//px contains array indexes [y, x]
+const getPx = (arr, px) => arr[px[Y]][px[X]];
+const setPx = (arr, px, val) => arr[px[Y]][px[X]] = val;
+
+//Helpers to get array indexes of parent and child elements within an implicitly-structured heap
+const h_getParentIndex = i => Math.ceil(i / 2) - 1;
+const h_getChildIndex = i => i * 2 + 1;
+
+function pxToLatLng(px, tileBounds, zoom) {
+    const point = tileBounds.min
+        .multiplyBy(256)
+        .add([px[X] + 0.5, px[Y] + 0.5]);
+    return Map_.map.unproject(point, zoom);
+}
+
+/** Min-heap priority queue for pixels of the cost array */
+class PxHeap {
+    /** 
+     * Create a new min-heap for pixels of the analyzed area.
+     * @param {Float32Array[]} valueArr 2D array storing the values of each pixel for the purposes of sorting
+     * @param {Int32Array[]} indexArr 2D array storing the index of each pixel within this heap, to eliminate the need for searching
+     */
+    constructor(valueArr, indexArr) {
+        this.contents = [];
+        this.valueArr = valueArr;
+        this.indexArr = indexArr;
+    }
+
+    /**
+     * Compare the cost of the pixels at indexes `i` and `j`.
+     * Return `true` if `i > j`, `false` otherwise.
+     */
+    compare(i, j) {
+        const iVal = this.contents[i];
+        const jVal = this.contents[j];
+        return getPx(this.valueArr, iVal) > getPx(this.valueArr, jVal);
+    }
+
+    /** Swap the pixels at indexes `i` and `j` */
+    swap(i, j) {
+        const iVal = this.contents[i];
+        const jVal = this.contents[j];
+        setPx(this.indexArr, iVal, j);
+        setPx(this.indexArr, jVal, i);
+        this.contents[i] = jVal;
+        this.contents[j] = iVal;
+    }
+
+    /** Move the pixel at `index` up to a correct position within the heap */
+    bubbleUp(index) {
+        let parentIndex = h_getParentIndex(index);
+        while (parentIndex >= 0 && this.compare(parentIndex, index)) {
+            this.swap(index, parentIndex);
+            index = parentIndex;
+            parentIndex = h_getParentIndex(index);
+        }
+    }
+
+    /** Move the pixel at the head of the heap down to a correct position within the heap */
+    bubbleDown() {
+        let index = 0, childIndex = 1;
+        let swapped = true;
+        const length = this.contents.length;
+        while (swapped && childIndex < length) {
+            swapped = false;
+            if (childIndex !== length - 1 && this.compare(childIndex, childIndex + 1)) {
+                childIndex++;
+            }
+            if (this.compare(index, childIndex)) {
+                this.swap(index, childIndex);
+                swapped = true;
+                index = childIndex;
+                childIndex = h_getChildIndex(index);
+            }
+        }
+    }
+
+    /** Insert a pixel coordinate tuple into the heap */
+    insert(px) {
+        let index = this.contents.length;
+        this.contents.push(px);
+        setPx(this.indexArr, px, index);
+        this.bubbleUp(index);
+    }
+
+    /** Remove the pixel coordinate tuple with the lowest cost from the heap */
+    remove() {
+        const result = this.contents[0];
+        setPx(this.indexArr, result, -1); //Mark pixel as removed
+        const lastPx = this.contents.pop();
+        if (this.contents.length > 0) {
+            this.contents[0] = lastPx;
+            setPx(this.indexArr, lastPx, 0);
+            this.bubbleDown();
+        }
+        return result;
+    }
+}
+
+/**
+ * Values to return in the backlink array. Direction back to the start ordered ascending clockwise
+ * from the right.
+ */
+const moveToBacklink = [
+    [ 0,  4,  0,  6,  0],
+    [ 2,  3,  5,  7,  8],
+    [ 0,  1,  0,  9,  0],
+    [16, 15, 13, 11, 10],
+    [ 0, 14,  0, 12,  0]
+];
+
+/**
+ * Moves from a pixel to its 8 immediate neighbors.
+ * A purely distance-based model will produce an octagon with these moves.
+ */
+const queenMoves = [
+    [-1, -1], [-1, 0], [-1, 1],
+    [0, -1],          [0, 1],
+    [1, -1], [1, 0], [1, 1]
+];
+
+/**
+ * In addition to queenMoves, all moves between pixels that a knight could make on a chessboard.
+ * This improves accuracy by allowing more angles of movement at the expense of greater running time.
+ * A purely distance-based model will produce a 16-sided polygon with these moves.
+ */
+const knightMoves = [
+    ...queenMoves,
+    [-2, -1], [-2, 1],
+    [-1, -2], [-1, 2],
+    [1, -2], [1, 2],
+    [2, -1], [2, 1]
+];
+
+/**
+ * Runs Dijkstra's Algorithm over an array of map data.
+ * @param {L.Point} startPx Location of starting pixel, as a Leaflet point
+ * @param {L.Bounds} tileBounds Tile bounds of the analyzed area
+ * @param {Model} model Model used to calculate cost
+ * @param {number} zoom Zoom level of the analyzed data
+ * @param {number} maxCost Max cost to analyze out to.
+ * @param {boolean} knightsMove Whether to use the knight's move for improved accuracy. Default `true`.
+ * @returns An object containing an accumulated cost array and a backlink array.
+ */
+export default function generateIsochrone(
+    startPx,
+    tileBounds,
+    model,
+    zoom,
+    maxCost = Infinity,
+    knightsMove = true
+) {
+    const moves = knightsMove ? knightMoves : queenMoves;
+    const size = tileBounds.getSize().multiplyBy(256);
+
+    //Set up dijkstra's
+    const makeDataArray = (type, fillWith) => {
+        let arr = [];
+        for (let y = 0; y < size.y; y++) {
+            arr.push(new type(size.x).fill(fillWith));
+        }
+        return arr;
+    }
+    let costArr = makeDataArray(Float32Array, Infinity);
+    let linkArr = makeDataArray(Uint8Array, 0);
+    let indexArr = makeDataArray(Int32Array, -2);
+        //-2: px is unvisited; -1: px has been removed
+    
+    let heap = new PxHeap(costArr, indexArr);
+
+    costArr[startPx.y][startPx.x] = 0;
+    heap.insert([startPx.y, startPx.x]);
+
+    while (heap.contents.length > 0) {
+        const cPx = heap.remove(); //current pixel
+        const cCost = getPx(costArr, cPx);
+        const cLatLng = pxToLatLng(cPx, tileBounds, zoom);
+
+        for (const m of moves) {
+            const tPx = [cPx[Y] + m[Y], cPx[X] + m[X]]; //target pixel
+
+            //Check that target pixel is within bounds
+            if (tPx[Y] < 0 || tPx[X] < 0 || tPx[Y] >= size.y || tPx[X] >= size.x)
+                continue;
+            
+            //Check that target pixel hasn't already been visited
+            const tPxIndex = getPx(indexArr, tPx);
+            if (tPxIndex === -1) continue;
+
+            //Check that target pixel can be reached within cost budget
+            const tLatLng = pxToLatLng(tPx, tileBounds, zoom);
+            const cost = model.costFunction(cPx, tPx, cLatLng, tLatLng) + cCost;
+            if (cost > maxCost || !isFinite(cost)) continue;
+            
+            if (tPxIndex === -2) { //tPx is unvisited
+                setPx(costArr, tPx, cost);
+                setPx(linkArr, tPx, moveToBacklink[m[Y] + 2][m[X] + 2]);
+                heap.insert(tPx);
+            } else if (cost < getPx(costArr, tPx)) { //tPx is visited but this path is better
+                setPx(costArr, tPx, cost);
+                setPx(linkArr, tPx, moveToBacklink[m[Y] + 2][m[X] + 2]);
+                heap.bubbleUp(tPxIndex); //Cost has decreased; pixel's heap position must be updated
+            }
+        }
+    }
+    return {cost: costArr, backlink: linkArr};
+}

--- a/src/essence/Tools/Isochrone/IsochroneTool_Manager.js
+++ b/src/essence/Tools/Isochrone/IsochroneTool_Manager.js
@@ -1,0 +1,430 @@
+import $ from 'jquery';
+
+import Map_ from '../../Basics/Map_/Map_';
+import F_ from '../../Basics/Formulae_/Formulae_';
+
+import generateIsochrone from './IsochroneTool_Algorithm';
+import QueryJob from './IsochroneTool_Query';
+import { addOption, addSection, createInput, createDropdown, createLoadBar } from './ui.js';
+
+const GLOBAL_MIN_RESOLUTION = 4;
+const GLOBAL_MAX_RESOLUTION = 20;
+
+class IsochroneManager {
+    constructor(id, dataSources, models, options = {}) {
+        this.id = id;
+        this.dataSources = dataSources;
+        this.models = models;
+        
+        this.options = {
+            visible: true,
+            color: 0,
+            opacity: 0.8,
+            maxRadius: 5000,
+            resolution: GLOBAL_MIN_RESOLUTION,
+            model: 0,
+            maxCost: 5000
+        };
+        Object.assign(this.options, options);
+
+        this.optionEls = {};
+        this.sections = {
+            data: null,
+            model: null
+        };
+
+        this.onChange = () => {};
+        this.onDelete = () => {};
+        this.onFocus = () => {};
+
+        this.minResolution = GLOBAL_MIN_RESOLUTION;
+        this.maxResolution = GLOBAL_MAX_RESOLUTION;
+        this.start = null; //L.LatLng
+        this.startPx = null; //L.Point
+        this.tileBounds = null; //L.Bounds
+
+        this.currentStage = 0;
+        this.queryJobs = [];
+
+        this.modelProto = null;
+        this.model = null; //Model
+
+        this.updateTimeout = 0;
+
+        this.cost = null;
+        this.backlink = null;
+
+        this.layerName = 'isochrone_' + this.id;
+        //assigned by IsochroneTool
+        this.marker = null;
+    }
+
+    /******************** UI AND INPUT ********************/
+
+    handleInput(e, option, action = 0) {
+        window.clearTimeout(this.updateTimeout);
+        this.updateTimeout = window.setTimeout(() => this._handleInput(e, option, action), 100);
+    }
+    _handleInput(e, option, action) {
+        if (option !== null) {
+            if (typeof e === 'object') {
+                this.options[option] = parseFloat(e.target.value);
+            } else {
+                this.options[option] = e;
+            }
+        }
+
+        this.onFocus();
+
+        if (this.start !== null && action >= this.currentStage) {
+            switch (action) {
+                case 3: //Change requires getting new data
+                    this.setBounds();
+                break;
+                case 2: //Change requires generating new shape on same data
+                    this.analyze();
+                break;
+                case 1: //Change requires redrawing same shape
+                    this.onChange();
+                break;
+                default: //Change changes nothing!
+            }
+        }
+    }
+
+    makeElement(gradientEls) {
+        let root = $('<li></li>');
+        let header = $('<div class="isochroneHeader"></div>').appendTo(root);
+        let options = $('<div class="isochroneOptions"></div>').appendTo(root);
+        this.optionEls.options = options;
+        this.optionEls.root = root;
+
+        header.on('click', () => this.onFocus());
+
+        $('<div class="checkbox on"></div>').appendTo(header).on('click', e => {
+            let target = $(e.target);
+            const visible = !target.hasClass('on');
+            if (visible) {
+                target.addClass('on');
+            } else {
+                target.removeClass('on');
+            }
+            this.handleInput(visible, 'visible', 1);
+        });
+        $(`<div class="title">Isochrone ${this.id}</div>`).appendTo(header);
+        $('<i class="iscicon mdi mdi-18px mdi-close"></i>').appendTo(header).on('click', e => {
+            this.onDelete();
+        });
+        $('<i class="iscicon mdi mdi-24px mdi-menu-down"></i>').appendTo(header).on('click', e => {
+            let target = $(e.target);
+            const collapsed = this.optionEls.options.hasClass('collapsed');
+            if (collapsed) {
+                this.optionEls.options.removeClass('collapsed');
+                target.removeClass('mdi-menu-right');
+                target.addClass('mdi-menu-down');
+            } else {
+                this.optionEls.options.addClass('collapsed');
+                target.removeClass('mdi-menu-down');
+                target.addClass('mdi-menu-right');
+            }
+        });
+
+        this.optionEls.maxRadius = createInput(
+            'Max radius',
+            options,
+            'km',
+            this.options.maxRadius / 1000,
+            `min="1" step="1" default="250"`
+        ).on('change', e => {
+            const inMeters = parseFloat(e.target.value) * 1000;
+            this.handleInput(inMeters, 'maxRadius', inMeters > this.options.maxRadius ? 3 : 0);
+        });
+
+        this.optionEls.color = gradientEls;
+        $(this.optionEls.color[this.options.color]).addClass('selected');
+        const colorContainer = $('<div class="dropdown color"></div>')
+            .appendTo(addOption('Color', options));
+        for (const i in gradientEls) {
+            $(gradientEls[i]).appendTo(colorContainer).on('click', e => {
+                if(this.options.color !== i) {
+                    $(this.optionEls.color[this.options.color]).removeClass('selected');
+                    $(e.target).addClass('selected');
+                    this.handleInput(i, 'color', 1);
+                }
+            });
+        }
+
+        this.optionEls.opacity =
+            $(`<input class="slider2" type="range" min="0" max="1" step="0.01" value="${this.options.opacity}" default="0.4"></input>`)
+            .appendTo(addOption('Opacity', options))
+            .on('change', e => this.handleInput(e, 'opacity', 1));
+        
+        this.optionEls.steps = createInput(
+            'Steps',
+            options,
+            false,
+            0,
+            'min="0" step="1" default="0"'
+        ).on('change', e => this.handleInput(e, 'steps', 1));
+
+        this.optionEls.model = createDropdown(
+            'Model',
+            options,
+            this.models.map(m => m.nameString)
+        ).on(
+            'change',
+            e => {
+                if (this.currentStage > 3) {
+                    //Recover from misconfigured model
+                    this.currentStage = 0;
+                    if (this.marker !== null) {
+                        this.marker.dragging.enable();
+                    }
+                }
+                const reuseData = this.setupModel(e.target.value);
+                this.handleInput(e, 'model', reuseData ? 2 : 3);
+            }
+        );
+        
+        this.sections.data = addSection('Data Properties', options);
+        this.sections.model = addSection('Model Properties', options);
+        this.setupModel();
+        
+        return root;
+    }
+
+    setupModel(modelIndex = this.options.model) {
+        const newModelProto = this.models[modelIndex];
+
+        let reuseData = false;
+        if (this.modelProto !== null) {
+            reuseData = newModelProto.requiredData.reduce(
+                (a, c) => a && this.modelProto.requiredData.indexOf(c) > -1 && this.model.data[c],
+                true
+            );
+        }
+
+        let newModel = new newModelProto();
+        if (reuseData) {
+            for (const d of newModelProto.requiredData) {
+                newModel.data[d] = this.model.data[d];
+            }
+        }
+        this.modelProto = newModelProto;
+        this.model = newModel;
+
+        this.sections.data.empty();
+        this.sections.model.empty();
+
+        this.optionEls.resolution = createDropdown(
+           'Resolution',
+           this.sections.data
+        ).on('change', e => this.handleInput(e, 'resolution', 3));
+        
+        for (const dataType of this.modelProto.requiredData) {
+            const lcDataType = dataType.toLowerCase();
+            if (this.dataSources[lcDataType] === undefined || this.dataSources[lcDataType].length === 0) {
+                //Tool is misconfigured for this model; disable
+                this.sections.data.empty();
+                createLoadBar(
+                    `No valid source for ${dataType}!`,
+                    this.sections.data,
+                    true
+                );
+                this.currentStage = 4;
+                if (this.marker !== null) {
+                    this.marker.dragging.disable();
+                }
+                return false;
+            }
+            this.options[lcDataType + '_source'] = 0;
+            createDropdown(
+                dataType + ' source',
+                this.sections.data,
+                this.dataSources[lcDataType].map(s => s.name)
+            ).on('change', e => {
+                this.options[lcDataType + '_source'] = parseInt(e.target.value);
+                this.updateResolutionRange();
+                this.handleInput(e, null, 3);
+            });
+        }
+
+        this.updateResolutionRange();
+        
+        createInput(
+            'Max ' + this.modelProto.costName,
+            this.sections.model,
+            this.modelProto.costUnitSymbol,
+            this.modelProto.defaultCost,
+            `min="0" step="1"`
+        ).on('change', e => this.handleInput(e, 'maxCost', parseFloat(e.target.value) < this.options.maxCost ? 1 : 2));
+        this.options.maxCost = this.modelProto.defaultCost;
+
+        this.model.createOptions(this.sections.model, (action) => this.handleInput(null, null, action));
+
+        return reuseData;
+    }
+
+    focus() {
+        this.optionEls.root.addClass('focused');
+    }
+
+    unfocus() {
+        this.optionEls.root.removeClass('focused');
+    }
+    
+    updateResolutionRange() {
+        let max = GLOBAL_MAX_RESOLUTION;
+        let min = GLOBAL_MIN_RESOLUTION;
+        for (const dataType of this.modelProto.requiredData) {
+            const lcDataType = dataType.toLowerCase();
+            const sourceObj = this.dataSources[lcDataType][this.options[lcDataType + '_source']];
+            max = Math.min(max, sourceObj.maxResolution);
+            min = Math.max(min, sourceObj.minResolution);
+        }
+        const newVal = Math.max(min, Math.min(max, this.options.resolution));
+        this.optionEls.resolution.empty();
+        for (let e = min; e <= max; e++) {
+            $(`<option value=${e}${e === newVal ? ' selected' : ''}>${e}</option>`)
+                .appendTo(this.optionEls.resolution);
+        }
+        this.minResolution = min;
+        this.maxResolution = max;
+        this.optionEls.resolution.value = newVal;
+        this.options.resolution = newVal;
+    }
+
+    /******************** ISOCHRONE GENERATION ********************/
+
+    setBounds() {
+        this.currentStage = 3;
+
+        const startPoint = Map_.map.project(this.start, this.options.resolution);
+        const measureLatLng = Map_.map.unproject(startPoint.add([1, 0]), this.options.resolution);
+        const pxRadius = this.options.maxRadius / this.start.distanceTo(measureLatLng);
+
+        const min = startPoint.subtract([pxRadius, pxRadius]).divideBy(256).floor();
+        const max = startPoint.add([pxRadius, pxRadius]).divideBy(256).ceil();
+        this.tileBounds = new window.L.Bounds(min, max);
+
+        this.startPx = Map_.map
+            .project(this.start, this.options.resolution)
+            .subtract(min.multiplyBy(256))
+            .floor();
+
+        this.getData();
+    }
+
+    getRequiredTilesList(source) {
+        const {zoomOffset} = source;
+        const zoom = this.options.resolution + zoomOffset;
+        let bounds = this.tileBounds;
+        if (zoomOffset !== 0) { //Handle lower-res tiles
+            const scaleFactor = Math.pow(2, zoomOffset);
+            bounds = window.L.bounds(
+                this.tileBounds.min.multiplyBy(scaleFactor),
+                this.tileBounds.max.multiplyBy(scaleFactor)
+            );
+        }
+        const startPoint = Map_.map.project(this.start, zoom);
+        const startTile = startPoint.clone().divideBy(256).floor();
+        
+        let tileList = [];
+        for (let y = bounds.min.y; y < bounds.max.y; y++) {
+            for (let x = bounds.min.x; x < bounds.max.x; x++) {
+                //Measure distance to start from nearest corner/edge
+                let measureX = startPoint.x;
+                if (x > startTile.x) {
+                    measureX = x * 256;
+                } else if (x < startTile.x) {
+                    measureX = (x + 1) * 256;
+                }
+
+                let measureY = startPoint.y;
+                if (y > startTile.y) {
+                    measureY = y * 256;
+                } else if (y < startTile.y) {
+                    measureY = (y + 1) * 256;
+                }
+
+                const measureLatLng = Map_.map.unproject([measureX, measureY], zoom);
+                const dist = F_.lngLatDistBetween(
+                    this.start.lng,
+                    this.start.lat,
+                    measureLatLng.lng,
+                    measureLatLng.lat
+                );
+
+                if (dist <= this.options.maxRadius) {
+                    tileList.push({
+                        x,
+                        y,
+                        z: zoom,
+                        relX: x - bounds.min.x,
+                        relY: y - bounds.min.y,
+                        dist
+                    });
+                }
+            }
+        }
+
+        tileList.sort((a, b) => a.dist - b.dist);
+        return tileList;
+    }
+
+    getData() {
+        this.queryJobs.map(job => job.stop());
+        this.queryJobs = [];
+
+        let promises = [];
+        for (const dataType of this.modelProto.requiredData) {
+            const lcDataType = dataType.toLowerCase();
+            const sourceIndex = this.options[lcDataType + '_source'];
+            const source = this.dataSources[lcDataType][sourceIndex];
+            const requiredTiles = this.getRequiredTilesList(source);
+
+            const job = new QueryJob(source, requiredTiles, this.tileBounds);
+            this.queryJobs.push(job);
+            let bar;
+            const promise = job.start(
+                () => bar = createLoadBar(`Loading ${dataType}...`, this.optionEls.options),
+                (prog) => bar.css({width: `${prog * 100}%`}),
+                () => bar.parent().remove()
+            );
+            promises.push(promise);
+        }
+
+        Promise.all(promises).then(result => {
+            const dataArr = this.modelProto.requiredData.map((d, i) => [d, result[i]]);
+            const dataObj = Object.fromEntries(dataArr);
+            this.model.setData(dataObj);
+            this.queryJobs = [];
+            this.analyze();
+        }).catch(msg => {
+            if (msg !== "Query job stopped.") {
+                console.log(msg);
+            }
+        });
+    }
+
+    analyze() {
+        this.currentStage = 2;
+        const result = generateIsochrone(
+            this.startPx,
+            this.tileBounds,
+            this.model,
+            this.options.resolution,
+            this.options.maxCost
+        );
+        this.cost = result.cost;
+        this.backlink = result.backlink;
+        
+        this.currentStage = 1;
+        this.onChange();
+        this.marker.dragging.enable();
+       
+        this.currentStage = 0;
+    }
+}
+
+export default IsochroneManager;

--- a/src/essence/Tools/Isochrone/IsochroneTool_Query.js
+++ b/src/essence/Tools/Isochrone/IsochroneTool_Query.js
@@ -1,0 +1,201 @@
+import Map_ from "../../Basics/Map_/Map_";
+import F_ from "../../Basics/Formulae_/Formulae_";
+import L_ from "../../Basics/Layers_/Layers_";
+
+const MAX_WORKERS = 8;
+
+const QueryManager = {
+    cache: {},
+    //TODO: queue jobs here
+    //(so e.g. two isochrones will load in sequence w/o slowing each other down)
+    jobQueue: [],
+    jobInProgress: false,
+    numWorkers: 0,
+    currentJob: null,
+
+    //These may be expanded to maintain a max cache size
+    isInCache: url => QueryManager.cache[url] !== undefined,
+    addToCache: (url, data) => QueryManager.cache[url] = data,
+
+    fillUrl: function(url, tile) {
+        const pxWorldBound = Map_.map.getPixelWorldBounds(tile.z);
+        const yTileWorldBound = Math.ceil(pxWorldBound.max.y / 256) - 1;
+
+        let filledUrl = url.replace('{x}', tile.x);
+        filledUrl = filledUrl.replace('{y}', yTileWorldBound - tile.y);
+        filledUrl = filledUrl.replace('{z}', tile.z);
+        return filledUrl;
+    },
+
+    getPNG: function(url) {
+        //just promisifying png.js
+        const queryPromise = new Promise((resolve, reject) => {
+            window.PNG.load(url, resolve, reject);
+        });
+
+        //PNG.js has no native error callback!
+        //This workaround will at least keep things moving
+        const timeoutPromise = new Promise((resolve, reject) => {
+            window.setTimeout(() => reject(url + ": timed out"), 10000);
+        });
+        return Promise.race([queryPromise, timeoutPromise]);
+    },
+
+    decodePNG: function(img) {
+        if (!img) return null;
+        let rgbaArr = img.decode();
+
+        const length = rgbaArr.length / 4;
+        let heights = new Float32Array(length);
+        let p = 0;
+        for (let i = 0; i < length; i++) {
+            heights[i] = F_.RGBAto32({
+                r: rgbaArr[p],
+                g: rgbaArr[p + 1],
+                b: rgbaArr[p + 2],
+                a: rgbaArr[p + 3]
+            });
+            p += 4;
+        }
+        return heights;
+    },
+
+    getTile: async function(urlTemplate, tile) {
+        const url = this.fillUrl(urlTemplate, tile);
+        if (this.isInCache(url)) {
+            return this.cache[url];
+        } else {
+            const png = await this.getPNG(url).catch(msg => {
+                console.log(msg);
+                return null;
+            });
+            const data = this.decodePNG(png);
+            this.addToCache(url, data);
+            return data;
+        }
+    }
+}
+
+class QueryJob {
+    constructor({tileurl, resolution, interpolateSeams}, tileList, bounds) {
+        this.tileurl = F_.isUrlAbsolute(tileurl) ? tileurl : L_.missionPath + tileurl;
+        this.tileList = tileList;
+        this.bounds = bounds;
+        this.resolution = resolution;
+        this.interpolateSeams = interpolateSeams;
+
+        this.active = false;
+        this.tilesQueried = 0;
+        this.tilesLoaded = 0;
+        this.numWorkers = 0;
+        this.numTiles = tileList.length;
+
+        this.onStop = () => {};
+
+        this.size = bounds.getSize().multiplyBy(256);
+        this.result = [];
+        for (let y = 0; y < this.size.y; y++) {
+            this.result.push(new Float32Array(this.size.x).fill(Infinity));
+        }
+    }
+
+    /**
+     * Start this job loading tiles
+     * @param {Function} onStart Function to call when the job starts
+     * @param {Function} onProgress Function to call to update progress on the job
+     * @param {Function} onEnd Function to call when the job ends
+     * @returns 
+     */
+    start(onStart = () => {}, onProgress = () => {}, onEnd = () => {}) {
+        this.active = true;
+        this.onStop = onEnd;
+
+        return new Promise((resolve, reject) => {
+            const createHandler = tile => result => {
+                if (result) {
+                    this.handleTileData(tile, result);
+                }
+                this.numWorkers--;
+                this.tilesLoaded++;
+                onProgress(this.tilesLoaded / this.numTiles);
+                startNextQuery();
+            };
+
+            const startNextQuery = () => {
+                if (!this.active) {
+                    reject("Query job stopped.");
+                } else if (this.numWorkers < MAX_WORKERS && this.tilesQueried < this.numTiles) {
+                    const currentTile = this.tileList[this.tilesQueried];
+                    QueryManager.getTile(this.tileurl, currentTile)
+                        .then(createHandler(currentTile));
+                    
+                    this.tilesQueried++;
+                    this.numWorkers++;
+                    startNextQuery();
+                } else if (this.numWorkers === 0 && this.tilesQueried === this.numTiles) {
+                    this.processLoadedData();
+                    this.active = false;
+                    onEnd();
+                    resolve(this.result);
+                }
+            };
+
+            onStart();
+            startNextQuery();
+        });
+    }
+
+    handleTileData(tile, data) {
+        const startX = tile.relX * this.resolution;
+        const startY = tile.relY * this.resolution;
+        for (let y = 0; y < this.resolution; y++) {
+            const yResult = y + startY;
+            const dataRow = data.slice(y * this.resolution, (y + 1) * this.resolution);
+            this.result[yResult].set(dataRow, startX);
+        }
+    }
+
+    processLoadedData() { //ViewshedTool_Manager.js (function interpolateSeams)
+        if(!this.interpolateSeams) return;
+
+        // Vertical | |
+        const maxX = this.size.x - this.resolution;
+        for (let x = this.resolution; x < maxX; x += this.resolution) {
+            for (let y = 0; y < this.size.y; y++) {
+                if (this.result[y][x - 1] === this.result[y][x] && isFinite(this.result[y][x])) {
+                    const a = this.result[y][x - 2];
+                    const b = this.result[y][x + 1];
+
+                    const inc = (a - b) / 3;
+
+                    this.result[y][x - 1] = a - inc;
+                    this.result[y][x] = b + inc;
+                }
+            }
+        }
+
+        // Horizontal _ _
+        const maxY = this.size.y - this.resolution;
+        for (let y = this.resolution; y < maxY; y += this.resolution) {
+            for (let x = 0; x < this.size.x; x++) {
+                if (this.result[y - 1][x] === this.result[y][x] && isFinite(this.result[y][x])) {
+                    const a = this.result[y - 2][x];
+                    const b = this.result[y + 1][x];
+
+                    const inc = (a - b) / 3;
+
+                    this.result[y - 1][x] = a - inc;
+                    this.result[y][x] = b + inc;
+                }
+            }
+        }
+    }
+
+    /** Stop a job in progress */
+    stop() {
+        this.onStop();
+        this.active = false;
+    }
+}
+
+export default QueryJob;

--- a/src/essence/Tools/Isochrone/config.json
+++ b/src/essence/Tools/Isochrone/config.json
@@ -1,0 +1,36 @@
+{
+    "defaultIcon": "circle-double",
+    "description": "Find the range of locations accessible to an explorer within a given time.",
+    "descriptionFull": {
+        "title": "Given a user-defined starting point, render a shaded region where colors indicate minimum travel time or resource expenditure to reach a given location. Hover over the region to view the least costly path from the start to the cursor. Costs are calculated based on selectable and configurable models, which may each require multiple different tilesets as input.",
+        "example": {
+            "data": {
+                "DEM": [
+                    {
+                        "name": "Unique Name 1",
+                        "tileurl": "Layers/Example/{z}/{x}/{y}.png",
+                        "minZoom": 8,
+                        "maxNativeZoom": 18,
+                        "resolution": 256,
+                        "interpolateSeams": true
+                    },
+                    { "...": "..." }
+                ],
+                "slope": [
+                    { "...": "..." }
+                ],
+                "cost": [
+                    { "...": "..." }
+                ]
+            },
+            "interpolateSeams": false,
+            "models": ["Traverse Time", "Isodistance", "..."]
+        }
+    },
+    "hasVars": true,
+    "name": "Isochrone",
+    "toolbarPriority": 10,
+    "paths": {
+        "IsochroneTool": "essence/Tools/Isochrone/IsochroneTool"
+    }
+}

--- a/src/essence/Tools/Isochrone/models/Model.js
+++ b/src/essence/Tools/Isochrone/models/Model.js
@@ -1,0 +1,67 @@
+/** Class representing a model of resource expenditure (time, power, etc.) on a traverse */
+export default class Model {
+    /** Name of this model, as it will appear in the model selection dropdown */
+    static nameString = 'Model';
+
+    /** Names of all data types required for this model (e.g. "DEM", "Slope", "Cost") */
+    static requiredData = ['DEM'];
+    
+    /** Name of the resource this class models, as it will appear in the name of the "max cost" option */
+    static costName = 'distance';
+
+    /** Units of the resource this class models, as it will appear in the "max cost" option */
+    static costUnitSymbol = 'm';
+
+    /** Default setting of the "max cost" option */
+    static defaultCost = 1000;
+
+    /** Determines whether this model is available by default (if "models" property is not set in the tool configuration) */
+    static enabledByDefault = true;
+
+    /**
+     * Converts a cost value produced by this model to a human-readable string.
+     * Override to specify how this model's costs are displayed (e.g. hh:mm:ss for time models)
+     * @param {number} cost Cost to convert to string
+     * @returns {string} `cost` as a properly-formatted string
+     */
+    static costToString(cost) {
+        return cost.toFixed(1) + this.costUnitSymbol;
+    }
+
+    constructor() {
+        /**
+         * Will be filled before costFunction is run with 2D data arrays for all keys listed in `requiredData`, e.g.:
+         * `{ "DEM": Float32Array[], "Slope": Float32Array[] }`.
+         * All data arrays are guaranteed to be the same size and to represent the same area of the map.
+         */
+        this.data = {};
+    }
+
+    /**
+     * Called to set or update data. Override to perform custom preprocessing on all new input data.
+     * @param {Object} data Object containing data arrays
+     */
+    setData(data) {
+        this.data = data;
+    }
+
+    /**
+     * Compute the cost of moving from a "current" pixel to a "target" pixel, based on data from `this.data`.
+     * This is the core of a model and must be overridden to produce a new and useful model.
+     * @param {number[]} cPx Index tuple [y, x] for the current pixel
+     * @param {number[]} tPx Index tuple [y, x] for the target pixel
+     * @param {L.LatLng} cLatLng Lat/long position of the current pixel
+     * @param {L.LatLng} tLatLng Lat/long position of the target pixel
+     * @returns {number} Cost of moving from `cPx` to `tPx`.
+     */
+    costFunction(cPx, tPx, cLatLng, tLatLng) {
+        return 10;
+    }
+
+    /**
+     * Create a custom interface in the left toolbar for modifying model-specific options
+     * @param {Element} root The root element within which to build the UI
+     * @param {(action: number) => void} onChange Function to signal the manager to update when a parameter changes. Accepts an action number (see `IsochroneManager._handleInput`)
+     */
+    createOptions(root, onChange) {}
+}

--- a/src/essence/Tools/Isochrone/models/Model_Example.js
+++ b/src/essence/Tools/Isochrone/models/Model_Example.js
@@ -1,0 +1,21 @@
+import Model from "./Model";
+import { createDropdown, createInput } from "../ui";
+
+/** Empty model demonstrating the ability of the model interface (multiple data sources, custom options, etc.) */
+class Model_Example extends Model {
+    static nameString = "Example";
+    static requiredData = ["DEM", "Slope"];
+
+    static costName = "energy use";
+    static costUnitSymbol = "Kcal";
+    static defaultCost = 100;
+
+    static enabledByDefault = false;
+
+    createOptions(root, onChange) {
+        createDropdown("Model prop 1", root, ["dropdown"]);
+        createInput("Model prop 2", root, "unit", 15);
+    }
+}
+
+export default Model_Example;

--- a/src/essence/Tools/Isochrone/models/Model_Isodistance.js
+++ b/src/essence/Tools/Isochrone/models/Model_Isodistance.js
@@ -1,0 +1,46 @@
+import F_ from "../../../Basics/Formulae_/Formulae_";
+import Model from "./Model";
+import { createInput } from "../ui";
+
+const getPx = (arr, px) => arr[px[0]][px[1]];
+
+/** Terrain-aware distance model, with scale option to emphasize or ignore terrain */
+class Model_Isodistance extends Model {
+    static nameString = "Isodistance";
+    static requiredData = ["DEM"];
+    static defaultCost = 5000;
+
+    constructor() {
+        super();
+        this.terrainScale = 1;
+    }
+
+    costFunction(cPx, tPx, cLatLng, tLatLng) {
+        const dist2d = F_.lngLatDistBetween(
+            cLatLng.lng,
+            cLatLng.lat,
+            tLatLng.lng,
+            tLatLng.lat
+        );
+        const cEl = getPx(this.data.DEM, cPx);
+        const tEl = getPx(this.data.DEM, tPx);
+        const vDist = (cEl - tEl) * this.terrainScale;
+        const result = Math.sqrt(vDist * vDist + dist2d * dist2d);
+        return result;
+    }
+
+    createOptions(root, onChange) {
+        createInput(
+            "Terrain scale",
+            root,
+            "X",
+            1,
+            `min="0" default="1" step="0.2"`
+        ).on("change", e => {
+            this.terrainScale = parseFloat(e.target.value);
+            onChange(2);
+        });
+    }
+}
+
+export default Model_Isodistance;

--- a/src/essence/Tools/Isochrone/models/Model_Traverse.js
+++ b/src/essence/Tools/Isochrone/models/Model_Traverse.js
@@ -1,0 +1,53 @@
+import F_ from "../../../Basics/Formulae_/Formulae_";
+import Model from "./Model";
+
+const getPx = (arr, px) => arr[px[0]][px[1]];
+
+/** Naive lunar EVA traverse time model, based on Apollo */
+class Model_Traverse extends Model {
+    static nameString = "Traverse Time";
+    static requiredData = ["DEM"];
+
+    static costName = "time";
+    static costUnitSymbol = "min";
+    static defaultCost = 60;
+
+    static costToString(cost) {
+        const roundCost = Math.round(cost);
+        const hours = Math.floor(roundCost / 60);
+        const mins = roundCost % 60;
+        if (hours) {
+            const hourString = hours.toString().padStart(2, '0');
+            const minString = mins.toString().padStart(2, '0');
+            return hourString + ':' + minString;
+        } else {
+            return mins + 'min';
+        }
+    }
+
+    costFunction(cPx, tPx, cLatLng, tLatLng) {
+        const dist2d = F_.lngLatDistBetween(
+            cLatLng.lng,
+            cLatLng.lat,
+            tLatLng.lng,
+            tLatLng.lat
+        );
+        const distVert = getPx(this.data.DEM, cPx) - getPx(this.data.DEM, tPx);
+        const distTotal = Math.sqrt(distVert * distVert + dist2d * dist2d);
+        const slope = Math.tan(distVert / dist2d) * (180 / Math.PI);
+
+        //https://dspace.mit.edu/bitstream/handle/1721.1/38526/162623870-MIT.pdf (pg. 73)
+        let velocity; // m/s
+        if (slope < -15) velocity = 0;
+        else if (slope < -10) velocity = 0.095 * slope + 1.95;
+        else if (slope < 0) velocity = 0.06 * slope + 1.6;
+        else if (slope < 6) velocity = -0.2 * slope + 1.6;
+        else if (slope < 15) velocity = -0.039 * slope + 0.634;
+        else velocity = 0;
+
+        const result = distTotal / velocity / 60;
+        return result;
+    }
+}
+
+export default Model_Traverse;

--- a/src/essence/Tools/Isochrone/models/index.js
+++ b/src/essence/Tools/Isochrone/models/index.js
@@ -1,0 +1,11 @@
+import Model_Isodistance from "./Model_Isodistance";
+import Model_Traverse from "./Model_Traverse";
+import Model_Example from "./Model_Example";
+
+const models = [
+    Model_Isodistance,
+    Model_Traverse,
+    Model_Example
+];
+
+export default models;

--- a/src/essence/Tools/Isochrone/ui.js
+++ b/src/essence/Tools/Isochrone/ui.js
@@ -1,0 +1,42 @@
+import $ from 'jquery';
+
+export function addOption(title, root) {
+    return $(`<div><div>${title}</div></div>`).appendTo(root);
+}
+export function addSection(title, root) {
+    $(`<div class="sectionhead">${title}</div>`).appendTo(root);
+    return $(`<section></section>`).appendTo(root);
+}
+
+export function createInput(title, root, unit, value, attr = "") {
+    const innerContainer = $(`<div class="flexbetween"></div>`)
+        .appendTo(addOption(title, root));
+    const el = $( `<input type="number" ${attr} value="${value}">`)
+        .appendTo(innerContainer);
+    if (unit) {
+        $(`<div class="unit">${unit}</div>`).appendTo(innerContainer);
+    } else {
+        el.addClass('nounit');
+    }
+    return el;
+}
+
+export function createDropdown(title, root, options = []) {
+    let el = $(`<select class="dropdown"></select>`)
+        .appendTo(addOption(title, root))
+    const numOptions = options.length;
+    let selStr = ' selected';
+    for(let i = 0; i < numOptions; i++) {
+        const optionEl =
+            $(`<option value=${i}${selStr}></option>`).appendTo(el);
+        optionEl.html(options[i]);
+        selStr = '';
+    }
+    return el;
+}
+
+export function createLoadBar(msg, root, error = false) {
+    const container = $(`<div class="loading"></div>`).appendTo(root);
+    $(`<span>${msg}</span>`).appendTo(container);
+    return $(`<div${error ? ' class="error"' : ''}></div>`).appendTo(container);
+}


### PR DESCRIPTION
Adds a new Isochrone tool for analyzing and planning traverses. Features:
- Render isochrones as raster layers showing color-ramped accumulated cost out to a set maximum
- Hover over isochrones to show least-cost paths and minimum cost from start point to hovered point
- Separated cost model interface allows easy extension and switching models on-the-fly
- Add, remove, and separately edit multiple isochrones
- Configurable color ramps, color steps, opacity, resolution, data sources