### PR TITLE
#296 Fix WMS URL params being dropped

### DIFF
--- a/src/essence/Basics/Layers_/leaflet-tilelayer-middleware.js
+++ b/src/essence/Basics/Layers_/leaflet-tilelayer-middleware.js
@@ -234,7 +234,7 @@ L.TileLayer.ColorFilter = L.TileLayer.extend(colorFilterExtension)
 
 // We can't extend an already extended so we'll merge by hand
 L.TileLayer.WMSColorFilter = L.TileLayer.extend(
-    Object.assign(wmsExtension, colorFilterExtension)
+    Object.assign(colorFilterExtension, wmsExtension)
 )
 
 L.tileLayer.colorFilter = function (url, options) {


### PR DESCRIPTION
Closes #296 

Does not address second bug -- cannot reproduce.