### PR TITLE
Add new event listeners for MMGIS API

### DIFF
--- a/documentation/pages/markdowns/JavaScript_API.md
+++ b/documentation/pages/markdowns/JavaScript_API.md
@@ -380,7 +380,7 @@ window.mmgisAPI.updateLayersTime()
 
 ### addEventListener(eventName, functionReference)
 
-This function adds a map event listener added using the MMGIS API. This function takes in one of the following events: `onPan`, `onZoom`, `onClick`.
+This function adds a map event or MMGIS action listener added using the MMGIS API. This function takes in one of the following events: `onPan`, `onZoom`, `onClick`, `toolChange`, `layerVisibilityChange`. The MMGIS action listener (`toolChange`, `layerVisibilityChange`) functions are called with an `event` parameter.
 
 #### Function parameters
 
@@ -399,15 +399,21 @@ function listener() {
 }
 
 window.mmgisAPI.addEventListener('onPan', listener)
+
+function mmgisListener(event) {
+    console.log('event', event)
+}
+
+window.mmgisAPI.addEventListener('toolChange', mmgisListener)
 ```
 
 ### removeEventListener(eventName, functionReference)
 
-This function removes a map event listener added using the MMGIS API.
+This function removes a map event or MMGIS action  listener added using the MMGIS API.
 
 #### Function parameters
 
-- `eventName` - name of event to add listener to. Available events: `onPan`, `onZoom`, `onClick`
+- `eventName` - name of event to remove listener from. Available events: `onPan`, `onZoom`, `onClick`, `toolChange`, `layerVisibilityChange`
 - `functionReference` - function reference to listener event callback function. `null` value removes all functions for a given `eventName`
 
 The following is an example of how to call the `removeEventListener` function:
@@ -499,4 +505,14 @@ window.mmgisAPI.onLoaded(() => {
 
     window.mmgisAPI.addEventListener('onPan', listener)
 })
+```
+
+### getActiveTool
+
+This function returns an object with the currently active tool and the name of the active tool.
+
+The following is an example of how to call the `getActiveTool` function:
+
+```javascript
+window.mmgisAPI.getActiveTool()
 ```

--- a/src/essence/Basics/ToolController_/ToolController_.js
+++ b/src/essence/Basics/ToolController_/ToolController_.js
@@ -93,6 +93,15 @@ let ToolController_ = {
                             ToolController_.makeTool(
                                 ToolController_.toolModuleNames[i]
                             )
+
+                            // Dispatch `toolChange` event
+                            let _event = new CustomEvent('toolChange', {
+                                detail: {
+                                    activeTool: ToolController_.activeTool,
+                                    activeToolName: ToolController_.activeToolName,
+                                }
+                            })
+                            document.dispatchEvent(_event);
                         }
                     })(i)
                 )

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -491,6 +491,17 @@ function interfaceWithMMGIS() {
                 L_.layersGroup[li.attr('name')] == null
             )
                 li.addClass('layernotfound')
+
+            // Dispatch `layerVisibilityChange` event
+            const layerName = li.attr('name')
+            let _event = new CustomEvent('layerVisibilityChange', {
+                detail: {
+                    layer: L_.layersNamed[layerName],
+                    layerName,
+                    visible: L_.toggledArray[layerName],
+                }
+            })
+            document.dispatchEvent(_event);
         }
     }
     //Add event functions and whatnot

--- a/src/essence/mmgisAPI/mmgisAPI.js
+++ b/src/essence/mmgisAPI/mmgisAPI.js
@@ -160,6 +160,15 @@ var mmgisAPI_ = {
 
         return null
     },
+    getActiveTool: function () {
+        if (ToolController_) {
+            return {
+                activeTool: ToolController_.activeTool,
+                activeToolName: ToolController_.activeToolName,
+            }
+        }
+        return null
+    },
     // Returns an object with the visibility state of all layers
     getVisibleLayers: function () {
         // Also return the visibility of the DrawTool layers
@@ -183,9 +192,13 @@ var mmgisAPI_ = {
     // Adds map event listener
     addEventListener: function (eventName, functionReference) {
         const listener = mmgisAPI_.getLeafletMapEvent(eventName)
+        const mmgisListener = mmgisAPI_.checkMMGISEvent(eventName)
         if (listener) {
             console.log('Add listener:', listener)
             mmgisAPI_.map.addEventListener(listener, functionReference)
+        } else if (mmgisListener) {
+            console.log('Add listener', eventName)
+            document.addEventListener(eventName, functionReference);
         } else {
             //mmgisAPI_.customListeners[eventName] = mmgisAPI_.customListeners[eventName] || []
             //mmgisAPI_.customListeners[eventName].push(functionReference)
@@ -197,9 +210,13 @@ var mmgisAPI_ = {
     // Removes map event listener added using the MMGIS API
     removeEventListener: function (eventName, functionReference) {
         const listener = mmgisAPI_.getLeafletMapEvent(eventName)
+        const mmgisListener = mmgisAPI_.checkMMGISEvent(eventName)
         if (listener) {
             console.log('Remove listener:', listener)
             mmgisAPI_.map.removeEventListener(listener, functionReference)
+        } else if (mmgisListener) {
+            console.log('Remove listener', eventName)
+            document.removeEventListener(eventName, functionReference);
         } else {
             //if(mmgisAPI_.customListeners[eventName]) {
             //    mmgisAPI_.customListeners[eventName] = mmgisAPI_.customListeners[eventName].filter(f => f !== functionReference)
@@ -218,6 +235,10 @@ var mmgisAPI_ = {
             return 'click'
         }
         return null
+    },
+    checkMMGISEvent: function (eventName) {
+        const validEvents = ['toolChange', 'layerVisibilityChange']
+        return validEvents.includes(eventName)
     },
     writeCoordinateURL: function () {
         return QueryURL.writeCoordinateURL(false)
@@ -385,20 +406,26 @@ var mmgisAPI = {
      */
     getActiveFeature: mmgisAPI_.getActiveFeature,
 
+    /** getActiveTool - returns the currently active tool
+     * @returns {object} - The currently active tool and the name of the active tool as an object.
+     */
+    getActiveTool: mmgisAPI_.getActiveTool,
+
     /** getVisibleLayers - returns an object with the visibility state of all layers
      * @returns {object} - an object containing the visibility state of each layer
      */
     getVisibleLayers: mmgisAPI_.getVisibleLayers,
 
-    /** addEventListener - adds map event listener.
-     * @param {string} - eventName - name of event to add listener to. Available events: onPan, onZoom, onClick
+    /** addEventListener - adds map event or MMGIS action listener.
+     * @param {string} - eventName - name of event to add listener to. Available events: onPan, onZoom, onClick, toolChange, layerVisibilityChange
+
      * @param {function} - functionReference - function reference to listener event callback function. null value removes all functions for a given eventName
 
      */
     addEventListener: mmgisAPI_.addEventListener,
 
-    /** removeEventListener - removes map event listener added using the MMGIS API.
-     * @param {string} - eventName - name of event to add listener to. Available events: onPan, onZoom, onClick
+    /** removeEventListener - removes map event or MMGIS action listener added using the MMGIS API.
+     * @param {string} - eventName - name of event to add listener to. Available events: onPan, onZoom, onClick, toolChange, layerVisibilityChange
      * @param {function} - functionReference - function reference to listener event callback function. null value removes all functions for a given eventName
      */
     removeEventListener: mmgisAPI_.removeEventListener,


### PR DESCRIPTION
This closes #203. This adds a listener for changing tools and adds a listener for layer visibility changes. The two new options are: `toolChange` and `layerVisibilityChange`. Both options have functions that are called with an `event` parameter. This also adds a `getActiveTool` function to get the active tool.

### Example
```
function mmgisListener(event) {
    console.log('event', event)
}
window.mmgisAPI.addEventListener('toolChange', mmgisListener)
```
