### PR TITLE
Update README to note the minimum required Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 ### System Requirements
 
-1. Install the latest version of [Node.js v14.9.0+](https://nodejs.org/en/download/). Developed with v16.13.2. Note that v18+ of Node.js fails to build.
+1. Install the latest version of [Node.js v14.15.0+](https://nodejs.org/en/download/). Developed with v16.13.2. Note that v18+ of Node.js fails to build.
 
 1. Install [PostgreSQL v10.14+](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads). Detailed [install instructions](https://www.postgresqltutorial.com/postgresql-getting-started/) for all platforms.
 1. Install [PostGIS 2.5+](https://postgis.net/install/). From the above install, you can use the 'Application Stack Builder' to install PostGIS or the default [PostGIS install instructions](https://postgis.net/install/) for all platforms.


### PR DESCRIPTION
The `sharp` package requires node >= 14.15.0.