### PR TITLE
Fix environment variable in sample.env for enabling websockets

### DIFF
--- a/docs/pages/Setup/ENVs/ENVs.md
+++ b/docs/pages/Setup/ENVs/ENVs.md
@@ -108,6 +108,6 @@ When not using AUTH=csso, this is a list of usernames to be treated as leads (us
 
 LDAP group of leads (users with elevated permissions) | string | default `''`
 
-#### `ENABLE_MMGIS_SOCKETS=`
+#### `ENABLE_MMGIS_WEBSOCKETS=`
 
 If true, enables the backend MMGIS websockets to tell clients to update layers | boolean | default `false`

--- a/sample.env
+++ b/sample.env
@@ -56,4 +56,4 @@ CSSO_LEAD_GROUP=A
 LEADS=["user1"]
 
 # If true, enables the backend MMGIS websockets to tell clients to update layers
-ENABLE_MMGIS_SOCKETS=false
+ENABLE_MMGIS_WEBSOCKETS=false


### PR DESCRIPTION
This fixes a typo in the sample.env file for enabling the websockets feature.