### PR TITLE
Set WMS parameters when calling setTime function

### DIFF
--- a/src/essence/Ancillary/TimeControl.js
+++ b/src/essence/Ancillary/TimeControl.js
@@ -273,6 +273,10 @@ var TimeControl = {
                     layer.time.end
                 )
                 updatedLayers.push(layer.name)
+
+                if (layer.type == 'tile') {
+                    TimeControl.setLayerWmsParams(layer)
+                }
             }
         }
         return updatedLayers


### PR DESCRIPTION
Similar fix to #227. This makes sure the WMS parameters are set correctly when the `setTime` function is called without calling `reloadLayer`.