### PR TITLE
Add LineString functions

### DIFF
--- a/docs/pages/markdowns/JavaScript_API.md
+++ b/docs/pages/markdowns/JavaScript_API.md
@@ -114,6 +114,68 @@ The following is an example of how to call the `keepLastN` function:
 window.mmgisAPI.keepLastN('Waypoints', 2)
 ```
 
+### trimLineString(layerName, time, timeProp, trimN, startOrEnd)
+
+This function is used to trim a specified number of vertices on a specified layer containing GeoJson LineString features. This makes the following assumptions:
+- If trimming from the beginning of the layer, the time in the `time` parameter  must be after the start time of the first feature in the layer
+- If trimming from the end of the layer, the time in the `time` parameter  must be before the end time of the last feature in the layer
+
+#### Function parameters
+
+- `layerName` - name of layer to update
+- `time` - absolute time in the format of YYYY-MM-DDThh:mm:ssZ; represents start time if trimming from the beginning, otherwise represents the end time
+- `timeProp` - key representing the time property to be updated in the layer
+- `trimN` - number of vertices to trim
+- `startOrEnd` - direction to trim from; value can only be one of the following options: start, end
+
+The following are examples of how to call the `trimLineString` function:
+
+```javascript
+window.mmgisAPI.trimLineString('Traverse', '2021-12-01T15:03:00.000Z', 'start_time', 7, 'start')
+```
+
+```javascript
+window.mmgisAPI.trimLineString('Traverse', '2021-12-01T15:13:00.000Z', 'end_time', 7, 'end')
+```
+
+### appendLineString(layerName, inputData, timeProp)
+This function appends input data with a GeoJson Feature that contains a LineString. The LineString vertices from the input data is appended as vertices to the last Feature in the layer. The input data should also contain a property with `timeProp` as the key, representing the new end time for the updated data.
+
+#### Function parameters
+
+- `layerName` - name of layer to update
+- `inputData` - GeoJson data containing a single Feature containing a LineString
+- `timeProp` - key representing the time property to be updated in the layer
+
+The following is an example of how to call the `appendLineString` function:
+
+```javascript
+window.mmgisAPI.appendLineString(
+    'Traverse',
+    {
+        'type':'Feature',
+        'properties':{
+            'name': 2,
+            'Length_m': 0,
+            'COLOR': 0,
+            'route': 0,
+            'start_time': '2021-12-01T15:10:00.000Z',
+            'end_time': '2021-12-01T15:20:00.000Z'
+        },
+        'geometry':{
+                'type':'LineString',
+                'coordinates':[
+                    [145.862136,-73.208439],
+                    [135.063782,-71.898251],
+                    [130.828697,-75.540527],
+                    [122.767247,-72.658683],
+                    [120.133499,-75.018059]
+                ]
+        }
+    },
+    'end_time');
+```
+
 ## Time Control
 
 ## toggleTimeUI(visibility)

--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -2108,4 +2108,3 @@ function parseConfig(configData, urlOnLayers) {
 }
 
 export default L_
-window.L_ = L_

--- a/src/essence/mmgisAPI/mmgisAPI.js
+++ b/src/essence/mmgisAPI/mmgisAPI.js
@@ -258,6 +258,15 @@ var mmgisAPI = {
      * @param {keepFirstN} - keepN - number of features to keep from the beginning of the feature list. A value less than or equal to 0 keeps all previous features
      */
     keepFirstN: L_.keepFirstN,
+    /**
+     * This function is used to trim a specified number of vertices on a specified layer containing GeoJson LineString features.
+     * @param {string} - layerName - name of layer to update
+     * @param {object} - startTimeData - object with the following format: `{ key, newTime }` with key as a string representing the name of the key for the start time property in the LineString properties
+     * @param {object} - endTimeData - object with the following format: `{ key, newTime }` with key as a string representing the name of the key for the end time property in the LineString properties
+     * @param {number} - trimN - number of vertices to trim
+     * @param {string} - trimDirection - direction to trim from; value can only be one of the following options: start, end
+     */
+    trimLineString: L_.trimLineString,
 
     // Time Control API functions
 

--- a/src/essence/mmgisAPI/mmgisAPI.js
+++ b/src/essence/mmgisAPI/mmgisAPI.js
@@ -261,12 +261,18 @@ var mmgisAPI = {
     /**
      * This function is used to trim a specified number of vertices on a specified layer containing GeoJson LineString features.
      * @param {string} - layerName - name of layer to update
-     * @param {object} - startTimeData - object with the following format: `{ key, newTime }` with key as a string representing the name of the key for the start time property in the LineString properties
-     * @param {object} - endTimeData - object with the following format: `{ key, newTime }` with key as a string representing the name of the key for the end time property in the LineString properties
+     * @param {string} - time - absolute time in the format of YYYY-MM-DDThh:mm:ssZ; represents start time if trimming from the beginning, otherwise represents the end time
      * @param {number} - trimN - number of vertices to trim
-     * @param {string} - trimDirection - direction to trim from; value can only be one of the following options: start, end
+     * @param {string} - startOrEnd - direction to trim from; value can only be one of the following options: start, end
      */
     trimLineString: L_.trimLineString,
+    /**
+     * This function is used to append new LineString data to the last feature (with LineString geometry) in a layer
+     * @param {string} - layerName - name of layer to update
+     * @param {object} - inputData - a GeoJson Feature object containing geometry that is a LineString
+     * @param {string} - timeProp - name of time property in each feature in the layer and in the inputData
+     */
+    appendLineString: L_.appendLineString,
 
     // Time Control API functions
 


### PR DESCRIPTION
This adds two new functions to perform operations on vector layers containing features made up of `LineString`.

## trimLineString
This function can be used to trim a specified number of vertices on a specified layer containing GeoJson LineString features. The function can trim from either the beginning or end.

This function makes the following assumptions:
- The user calling the method knows exactly how many vertices they want to trim and the new start/end time
- The features are ordered based on time in ascending order
- All of the features in the layer must have `LineString` as the type
- If trimming from the beginning of the layer, the time in the `time` parameter must be after the start time of the first feature in the layer
- If trimming from the end of the layer, the time in the `time` parameter must be before the end time of the last feature in the layer

## appendLineString
This function appends input data with a GeoJson Feature that contains a LineString. The LineString vertices from the input data is appended as vertices to the last Feature in the layer. The new end time is updated using the information from the input data.

This function makes the following assumptions:
- There is at least one feature in the layer to append to
- The input data is a single GeoJson feature. Below is an example of the expected input data format:
    ```
     {
        'type':'Feature',
        'properties':{
            'name': 2,
            'Length_m': 0,
            'COLOR': 0,
            'route': 0,
            'start_time': '2021-12-01T15:10:00.000Z',
            'end_time': '2021-12-01T15:20:00.000Z'
        },
        'geometry':{
                'type':'LineString',
                'coordinates':[
                    [145.862136,-73.208439],
                    [135.063782,-71.898251],
                    [130.828697,-75.540527],
                    [122.767247,-72.658683],
                    [120.133499,-75.018059]
                ]
        }
    }
    ```