### PR TITLE
#169 API onClick fires for core DivIcon markers

### DIFF
--- a/src/css/mmgis.css
+++ b/src/css/mmgis.css
@@ -353,6 +353,10 @@ body {
     margin: 1px 7px 1px 7px;
 }
 
+.leafletDivIcon > * {
+    pointer-events: none !important;
+}
+
 .leaflet-marker-pane.hideDivIcons .leaflet-div-icon {
     opacity: 0 !important;
     pointer-events: none;

--- a/src/essence/Basics/Layers_/LayerConstructors.js
+++ b/src/essence/Basics/Layers_/LayerConstructors.js
@@ -291,13 +291,14 @@ export const constructVectorLayer = (
                             .replace(/\s/g, '')
                             .toLowerCase()} ${layerObj.name
                             .replace(/\s/g, '')
-                            .toLowerCase()}`,
+                            .toLowerCase()} leafletDivIcon`,
                         iconSize: [
                             (featureStyle.radius + pixelBuffer) * 2,
                             (featureStyle.radius + pixelBuffer) * 2,
                         ],
                         html: svg,
                     }),
+                    bubblingMouseEvents: true,
                 })
             }
 

--- a/src/essence/mmgisAPI/mmgisAPI.js
+++ b/src/essence/mmgisAPI/mmgisAPI.js
@@ -177,6 +177,7 @@ var mmgisAPI_ = {
 
         return { ...L_.toggledArray, ...drawToolVisibility }
     },
+    //customListeners: {},
     // Adds map event listener
     addEventListener: function (eventName, functionReference) {
         const listener = mmgisAPI_.getLeafletMapEvent(eventName)
@@ -184,6 +185,8 @@ var mmgisAPI_ = {
             console.log('Add listener', listener)
             mmgisAPI_.map.addEventListener(listener, functionReference)
         } else {
+            //mmgisAPI_.customListeners[eventName] = mmgisAPI_.customListeners[eventName] || []
+            //mmgisAPI_.customListeners[eventName].push(functionReference)
             console.warn(
                 'Warning: Unable to add event listener for ' + eventName
             )
@@ -196,6 +199,9 @@ var mmgisAPI_ = {
             console.log('Remove listener', listener)
             mmgisAPI_.map.removeEventListener(listener, functionReference)
         } else {
+            //if(mmgisAPI_.customListeners[eventName]) {
+            //    mmgisAPI_.customListeners[eventName] = mmgisAPI_.customListeners[eventName].filter(f => f !== functionReference)
+            //}
             console.warn(
                 'Warning: Unable to remove event listener for ' + eventName
             )


### PR DESCRIPTION
Closes #169

The issue was that, on div markers (a way to use HTML to style markers), the contents would capture the event and stop it from propagating to the map. Geologic symbol markers will still have this issue but all the standard 'shape' and 'bearing' markers should be fixed.