### PR TITLE
Dockerfile node:16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:16
 
 # Install GDAL with Python bindings
 RUN apt-get -y update


### PR DESCRIPTION
Upgrading to Node v16.13.2, tested and updated Dockerfile base image.
(There may be an unlikely one off problem from this change down the line).

Closes #132 