### PR TITLE
Description should be updated to match example code

### DIFF
--- a/docs/pages/markdowns/Vector.md
+++ b/docs/pages/markdowns/Vector.md
@@ -185,7 +185,7 @@ Example:
 }
 ```
 
-- `useNameAsKey`: The property key whose value should be the hover text of each feature. If left unset, the hover key and value will be the first one listed in the feature's properties.
+- `useKeyAsName`: The property key whose value should be the hover text of each feature. If left unset, the hover key and value will be the first one listed in the feature's properties.
 - `datasetLinks`: Datasets are csvs uploaded from the "Manage Datasets" page accessible on the lower left. Every time a feature from this layer is clicked with datasetLinks configured, it will request the data from the server and include it with it's regular geojson properties. This is especially useful when single features need a lot of metadata to perform a task as it loads it only as needed.
   - `prop`: This is a property key already within the features properties. It's value will be searched for in the specified dataset column.
   - `dataset`: The name of a dataset to link to. A list of datasets can be found in the "Manage Datasets" page.


### PR DESCRIPTION
While copy pasting to set a label property, I chose poorly. The example code is correct and the description is not.