### PR TITLE
Fix TimeControl so WMS information is set before layers are loaded

### DIFF
--- a/src/essence/Ancillary/TimeControl.js
+++ b/src/essence/Ancillary/TimeControl.js
@@ -90,6 +90,8 @@ var TimeControl = {
         if (L_.configData.time.visible == false) {
             TimeControl.toggleTimeUI(false)
         }
+    },
+    fina: function () {
         initLayerTimes()
     },
     toggleTimeUI: function (isOn) {

--- a/src/essence/essence.js
+++ b/src/essence/essence.js
@@ -178,14 +178,14 @@ var essence = {
         //Make the map
         if (swapping) Map_.clear()
 
+        //Make the time control
+        TimeControl.init()
+
         Map_.init(this.fina)
 
         //Now that the map is made
         Coordinates.init()
         ContextMenu.init()
-
-        //Make the time control
-        TimeControl.init()
 
         if (!swapping) {
             Description.init(L_.mission, L_.site, Map_, L_)
@@ -283,6 +283,8 @@ var essence = {
             UserInterface_.fina(L_, Viewer_, Map_, Globe_)
             //Finalize the Viewer
             Viewer_.fina(Map_)
+            //Finalize the TimeControl
+            TimeControl.fina()
             // Finalize the mmgisAPI
             mmgisAPI_.fina(Map_)
 


### PR DESCRIPTION
This should fix an issue where the WMS layer times are not set before the `mmgisAPI.onLoaded` callback function is called.