### PR TITLE
Fix function call order bug in addNewLayer function

### DIFF
--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -2504,8 +2504,6 @@ const L_ = {
     parseConfig: parseConfig,
     // Dynamically add a new layer or update a layer (used by WebSocket)
     addNewLayer: async function (data, layerName, type) {
-        layerName = L_.asLayerUUID(layerName)
-
         // Save so we can make sure we reproduce the same layer settings after parsing the config
         const toggledArray = { ...L_.layers.on }
 
@@ -2521,6 +2519,8 @@ const L_ = {
 
         // Set back
         L_.layers.on = { ...L_.layers.on, ...toggledArray }
+
+        layerName = L_.asLayerUUID(layerName)
 
         const newLayersOrdered = [...L_._layersOrdered]
         const index = L_._layersOrdered.findIndex((name) => name === layerName)


### PR DESCRIPTION
This fixes a bug in the `addNewLayer` function, which would crash if adding a new layer via the Rest API and then updating the client either manually or with forced updates. We should look for the new layer's UUID after parsing the database information with`parseConfig`.