### PR TITLE
Fix minor bugs

### DIFF
--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -726,6 +726,10 @@ var L_ = {
         }
 
         ToolController_.notifyActiveTool('setActiveFeature', L_.activeFeature)
+
+        if (!L_.activeFeature) {
+            L_.clearVectorLayerInfo()
+        }
     },
     highlight(layer) {
         if (layer == null) return

--- a/src/external/Dropy/dropy.js
+++ b/src/external/Dropy/dropy.js
@@ -20,7 +20,7 @@ export default {
                 '<dd class="dropy__content">',
                     '<ul>',
                         placeholder ? `<li><a class="dropy__header" style="pointer-events: none;">${placeholder}</a></li>` : '',
-                        items.map((item, i) => `<li><a${i === selectedIndex ? ' class="selected"' : ""} idx=${i} title="${item.includes('<') ? '' : item}">${item}</a></li>`).join('\n'),
+                        items.map((item, i) => `<li><a${i === selectedIndex ? ' class="selected"' : ""} idx=${i} title="${typeof item === 'string' && item.includes('<') ? '' : item}">${item}</a></li>`).join('\n'),
                     '</ul>',
                 '</dd>',
                 '<input type="hidden" name="first">',


### PR DESCRIPTION
This adds a fix suggested by @tariqksoliman to fix a bug that would cause a crash if an item's display name is a number. This also fixes a bug where clicking on the map with no features did not clear the info tool and description box.