### PR TITLE
#304 Fix DrawTool file list bug

### DIFF
--- a/src/essence/Tools/Draw/DrawTool.js
+++ b/src/essence/Tools/Draw/DrawTool.js
@@ -997,20 +997,20 @@ var DrawTool = {
         }
         if (typeof file_description !== 'string') return []
 
-        const tags = file_description.match(/#\w*/g) || []
+        const tags = file_description.match(/~#\w+/g) || []
         const uniqueTags = [...tags]
         // remove '#'s
-        tagFolders.tags = uniqueTags.map((t) => t.substring(1)) || []
+        tagFolders.tags = uniqueTags.map((t) => t.substring(2)) || []
 
-        const folders = file_description.match(/@\w*/g) || []
+        const folders = file_description.match(/~@\w+/g) || []
         const uniqueFolders = [...folders]
         // remove '@'s
-        tagFolders.folders = uniqueFolders.map((t) => t.substring(1)) || []
+        tagFolders.folders = uniqueFolders.map((t) => t.substring(2)) || []
 
-        const efolders = file_description.match(/\^\w*/g) || []
+        const efolders = file_description.match(/~\^\w+/g) || []
         const uniqueEFolders = [...efolders]
         // remove '^'s
-        tagFolders.efolders = uniqueEFolders.map((t) => t.substring(1)) || []
+        tagFolders.efolders = uniqueEFolders.map((t) => t.substring(2)) || []
 
         // At least one folder
         if (noDefaults !== true) {
@@ -1053,9 +1053,9 @@ var DrawTool = {
     stripTagsFromDescription(file_description) {
         if (typeof file_description !== 'string') return ''
         return file_description
-            .replaceAll(/#\w*/g, '')
-            .replaceAll(/@\w*/g, '')
-            .replaceAll(/\^\w*/g, '')
+            .replaceAll(/~#\w+/g, '')
+            .replaceAll(/~@\w+/g, '')
+            .replaceAll(/~\^\w+/g, '')
             .trimStart()
             .trimEnd()
     },

--- a/src/essence/Tools/Draw/DrawTool_Files.js
+++ b/src/essence/Tools/Draw/DrawTool_Files.js
@@ -421,11 +421,11 @@ var Files = {
                         }
                         if (
                             $(
-                                `.drawToolDrawFilesGroupElem[group_name=${g}] .drawToolDrawFilesGroupListElem > .drawToolDrawFilesListElem[file_id=${file.id}]`
+                                `.drawToolDrawFilesGroupElem[group_name="${g}"] .drawToolDrawFilesGroupListElem > .drawToolDrawFilesListElem[file_id="${file.id}"]`
                             ).length === 0
                         ) {
                             d3.select(
-                                `.drawToolDrawFilesGroupElem[group_name=${g}] .drawToolDrawFilesGroupListElem`
+                                `.drawToolDrawFilesGroupElem[group_name="${g}"] .drawToolDrawFilesGroupListElem`
                             )
                                 .append('li')
                                 .attr(

--- a/src/essence/Tools/Draw/DrawTool_Files.js
+++ b/src/essence/Tools/Draw/DrawTool_Files.js
@@ -1204,13 +1204,13 @@ var Files = {
                             file_description:
                                 description +
                                 existingTagFol['efolders']
-                                    .map((t) => ' ^' + t)
+                                    .map((t) => ' ~^' + t)
                                     .join('') +
                                 existingTagFol['folders']
-                                    .map((t) => ' @' + t)
+                                    .map((t) => ' ~@' + t)
                                     .join('') +
                                 existingTagFol['tags']
-                                    .map((t) => ' #' + t)
+                                    .map((t) => ' ~#' + t)
                                     .join(''),
                             public:
                                 elm


### PR DESCRIPTION
Closes #304 
Bug was caused by user-written empty tag signifiers in the description. (`# `)