### PR TITLE
#322 Add ROOT_PATH, Deprecate PUBLIC_URL

### DIFF
--- a/API/Backend/Config/setup.js
+++ b/API/Backend/Config/setup.js
@@ -9,7 +9,7 @@ let setup = {
       process.env.HIDE_CONFIG != "true"
     ) {
       s.app.get(
-        "/configure",
+        s.ROOT_PATH + "/configure",
         s.ensureGroup(s.permissions.users),
         s.ensureAdmin(true),
         (req, res) => {
@@ -24,7 +24,7 @@ let setup = {
     }
 
     s.app.use(
-      "/API/configure",
+      s.ROOT_PATH + "/API/configure",
       s.ensureAdmin(),
       s.checkHeadersCodeInjection,
       s.setContentType,

--- a/API/Backend/Datasets/setup.js
+++ b/API/Backend/Datasets/setup.js
@@ -1,9 +1,9 @@
 const router = require("./routes/datasets");
 let setup = {
   //Once the app initializes
-  onceInit: s => {
+  onceInit: (s) => {
     s.app.use(
-      "/API/datasets",
+      s.ROOT_PATH + "/API/datasets",
       s.ensureAdmin(),
       s.checkHeadersCodeInjection,
       s.setContentType,
@@ -11,9 +11,9 @@ let setup = {
     );
   },
   //Once the server starts
-  onceStarted: s => {},
+  onceStarted: (s) => {},
   //Once all tables sync
-  onceSynced: s => {}
+  onceSynced: (s) => {},
 };
 
 module.exports = setup;

--- a/API/Backend/Draw/setup.js
+++ b/API/Backend/Draw/setup.js
@@ -6,7 +6,7 @@ let setup = {
   //Once the app initializes
   onceInit: (s) => {
     s.app.use(
-      "/API/files",
+      s.ROOT_PATH + "/API/files",
       s.ensureUser(),
       s.checkHeadersCodeInjection,
       s.setContentType,
@@ -15,7 +15,7 @@ let setup = {
     );
 
     s.app.use(
-      "/API/draw",
+      s.ROOT_PATH + "/API/draw",
       s.ensureUser(),
       s.checkHeadersCodeInjection,
       s.setContentType,

--- a/API/Backend/Geodatasets/setup.js
+++ b/API/Backend/Geodatasets/setup.js
@@ -2,9 +2,9 @@ const router = require("./routes/geodatasets");
 
 let setup = {
   //Once the app initializes
-  onceInit: s => {
+  onceInit: (s) => {
     s.app.use(
-      "/API/geodatasets",
+      s.ROOT_PATH + "/API/geodatasets",
       s.ensureAdmin(),
       s.checkHeadersCodeInjection,
       s.setContentType,
@@ -12,9 +12,9 @@ let setup = {
     );
   },
   //Once the server starts
-  onceStarted: s => {},
+  onceStarted: (s) => {},
   //Once all tables sync
-  onceSynced: s => {}
+  onceSynced: (s) => {},
 };
 
 module.exports = setup;

--- a/API/Backend/LongTermToken/setup.js
+++ b/API/Backend/LongTermToken/setup.js
@@ -1,9 +1,9 @@
 const router = require("./routes/longtermtokens");
 let setup = {
   //Once the app initializes
-  onceInit: s => {
+  onceInit: (s) => {
     s.app.use(
-      "/API/longtermtoken",
+      s.ROOT_PATH + "/API/longtermtoken",
       s.ensureAdmin(false, true),
       s.checkHeadersCodeInjection,
       s.setContentType,
@@ -11,9 +11,9 @@ let setup = {
     );
   },
   //Once the server starts
-  onceStarted: s => {},
+  onceStarted: (s) => {},
   //Once all tables sync
-  onceSynced: s => {}
+  onceSynced: (s) => {},
 };
 
 module.exports = setup;

--- a/API/Backend/Shortener/setup.js
+++ b/API/Backend/Shortener/setup.js
@@ -2,9 +2,9 @@ const router = require("./routes/shortener");
 
 let setup = {
   //Once the app initializes
-  onceInit: s => {
+  onceInit: (s) => {
     s.app.use(
-      "/API/shortener",
+      s.ROOT_PATH + "/API/shortener",
       s.ensureUser(),
       s.checkHeadersCodeInjection,
       s.setContentType,
@@ -12,9 +12,9 @@ let setup = {
     );
   },
   //Once the server starts
-  onceStarted: s => {},
+  onceStarted: (s) => {},
   //Once all tables sync
-  onceSynced: s => {}
+  onceSynced: (s) => {},
 };
 
 module.exports = setup;

--- a/API/Backend/Users/setup.js
+++ b/API/Backend/Users/setup.js
@@ -3,7 +3,7 @@ const router = require("./routes/users");
 let setup = {
   //Once the app initializes
   onceInit: (s) => {
-    s.app.use("/API/users", s.checkHeadersCodeInjection, router);
+    s.app.use(s.ROOT_PATH + "/API/users", s.checkHeadersCodeInjection, router);
   },
   //Once the server starts
   onceStarted: (s) => {},

--- a/API/Backend/Utils/setup.js
+++ b/API/Backend/Utils/setup.js
@@ -2,7 +2,12 @@ const router = require("./routes/utils");
 let setup = {
   //Once the app initializes
   onceInit: (s) => {
-    s.app.use("/API/utils", s.ensureUser(), s.setContentType, router);
+    s.app.use(
+      s.ROOT_PATH + "/API/utils",
+      s.ensureUser(),
+      s.setContentType,
+      router
+    );
   },
   //Once the server starts
   onceStarted: (s) => {},

--- a/API/Backend/Webhooks/setup.js
+++ b/API/Backend/Webhooks/setup.js
@@ -6,10 +6,14 @@ const routerTestWebhooks = require("./routes/testwebhooks");
 let setup = {
   //Once the app initializes
   onceInit: (s) => {
-    s.app.use("/API/webhooks", s.checkHeadersCodeInjection, routerWebhooks);
+    s.app.use(
+      s.ROOT_PATH + "/API/webhooks",
+      s.checkHeadersCodeInjection,
+      routerWebhooks
+    );
     if (process.env.NODE_ENV === "development") {
       s.app.use(
-        "/API/testwebhooks",
+        s.ROOT_PATH + "/API/testwebhooks",
         s.checkHeadersCodeInjection,
         routerTestWebhooks
       );

--- a/API/Backend/setupTemplate.js
+++ b/API/Backend/setupTemplate.js
@@ -2,12 +2,12 @@ const router = require("./routes/your_router");
 
 let setup = {
   //Once the app initializes
-  onceInit: s => {},
+  onceInit: (s) => {},
   //Once the server starts
-  onceStarted: s => {},
+  onceStarted: (s) => {},
   //Once all tables sync
-  onceSynced: s => {},
-  envs: [{ name: "ENV_VAR", description: "", required: false, private: false }]
+  onceSynced: (s) => {},
+  envs: [{ name: "ENV_VAR", description: "", required: false, private: false }],
 };
 
 module.exports = setup;

--- a/config/js/config.js
+++ b/config/js/config.js
@@ -27,7 +27,9 @@ function initialize() {
       url: calls.logout.url,
       data: {},
       success: function (data) {
-        window.location = "/";
+        // Remove last directory from pathname
+        const path = window.location.pathname.split("/");
+        window.location.href = path.slice(0, path.length - 1).join("/") || "/";
       },
     });
   });

--- a/config/login/adminlogin.css
+++ b/config/login/adminlogin.css
@@ -1,11 +1,6 @@
-@font-face {
-  font-family: "Source Sans Pro";
-  src: url(public/fonts/sourcesanspro/SourceSansPro-Regular.ttf);
-}
-
 body,
 html {
-  font-family: "Source Sans Pro", sans-serif;
+  font-family: sans-serif;
   background-color: #1a1a1a;
   padding: 0;
   margin: 0;
@@ -27,7 +22,7 @@ html {
 }
 
 .box h4 {
-  font-family: "Source Sans Pro", sans-serif;
+  font-family: sans-serif;
   color: #08aeea;
   font-size: 18px;
   margin-top: 94px;
@@ -39,7 +34,7 @@ html {
 }
 
 .box h5 {
-  font-family: "Source Sans Pro", sans-serif;
+  font-family: sans-serif;
   font-size: 13px;
   color: #a1a4ad;
   letter-spacing: 1.5px;
@@ -94,7 +89,7 @@ a:hover {
   cursor: pointer;
   text-align: center;
   user-select: none;
-  font-family: "Source Sans Pro", sans-serif;
+  font-family: sans-serif;
   line-height: 49px;
 }
 

--- a/config/login/adminlogin.js
+++ b/config/login/adminlogin.js
@@ -98,14 +98,6 @@ function setupLogin() {
   });
 }
 
-// Is used in views/configure.pug
-function back() {
-  window.location = window.location.substring(
-    0,
-    window.location.lastIndexOf("/")
-  );
-}
-
 $(document).ready(function () {
   $(document).on("keypress", function (e) {
     if (e.which == 13) {
@@ -132,6 +124,8 @@ $(document).ready(function () {
   });
 
   $("#backIcon").on("click", function () {
-    window.location.href = "/";
+    // Remove last directory from pathname
+    const path = window.location.pathname.split("/");
+    window.location.href = path.slice(0, path.length - 1).join("/") || "/";
   });
 });

--- a/config/pre/RefreshAuth.js
+++ b/config/pre/RefreshAuth.js
@@ -1,0 +1,117 @@
+//function from https://stackoverflow.com/questions/6312993/javascript-seconds-to-time-string-with-format-hhmmss
+String.prototype.toHHMMSS = function () {
+    var sec_num = parseInt(this, 10) // don't forget the second param
+    var hours = Math.floor(sec_num / 3600)
+    var minutes = Math.floor((sec_num - hours * 3600) / 60)
+    var seconds = sec_num - hours * 3600 - minutes * 60
+
+    if (hours < 10) {
+        hours = '0' + hours
+    }
+    if (minutes < 10) {
+        minutes = '0' + minutes
+    }
+    if (seconds < 10) {
+        seconds = '0' + seconds
+    }
+    return hours + ':' + minutes + ':' + seconds
+}
+
+//set interval that checks valid sso
+//every 4:30min checks if the token will expire in less than 5min
+//refreshes if the user moved their mouse in the past 20min
+if (mmgisglobal.SERVER == 'node' && mmgisglobal.AUTH == 'csso') {
+    console.log(
+        '%cAUTH_REFRESH ON',
+        'background: #006280; padding: 0px 4px 0px 4px;'
+    )
+    //Add your own login/logout redirects
+    function ssologout() {
+        window.location.href = '/ssologoutredirect'
+    }
+    function ssologin() {
+        window.location.href =
+            '/ssologinredirect?redirect=' + window.location.href
+    }
+
+    mmgisglobal.lastInteraction = Math.floor(Date.now() / 1000)
+    var _refreshAuth_checkEvery = 60000 * 10 //milliseconds
+    var _refreshAuth_expiringLessThan = 60 * 11 //seconds
+    var _refreshAuth_interactedPast = 60000 * 30 //milliseconds
+
+    function ssorefresh() {
+        var request = new XMLHttpRequest()
+        request.open('Post', '/ssostatus', true)
+        request.onload = function () {
+            if (request.status >= 200 && request.status < 400) {
+                var result = request.responseText
+                result = JSON.parse(result)
+
+                var now = Math.floor(Date.now() / 1000)
+
+                if (mmgisglobal.SHOW_AUTH_TIMEOUT) {
+                    var append = false
+
+                    var elm = document.getElementById('AUTH_TIMEOUT')
+                    if (elm == null) {
+                        elm = document.createElement('div')
+                        append = true
+                    }
+                    elm.id = 'AUTH_TIMEOUT'
+                    elm.style.cssText =
+                        'position:fixed;left:225px;bottom:0px;z-index:11000;font-family:monospace;font-size:11px;color:#121626;'
+                    elm.innerHTML =
+                        'Authentication expiring in ' +
+                        (result.exp - now).toString().toHHMMSS() +
+                        '<div onclick="ssologin()" style="cursor:pointer;">Login again to renew</div>'
+
+                    if (append) document.body.appendChild(elm)
+                }
+
+                if (result.authenticated) {
+                    if (
+                        mmgisglobal.lastInteraction +
+                            _refreshAuth_interactedPast <=
+                        now
+                    ) {
+                        ssologout()
+                    } else if (
+                        now + _refreshAuth_expiringLessThan >=
+                        result.inactivity_timeout
+                    ) {
+                        var refresh = new XMLHttpRequest()
+                        refresh.open('Post', '/ssorefreshtimeout', true)
+                        refresh.onload = function () {
+                            if (refresh.status >= 200 && refresh.status < 400) {
+                                var result = refresh.responseText
+                                result = JSON.parse(result)
+                                if (!result.success) {
+                                    ssologout()
+                                }
+                            } else {
+                                ssologout()
+                            }
+                        }
+                        refresh.onerror = function () {
+                            ssologout()
+                        }
+                        refresh.send()
+                    }
+                } else {
+                    ssologout()
+                }
+            } else {
+                ssologout()
+            }
+        }
+
+        request.onerror = function () {
+            ssologout()
+        }
+
+        request.send()
+    }
+
+    ssorefresh()
+    setInterval(ssorefresh, _refreshAuth_checkEvery)
+}

--- a/configuration/env.js
+++ b/configuration/env.js
@@ -78,6 +78,10 @@ function getClientEnvironment(publicUrl) {
         // This should only be used as an escape hatch. Normally you would put
         // images into the `src` and `import` them in code to get their paths.
         PUBLIC_URL: publicUrl,
+        ROOT_PATH:
+          (process.env.NODE_ENV || "development") === "development"
+            ? ""
+            : process.env.ROOT_PATH || "",
         // We support configuring the sockjs pathname during development.
         // These settings let a developer run multiple simultaneous projects.
         // They are used as the connection `hostname`, `pathname` and `port`

--- a/configuration/paths.js
+++ b/configuration/paths.js
@@ -20,7 +20,7 @@ const publicUrlOrPath = getPublicUrlOrPath(
   process.env.NODE_ENV === "development"
     ? null
     : require(resolveApp("package.json")).homepage,
-  process.env.PUBLIC_URL
+  "./build" // Force process.env.PUBLIC_URL
 );
 
 const moduleFileExtensions = [

--- a/configuration/webpack.config.js
+++ b/configuration/webpack.config.js
@@ -94,11 +94,11 @@ module.exports = function (webpackEnv) {
           : { publicPath: paths.publicUrlOrPath },
       },
       isEnvProduction &&
-        process.env.PUBLIC_URL && {
+         {
           loader: "string-replace-loader",
           options: {
             search: /url\(\/public\//g,
-            replace: `url(${process.env.ROOT_PATH}/public/`,
+            replace: `url(../../../public/`,
           },
         },
       {

--- a/configuration/webpack.config.js
+++ b/configuration/webpack.config.js
@@ -98,7 +98,7 @@ module.exports = function (webpackEnv) {
           loader: "string-replace-loader",
           options: {
             search: /url\(\/public\//g,
-            replace: `url(${process.env.PUBLIC_URL}/`,
+            replace: `url(${process.env.ROOT_PATH}/public/`,
           },
         },
       {

--- a/docs/pages/Setup/ENVs/ENVs.md
+++ b/docs/pages/Setup/ENVs/ENVs.md
@@ -84,9 +84,13 @@ Sets the `Content-Security-Policy: frame-src` header to allow the embedding ifra
 
 Sets "SameSite=None; Secure" on the login cookie. Useful when using AUTH=local as an iframe within a cross-origin page. | boolean | default `false`
 
+#### `ROOT_PATH=`
+
+Set MMGIS to be deployed under a subpath. This works just like the `PUBLIC_URL` env but, instead of being required at build, it happens wholly at run-time. Set `PUBLIC_URL=./build` for this to work properly. For example if serving at the subpath 'https://{domain}/path/where/I/serve/mmgis' is desired, set `ROOT_PATH=/path/where/I/serve/mmgis` and set `PUBLIC_URL=./build` | string | default `""`
+
 #### `PUBLIC_URL=`
 
-Set MMGIS to be deployed under a subpath. Use full and absolute paths only to the project's build directory. For example if serving at the subpath 'mmgis/' is desired, set PUBLIC_URL to 'https://{domain}/mmgis/build'. Changing PUBLIC_URL required a rebuild. | string | default `null` (domain root build '/build')
+Set MMGIS to be deployed under a subpath. Use full and absolute paths only to the project's build directory. For example if serving at the subpath 'mmgis/' is desired, set `PUBLIC_URL` to 'https://{domain}/mmgis/build'. Changing PUBLIC_URL required a rebuild. Read the documentation of the `ROOT_PATH` env before using this. | string | default `null` (domain root build '/build')
 
 #### `CLEARANCE_NUMBER=`
 

--- a/docs/pages/Setup/ENVs/ENVs.md
+++ b/docs/pages/Setup/ENVs/ENVs.md
@@ -86,11 +86,7 @@ Sets "SameSite=None; Secure" on the login cookie. Useful when using AUTH=local a
 
 #### `ROOT_PATH=`
 
-Set MMGIS to be deployed under a subpath. This works just like the `PUBLIC_URL` env but, instead of being required at build, it happens wholly at run-time. Set `PUBLIC_URL=./build` for this to work properly. For example if serving at the subpath 'https://{domain}/path/where/I/serve/mmgis' is desired, set `ROOT_PATH=/path/where/I/serve/mmgis` and set `PUBLIC_URL=./build` | string | default `""`
-
-#### `PUBLIC_URL=`
-
-Set MMGIS to be deployed under a subpath. Use full and absolute paths only to the project's build directory. For example if serving at the subpath 'mmgis/' is desired, set `PUBLIC_URL` to 'https://{domain}/mmgis/build'. Changing PUBLIC_URL required a rebuild. Read the documentation of the `ROOT_PATH` env before using this. | string | default `null` (domain root build '/build')
+Set MMGIS to be deployed under a subpath. For example if serving at the subpath 'https://{domain}/path/where/I/serve/mmgis' is desired, set `ROOT_PATH=/path/where/I/serve/mmgis`. If no subpath, leave blank. | string | default `""`
 
 #### `CLEARANCE_NUMBER=`
 

--- a/public/index.html
+++ b/public/index.html
@@ -335,6 +335,7 @@
           mmgisglobal.CLEARANCE_NUMBER = "#{CLEARANCE_NUMBER}";
           mmgisglobal.HOSTS = "#{HOSTS}";
           mmgisglobal.PORT = "#{PORT}";
+          mmgisglobal.ROOT_PATH = "#{ROOT_PATH}";
           mmgisglobal.ENABLE_MMGIS_WEBSOCKETS = "#{ENABLE_MMGIS_WEBSOCKETS}";
           mmgisglobal.THIRD_PARTY_COOKIES = "#{THIRD_PARTY_COOKIES}";
           break;
@@ -348,6 +349,7 @@
           mmgisglobal.FORCE_CONFIG_PATH = null;
           mmgisglobal.CLEARANCE_NUMBER = "%CLEARANCE_NUMBER%";
           mmgisglobal.PORT = "%PORT%";
+          mmgisglobal.ROOT_PATH = "%ROOT_PATH%";
           mmgisglobal.ENABLE_MMGIS_WEBSOCKETS = "%ENABLE_MMGIS_WEBSOCKETS%";
           mmgisglobal.THIRD_PARTY_COOKIES = "#{THIRD_PARTY_COOKIES}";
           // eslint-disable-next-line

--- a/run/server.js
+++ b/run/server.js
@@ -59,6 +59,12 @@ const guestUsername = "guest";
 
 const ROOT_PATH = isDevEnv ? "" : process.env.ROOT_PATH || "";
 
+if (!(process.env.PUBLIC_URL == null || process.env.PUBLIC_URL == ""))
+  logger(
+    "warn",
+    `The 'PUBLIC_URL' env is deprecated. Please using 'ROOT_PATH' instead.`
+  );
+
 const rootDir = `${__dirname}/..`;
 
 ///////////////////////////
@@ -442,7 +448,7 @@ app.disable("x-powered-by");
 app.disable("Origin");
 
 app.use(
-  "/api/docs/main",
+  `${ROOT_PATH}/api/docs/main`,
   swaggerUi.serve,
   useSwaggerSchema(swaggerDocumentMain)
 );
@@ -583,18 +589,28 @@ setups.getBackendSetups(function (setups) {
   // PAGES
 
   //docs
-  app.get("/docs", ensureUser(), ensureGroup(permissions.users), (req, res) => {
-    res.render("docs", {});
-  });
+  app.get(
+    `${ROOT_PATH}/docs`,
+    ensureUser(),
+    ensureGroup(permissions.users),
+    (req, res) => {
+      res.render("docs", {});
+    }
+  );
 
   //help
-  app.get("/help", ensureUser(), ensureGroup(permissions.users), (req, res) => {
-    res.render("help", {});
-  });
+  app.get(
+    `${ROOT_PATH}/help`,
+    ensureUser(),
+    ensureGroup(permissions.users),
+    (req, res) => {
+      res.render("help", {});
+    }
+  );
 
   // API
   //TEST
-  app.post("/api/test", function (req, res) {
+  app.post(`${ROOT_PATH}/api/test`, function (req, res) {
     res.send("Hello World!");
   });
 
@@ -602,7 +618,7 @@ setups.getBackendSetups(function (setups) {
 
   //utils getprofile
   app.post(
-    "/api/utils/getprofile",
+    `${ROOT_PATH}/api/utils/getprofile`,
     ensureUser(),
     ensureGroup(permissions.users),
     function (req, res) {
@@ -636,7 +652,7 @@ setups.getBackendSetups(function (setups) {
 
   //utils getbands
   app.post(
-    "/api/utils/getbands",
+    `${ROOT_PATH}/api/utils/getbands`,
     ensureUser(),
     ensureGroup(permissions.users),
     function (req, res) {

--- a/run/server.js
+++ b/run/server.js
@@ -57,6 +57,8 @@ const isDevEnv = process.env.NODE_ENV === "development";
 //Username to use when not logged in
 const guestUsername = "guest";
 
+const ROOT_PATH = isDevEnv ? "" : process.env.ROOT_PATH || "";
+
 const rootDir = `${__dirname}/..`;
 
 ///////////////////////////
@@ -386,6 +388,7 @@ let s = {
   swaggerUi,
   useSwaggerSchema,
   permissions,
+  ROOT_PATH,
 };
 
 // Trust first proxy
@@ -506,48 +509,72 @@ setups.getBackendSetups(function (setups) {
 
   // STATICS
 
-  app.use("/build", ensureUser(), express.static(path.join(rootDir, "/build")));
   app.use(
-    "/documentation",
+    `${ROOT_PATH}/build`,
+    ensureUser(),
+    express.static(path.join(rootDir, "/build"))
+  );
+  app.use(
+    `${ROOT_PATH}/documentation`,
     express.static(path.join(rootDir, "/documentation"))
   );
-  app.use("/docs/helps", express.static(path.join(rootDir, "/docs/helps")));
-  app.use("/README.md", express.static(path.join(rootDir, "/README.md")));
-  app.use("/config/login", express.static(path.join(rootDir, "/config/login")));
   app.use(
-    "/config/css",
+    `${ROOT_PATH}/docs/helps`,
+    express.static(path.join(rootDir, "/docs/helps"))
+  );
+  app.use(
+    `${ROOT_PATH}/README.md`,
+    express.static(path.join(rootDir, "/README.md"))
+  );
+  app.use(
+    `${ROOT_PATH}/config/login`,
+    express.static(path.join(rootDir, "/config/login"))
+  );
+  app.use(
+    `${ROOT_PATH}/config/css`,
     ensureUser(),
     express.static(path.join(rootDir, "/config/css"))
   );
   app.use(
-    "/config/js",
+    `${ROOT_PATH}/config/js`,
     ensureUser(),
     express.static(path.join(rootDir, "/config/js"))
   );
   app.use(
-    "/config/pre",
+    `${ROOT_PATH}/config/pre`,
     ensureUser(),
     express.static(path.join(rootDir, "/config/pre"))
   );
   app.use(
-    "/config/fonts",
+    `${ROOT_PATH}/config/fonts`,
     ensureUser(),
     express.static(path.join(rootDir, "/config/fonts"))
   );
 
   if (process.argv.includes("--with_examples"))
-    app.use("/examples", express.static(path.join(rootDir, "/examples")));
-  app.use("/public", express.static(path.join(rootDir, "/public")));
+    app.use(
+      `${ROOT_PATH}/examples`,
+      express.static(path.join(rootDir, "/examples"))
+    );
+  app.use(`${ROOT_PATH}/public`, express.static(path.join(rootDir, "/public")));
   app.use(
-    "/Missions",
+    `${ROOT_PATH}/Missions`,
     ensureUser(),
     middleware.missions(),
     express.static(path.join(rootDir, "/Missions"))
   );
 
   if (isDevEnv) {
-    app.use("/css", ensureUser(), express.static(path.join(rootDir, "/css")));
-    app.use("/src", ensureUser(), express.static(path.join(rootDir, "/src")));
+    app.use(
+      `${ROOT_PATH}/css`,
+      ensureUser(),
+      express.static(path.join(rootDir, "/css"))
+    );
+    app.use(
+      `${ROOT_PATH}/src`,
+      ensureUser(),
+      express.static(path.join(rootDir, "/src"))
+    );
   }
 
   // Disable for now
@@ -686,32 +713,38 @@ setups.getBackendSetups(function (setups) {
       // passing to it an array of LDAP group names (which were loaded
       // from the permissions.json file at the top of the file).
 
-      app.get("/", ensureUser(), ensureGroup(permissions.users), (req, res) => {
-        let user = guestUsername;
-        if (process.env.AUTH === "csso" || req.user != null) user = req.user;
+      app.get(
+        `${ROOT_PATH}/`,
+        ensureUser(),
+        ensureGroup(permissions.users),
+        (req, res) => {
+          let user = guestUsername;
+          if (process.env.AUTH === "csso" || req.user != null) user = req.user;
 
-        let permission = "000";
-        if (process.env.AUTH === "csso") permission = "001";
-        if (req.session.permission) permission = req.session.permission;
+          let permission = "000";
+          if (process.env.AUTH === "csso") permission = "001";
+          if (req.session.permission) permission = req.session.permission;
 
-        const groups = req.groups ? Object.keys(req.groups) : [];
-        res.render("../build/index.pug", {
-          user: user,
-          permission: permission,
-          groups: JSON.stringify(groups),
-          AUTH: process.env.AUTH,
-          NODE_ENV: process.env.NODE_ENV,
-          VERSION: packagejson.version,
-          FORCE_CONFIG_PATH: process.env.FORCE_CONFIG_PATH,
-          CLEARANCE_NUMBER: process.env.CLEARANCE_NUMBER,
-          ENABLE_MMGIS_WEBSOCKETS: process.env.ENABLE_MMGIS_WEBSOCKETS,
-          THIRD_PARTY_COOKIES: process.env.THIRD_PARTY_COOKIES,
-          PORT: process.env.PORT,
-          HOSTS: JSON.stringify({
-            scienceIntent: process.env.SCIENCE_INTENT_HOST,
-          }),
-        });
-      });
+          const groups = req.groups ? Object.keys(req.groups) : [];
+          res.render("../build/index.pug", {
+            user: user,
+            permission: permission,
+            groups: JSON.stringify(groups),
+            AUTH: process.env.AUTH,
+            NODE_ENV: process.env.NODE_ENV,
+            VERSION: packagejson.version,
+            FORCE_CONFIG_PATH: process.env.FORCE_CONFIG_PATH,
+            CLEARANCE_NUMBER: process.env.CLEARANCE_NUMBER,
+            ENABLE_MMGIS_WEBSOCKETS: process.env.ENABLE_MMGIS_WEBSOCKETS,
+            THIRD_PARTY_COOKIES: process.env.THIRD_PARTY_COOKIES,
+            PORT: process.env.PORT,
+            ROOT_PATH: ROOT_PATH,
+            HOSTS: JSON.stringify({
+              scienceIntent: process.env.SCIENCE_INTENT_HOST,
+            }),
+          });
+        }
+      );
     }
     if (err) {
       logger("infrastructure_error", "MMGIS did not start!", "server");

--- a/sample.env
+++ b/sample.env
@@ -28,8 +28,13 @@ THIRD_PARTY_COOKIES=false
 # Setting this will almost always have no effect
 FRAME_SRC=
 
+# Production server path at which MMGIS is hosted. Set `PUBLIC_URL=./build` for this to work properly
+ROOT_PATH=
+
 # Allows MMGIS to be deployed at a subpath. Use an absolute path. For example if serving at the subpath 'mmgis' is desired, set PUBLIC_URL to 'https://{domain}/mmgis/build'
-PUBLIC_URL=
+# Leave this as `./build` if you're using ROOT_PATH
+PUBLIC_URL=./build
+
 
 # Sets a clearance number for the website
 CLEARANCE_NUMBER=

--- a/sample.env
+++ b/sample.env
@@ -28,13 +28,8 @@ THIRD_PARTY_COOKIES=false
 # Setting this will almost always have no effect
 FRAME_SRC=
 
-# Production server path at which MMGIS is hosted. Set `PUBLIC_URL=./build` for this to work properly
+# Set MMGIS to be deployed under a subpath. For example if serving at the subpath 'https://{domain}/path/where/I/serve/mmgis' is desired, set `ROOT_PATH=/path/where/I/serve/mmgis`. If no subpath, leave blank.
 ROOT_PATH=
-
-# Allows MMGIS to be deployed at a subpath. Use an absolute path. For example if serving at the subpath 'mmgis' is desired, set PUBLIC_URL to 'https://{domain}/mmgis/build'
-# Leave this as `./build` if you're using ROOT_PATH
-PUBLIC_URL=./build
-
 
 # Sets a clearance number for the website
 CLEARANCE_NUMBER=

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -893,8 +893,9 @@ async function makeLayer(layerObj, evenIfOff, forceGeoJSON) {
             urlSplit[1] != null
         ) {
             layerUrl =
-                '/API/geodatasets/get?layer=' +
-                urlSplit[1] +
+                `${
+                    window.mmgisglobal.ROOT_PATH || ''
+                }/api/geodatasets/get?layer=${urlSplit[1]}` +
                 '&type=mvt&x={x}&y={y}&z={z}'
         }
 

--- a/src/pre/calls.js
+++ b/src/pre/calls.js
@@ -148,7 +148,11 @@ function api(call, data, success, error) {
 
     $.ajax({
         type: c[call].type,
-        url: c[call].url,
+        url: `${
+            window.mmgisglobal.ROOT_PATH
+                ? window.mmgisglobal.ROOT_PATH + '/'
+                : ''
+        }${c[call].url}`,
         data: data,
         xhrFields: {
             withCredentials: true,

--- a/views/configure.pug
+++ b/views/configure.pug
@@ -38,7 +38,7 @@ script(type='text/javascript' src='config/js/datasets.js')
 script(type='text/javascript' src='config/js/geodatasets.js')
 script(type='text/javascript' src='config/js/webhooks.js')
 script(type='text/javascript' src='config/js/config.js')
-script(type='text/javascript' src='src/pre/RefreshAuth.js')
+script(type='text/javascript' src='config/pre/RefreshAuth.js')
 
 #leftPanel
   #tbtitle


### PR DESCRIPTION

#### `ROOT_PATH=` is added

Set MMGIS to be deployed under a subpath. For example if serving at the subpath 'https://{domain}/path/where/I/serve/mmgis' is desired, set `ROOT_PATH=/path/where/I/serve/mmgis`. If no subpath, leave blank. | string | default `""`

#### PUBLIC_URL is deprecated