### PR TITLE
Add toggleLayer function to MMGIS API

### DIFF
--- a/documentation/pages/markdowns/JavaScript_API.md
+++ b/documentation/pages/markdowns/JavaScript_API.md
@@ -472,6 +472,25 @@ The following is an example of how to call the `getVisibleLayers` function:
 window.mmgisAPI.getVisibleLayers()
 ```
 
+### toggleLayer
+
+This function sets the visibility state for a named layer
+
+#### Function parameters
+
+- `layerName` - name of layer to toggle visiblity
+- `on` - (optional) Set `true` if the visibility should be on or `false` if visibility should be off. If not set, the current visiblity state will switch to the opposite state.
+
+The following is an example of how to call the `toggleLayer` function:
+
+```javascript
+# Set 'Layer 1' to be visible
+window.mmgisAPI.toggleLayer('Layer 1', true)
+
+# Toggle the visibility state of 'Layer 1'
+window.mmgisAPI.toggleLayer('Layer 1')
+```
+
 ## Miscellaneous Features
 
 ### writeCoordinateURL

--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -197,6 +197,10 @@ var L_ = {
         let on //if on -> turn off //if off -> turn on
         if (L_.toggledArray[s.name] === true) on = true
         else on = false
+
+        await L_.toggleLayerHelper(s, on)
+    },
+    toggleLayerHelper: async function (s, on) {
         if (s.type !== 'header') {
             if (on) {
                 if (L_.Map_.map.hasLayer(L_.layersGroup[s.name])) {

--- a/src/essence/mmgisAPI/mmgisAPI.js
+++ b/src/essence/mmgisAPI/mmgisAPI.js
@@ -1,7 +1,11 @@
 import L_ from '../Basics/Layers_/Layers_'
+import F_ from '../Basics/Formulae_/Formulae_'
 import ToolController_ from '../Basics/ToolController_/ToolController_'
 import QueryURL from '../Ancillary/QueryURL'
 import TimeControl from '../Ancillary/TimeControl'
+
+import $ from 'jquery'
+
 let L = window.L
 
 var mmgisAPI_ = {
@@ -255,6 +259,32 @@ var mmgisAPI_ = {
     unproject: function (xy) {
         return window.mmgisglobal.customCRS.unproject(xy)
     },
+    toggleLayer: async function (layerName, on) {
+        if (layerName in L_.layersDataByName) {
+            if (on === undefined || on === null) {
+                // If on is not defined, switch the visibility state of the layer
+                await L_.toggleLayer(L_.layersDataByName[layerName])
+            } else {
+                let state = L_.toggledArray[layerName] && !on ? true : false
+                await L_.toggleLayerHelper(L_.layersDataByName[layerName], state)
+            }
+
+            if (ToolController_.activeToolName === 'LayersTool') {
+                const id = `#layerstart${F_.getSafeName(layerName)} .checkbox`
+
+                if (L_.toggledArray[layerName]) {
+                    $(id).addClass('on')
+                } else {
+                    $(id).removeClass('on')
+                }
+            }
+        } else {
+            console.warn(
+                `'Warning: Unable to find layer named ${layereName}`
+            )
+            return
+        }
+    },
 }
 
 var mmgisAPI = {
@@ -460,6 +490,12 @@ var mmgisAPI = {
      * @param {object} {lng: 0, lat: 0} - converted lnglat
      */
     unproject: mmgisAPI_.unproject,
+
+    /** toggleLayer - set the visibility state for a named layer
+     * @param {string} - layerName - name of layer to set visiblity
+     * @param {boolean} - on - (optional) Set true if the visibility should be on or false if visibility should be off. If not set, the current visiblity state will switch to the opposite state.
+     */
+    toggleLayer: mmgisAPI_.toggleLayer,
 }
 
 window.mmgisAPI = mmgisAPI


### PR DESCRIPTION
This adds a function to the MMGIS API to toggle a layer's visibility state.

Examples:
```javascript
# Set 'Layer 1' to be visible
mmgisAPI.toggleLayer('Layer 1', true)

# Toggle the visibility state of 'Layer 1'
mmgisAPI.toggleLayer('Layer 1')
```