### PR TITLE
#239 Fix DrawTool layers move when changing attributes

### DIFF
--- a/src/essence/Ancillary/Login/Login.js
+++ b/src/essence/Ancillary/Login/Login.js
@@ -71,9 +71,11 @@ var Login = {
                 window.mmgisglobal.AUTH === 'local') &&
             window.mmgisglobal.hasOwnProperty('user')
         ) {
-            this.loggedIn = true
             this.username = window.mmgisglobal.user
-            this.beganLoggedIn = true
+            if (this.username != 'guest') {
+                this.loggedIn = true
+                this.beganLoggedIn = true
+            }
         }
 
         Login.loginBar = d3

--- a/src/essence/Ancillary/Search.js
+++ b/src/essence/Ancillary/Search.js
@@ -211,7 +211,7 @@ async function changeSearchField(val, selectedPlaceholder) {
         Search.arrayToSearch = []
         let data
         try {
-            data = L_.layersGroup[Search.lname].toGeoJSON()
+            data = L_.layersGroup[Search.lname].toGeoJSON(L_.GEOJSON_PRECISION)
         } catch (err) {
             data = { features: [] }
         }

--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -75,6 +75,7 @@ var L_ = {
     },
     //URL search strings
     searchStrings: null,
+    GEOJSON_PRECISION: 10,
     //URL search file
     searchFile: null,
     toolsLoaded: false,
@@ -399,7 +400,9 @@ var L_ = {
                                     name: s.name,
                                     order: L_.layersOrdered, // Since higher order in litho is on top
                                     on: L_.opacityArray[s.name] ? true : false,
-                                    geojson: L_.layersGroup[s.name].toGeoJSON(),
+                                    geojson: L_.layersGroup[s.name].toGeoJSON(
+                                        L_.GEOJSON_PRECISION
+                                    ),
                                     onClick: (feature, lnglat, layer) => {
                                         this.selectFeature(layer.name, feature)
                                     },
@@ -678,7 +681,9 @@ var L_ = {
                                 name: s.name,
                                 order: L_.layersOrdered, // Since higher order in litho is on top
                                 on: L_.opacityArray[s.name] ? true : false,
-                                geojson: L_.layersGroup[s.name].toGeoJSON(),
+                                geojson: L_.layersGroup[s.name].toGeoJSON(
+                                    L_.GEOJSON_PRECISION
+                                ),
                                 onClick: (feature, lnglat, layer) => {
                                     this.selectFeature(layer.name, feature)
                                 },
@@ -1742,7 +1747,9 @@ var L_ = {
         updateLayer.removeLayer(removeLayer)
 
         var layerName = updateLayer._layerName
-        var layersGeoJSON = L_.layersGroup[layerName].toGeoJSON()
+        var layersGeoJSON = L_.layersGroup[layerName].toGeoJSON(
+            L_.GEOJSON_PRECISION
+        )
         L_.clearGeoJSONData(updateLayer)
         L_.addGeoJSONData(updateLayer, layersGeoJSON)
     },
@@ -1969,7 +1976,7 @@ var L_ = {
             const updateLayer = L_.layersGroup[layerName]
 
             var layers = updateLayer.getLayers()
-            var layersGeoJSON = updateLayer.toGeoJSON()
+            var layersGeoJSON = updateLayer.toGeoJSON(L_.GEOJSON_PRECISION)
             var features = layersGeoJSON.features
 
             // All of the features have to be a LineString
@@ -2146,7 +2153,7 @@ var L_ = {
             const updateLayer = L_.layersGroup[layerName]
 
             var layers = updateLayer.getLayers()
-            var layersGeoJSON = updateLayer.toGeoJSON()
+            var layersGeoJSON = updateLayer.toGeoJSON(L_.GEOJSON_PRECISION)
             var features = layersGeoJSON.features
 
             if (features.length > 0) {
@@ -2251,7 +2258,9 @@ var L_ = {
     // Make a layer's sublayer match the layers data again
     syncSublayerData: function (layerName) {
         try {
-            let geojson = L_.layersGroup[layerName].toGeoJSON()
+            let geojson = L_.layersGroup[layerName].toGeoJSON(
+                L_.GEOJSON_PRECISION
+            )
             if (L_.layersGroup[layerName]._sourceGeoJSON)
                 geojson = L_.layersGroup[layerName]._sourceGeoJSON
 

--- a/src/essence/Tools/Draw/DrawTool_Drawing.js
+++ b/src/essence/Tools/Draw/DrawTool_Drawing.js
@@ -83,7 +83,9 @@ var Drawing = {
                     2
                 )
             } else {
-                let features = lg[i] ? lg[i].toGeoJSON().features : null
+                let features = lg[i]
+                    ? lg[i].toGeoJSON(L_.GEOJSON_PRECISION).features
+                    : null
                 if (features != null) {
                     let geojson = features[0]
                     if (F_.doBoundingBoxesIntersect(bb, turf.bbox(geojson))) {
@@ -514,7 +516,7 @@ var drawing = {
             var d = drawing.polygon
             if (d.shiftDisabled) return
 
-            d.shape = d.shape.toGeoJSON()
+            d.shape = d.shape.toGeoJSON(L_.GEOJSON_PRECISION)
 
             d.shape.geometry.type = 'Polygon'
             d.shape.geometry.coordinates.push(d.shape.geometry.coordinates[0])
@@ -782,7 +784,7 @@ var drawing = {
             if (typeof overrideFinishCallback === 'function') {
                 d.overstop = function () {
                     if (typeof d.shape.toGeoJSON === 'function') {
-                        let s = d.shape.toGeoJSON()
+                        let s = d.shape.toGeoJSON(L_.GEOJSON_PRECISION)
                         s.geometry.type = 'LineString'
                         s.properties.style = d.style
                         overrideFinishCallback(s)
@@ -899,7 +901,7 @@ var drawing = {
             var d = drawing.line
 
             if (d.shiftDisabled) return
-            d.shape = d.shape.toGeoJSON()
+            d.shape = d.shape.toGeoJSON(L_.GEOJSON_PRECISION)
             d.shape.geometry.type = 'LineString'
             d.shape.properties.style = d.style
             var n = $('#drawToolDrawFeaturesNewName')
@@ -1397,7 +1399,9 @@ var drawing = {
             var d = drawing.arrow
             if (d.shiftDisabled) return
 
-            d.shape = new L.Polyline([d.startPt, e.latlng]).toGeoJSON()
+            d.shape = new L.Polyline([d.startPt, e.latlng]).toGeoJSON(
+                L_.GEOJSON_PRECISION
+            )
 
             d.shape.properties.style = d.style
             d.shape.properties.name = 'Arrow'

--- a/src/essence/Tools/Draw/DrawTool_Editing.js
+++ b/src/essence/Tools/Draw/DrawTool_Editing.js
@@ -283,7 +283,7 @@ var Editing = {
         if (!deselecting) {
             if (typeof DrawTool.contextMenuLayer.toGeoJSON === 'function')
                 DrawTool.contextMenuLayerOriginalGeoJSON =
-                    DrawTool.contextMenuLayer.toGeoJSON()
+                    DrawTool.contextMenuLayer.toGeoJSON(L_.GEOJSON_PRECISION)
             else
                 DrawTool.contextMenuLayerOriginalGeoJSON =
                     DrawTool.contextMenuLayer.feature
@@ -395,7 +395,9 @@ var Editing = {
                 DrawTool.contextMenuLayer = DrawTool.contextMenuLayers[0].layer
                 if (typeof DrawTool.contextMenuLayer.toGeoJSON === 'function')
                     DrawTool.contextMenuLayerOriginalGeoJSON =
-                        DrawTool.contextMenuLayer.toGeoJSON()
+                        DrawTool.contextMenuLayer.toGeoJSON(
+                            L_.GEOJSON_PRECISION
+                        )
                 else
                     DrawTool.contextMenuLayerOriginalGeoJSON =
                         DrawTool.contextMenuLayer.feature
@@ -861,7 +863,9 @@ var Editing = {
             Map_.rmNotNull(DrawTool.contextMenuLayers[0].selectionLayer)
             if (typeof DrawTool.contextMenuLayer.toGeoJSON !== 'function')
                 return
-            var bbox = turf.bbox(DrawTool.contextMenuLayer.toGeoJSON())
+            var bbox = turf.bbox(
+                DrawTool.contextMenuLayer.toGeoJSON(L_.GEOJSON_PRECISION)
+            )
             var bounds = [
                 [bbox[1], bbox[0]],
                 [bbox[3], bbox[2]],
@@ -2307,7 +2311,9 @@ var Editing = {
                 //Then just a regular single save
                 if (typeof DrawTool.contextMenuLayer.toGeoJSON === 'function')
                     DrawTool.contextMenuLayerOriginalGeoJSON =
-                        DrawTool.contextMenuLayer.toGeoJSON()
+                        DrawTool.contextMenuLayer.toGeoJSON(
+                            L_.GEOJSON_PRECISION
+                        )
                 else
                     DrawTool.contextMenuLayerOriginalGeoJSON =
                         DrawTool.contextMenuLayer.feature
@@ -2328,14 +2334,16 @@ var Editing = {
 
                 var newGeometry
                 if (featureType != 'note' && featureType != 'arrow') {
-                    newGeometry = DrawTool.contextMenuLayer.toGeoJSON().geometry
+                    newGeometry = DrawTool.contextMenuLayer.toGeoJSON(
+                        L_.GEOJSON_PRECISION
+                    ).geometry
                     if (
                         newGeometry == null &&
                         DrawTool.contextMenuLayer.hasOwnProperty('_layers')
                     )
                         newGeometry = DrawTool.contextMenuLayer._layers
                             .getFirst()
-                            .toGeoJSON().geometry
+                            .toGeoJSON(L_.GEOJSON_PRECISION).geometry
                 } else if (featureType == 'note') {
                     newGeometry = {
                         type: 'Point',

--- a/src/essence/Tools/Draw/DrawTool_Files.js
+++ b/src/essence/Tools/Draw/DrawTool_Files.js
@@ -24,6 +24,7 @@ var Files = {
         DrawTool.refreshNoteEvents = Files.refreshNoteEvents
         DrawTool.refreshMasterCheckbox = Files.refreshMasterCheckbox
     },
+    currentOpenFolderName: null,
     prevFilterString: '',
     populateFiles: function (activeFileId) {
         $('#drawToolDrawFilesListMaster *').remove()
@@ -464,6 +465,7 @@ var Files = {
             const icons = Files.getGroupingIcons(elmg)
             if (isOpen) {
                 elm.attr('state', 'off')
+                Files.currentOpenFolderName = null
                 li.css({ display: 'none' })
                 elm.find('i').removeClass(icons.open)
                 elm.find('i').addClass(icons.closed)
@@ -483,11 +485,17 @@ var Files = {
                     elm2.find('i').addClass(icons2.closed)
                 })
                 elm.attr('state', 'on')
+                Files.currentOpenFolderName = elm.attr('group_name')
                 li.css({ display: 'block' })
                 elm.find('i').removeClass(icons.closed)
                 elm.find('i').addClass(icons.open)
             }
         })
+
+        if (Files.currentOpenFolderName != null)
+            $(
+                `.drawToolDrawFilesGroupElemHead[group_name=${Files.currentOpenFolderName}]`
+            ).trigger('click')
 
         //Li Elem Context Menu
         $(

--- a/src/essence/Tools/Layers/Filtering/Filtering.js
+++ b/src/essence/Tools/Layers/Filtering/Filtering.js
@@ -40,7 +40,7 @@ const Filtering = {
             try {
                 Filtering.filters[layerName].geojson =
                     Filtering.filters[layerName].geojson ||
-                    L_.layersGroup[layerName].toGeoJSON()
+                    L_.layersGroup[layerName].toGeoJSON(L_.GEOJSON_PRECISION)
             } catch (err) {
                 console.warn(
                     `Filtering - Cannot find GeoJSON to filter on for layer: ${layerName}`

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -745,7 +745,7 @@ function interfaceWithMMGIS(fromInit) {
         let layerName = li.attr('name')
         F_.downloadObject(
             L_.convertGeoJSONLngLatsToPrimaryCoordinates(
-                L_.layersGroup[layerName].toGeoJSON(10)
+                L_.layersGroup[layerName].toGeoJSON(L_.GEOJSON_PRECISION)
             ),
             layerName,
             '.json'
@@ -757,7 +757,7 @@ function interfaceWithMMGIS(fromInit) {
 
         let layerName = li.attr('name')
         F_.downloadObject(
-            L_.layersGroup[layerName].toGeoJSON(10),
+            L_.layersGroup[layerName].toGeoJSON(L_.GEOJSON_PRECISION),
             layerName,
             '.json'
         )

--- a/src/external/Leaflet/leaflet-pip.js
+++ b/src/external/Leaflet/leaflet-pip.js
@@ -79,7 +79,7 @@
                                                 type: 'Point',
                                                 coordinates: p,
                                             },
-                                            l.toGeoJSON().geometry
+                                            l.toGeoJSON(10).geometry
                                         )
                                     ) {
                                         results.push(l)


### PR DESCRIPTION
Closes #239 

Just needed to set precision values in the toGeoJSON functions. They default to 6 decimal places and I bumped them all up to 10.

Additional little fixes:
- Stop treating the default 'guest' user as true user. No longer need to logout of the guest user to login as another user in some auth modes.
- DrawTool remembers the open folder and reopens it when switching tabs.