### PR TITLE
Make sure WMS parameters are set correctly

### DIFF
--- a/src/essence/Ancillary/TimeControl.js
+++ b/src/essence/Ancillary/TimeControl.js
@@ -171,6 +171,11 @@ var TimeControl = {
             d3.select('.endtime.' + layer.name.replace(/\s/g, '')).text(
                 layer.time.end
             )
+
+            if (layer.type == 'tile') {
+                TimeControl.setLayerWmsParams(layer)
+            }
+
         }
         return true
     },


### PR DESCRIPTION
This makes sure the layer WMS parameters are set without calling reloadLayer.