### PR TITLE
Fix onClick event listener bug

### DIFF
--- a/src/essence/Tools/Draw/DrawTool_Drawing.js
+++ b/src/essence/Tools/Draw/DrawTool_Drawing.js
@@ -586,7 +586,6 @@ var drawing = {
 
             d.stopclick = false
 
-            Map_.map.off('click', d.start)
             Map_.map.off('draw:created', d.stop)
             if (typeof d.drawing.disable === 'function') d.drawing.disable()
         },


### PR DESCRIPTION
This fixes the following bug:
> I’m setting up “onClick” and “toolChange” event listeners after MMGIS loads. It looks like when I switch to the draw pane, the onClick event listener stops working (which isn’t a problem for us), but when I switch back to any of the other panes (layers, legend, etc.) the onClick event listener doesn’t resume firing on clicks. I can send a screen recording if this doesn’t make sense.

This fixes the bug because `d.start` is an undefined function so it was removing _all_ of the click event listeners on the Leaflet map.
