### PR TITLE
#341 Export working config, disable override

### DIFF
--- a/API/Backend/Config/setup.js
+++ b/API/Backend/Config/setup.js
@@ -20,6 +20,7 @@ let setup = {
             NODE_ENV: process.env.NODE_ENV,
             PORT: process.env.PORT || "8888",
             ENABLE_CONFIG_WEBSOCKETS: process.env.ENABLE_CONFIG_WEBSOCKETS,
+            ENABLE_CONFIG_OVERRIDE: process.env.ENABLE_CONFIG_OVERRIDE,
             ROOT_PATH:
               process.env.NODE_ENV === "development"
                 ? ""

--- a/config/js/config.js
+++ b/config/js/config.js
@@ -3,7 +3,7 @@ var grandLayerCounter = 0;
 var mission = "";
 var configId = -1;
 var lockConfig = false;
-var lockConfigCount;
+var lockConfigCount = false;
 //The active mission filepath
 var missionPath = "";
 var tData;
@@ -855,6 +855,17 @@ function initialize() {
     });
 
     $("#deleteMissionName").val("");
+  });
+
+  //Download working config button
+  $("#download_working_config").on("click", function () {
+    downloadObject(
+      save("returnJSON"),
+      mission + "_config_WORKING",
+      ".json",
+      true
+    );
+    toast("success", "Download Successful.");
   });
 
   //Save changes button
@@ -1964,7 +1975,7 @@ function materializeDraggableMouseUp(e) {
 
 //Save Changes
 //Reconstructs JSON from html (doesn't modify the initial json directly)
-function save() {
+function save(returnJSON) {
   if (missionPath.length > 0) {
     var json = {
       msv: {},
@@ -2484,7 +2495,8 @@ function save() {
       });
 
     //SAVE HERE
-    saveConfig(json);
+    if (returnJSON === "returnJSON") return json;
+    else saveConfig(json);
   } else {
     toast("warning", "No Mission selected.", 5000);
   }
@@ -2529,16 +2541,24 @@ function addMission() {
 
 function saveConfig(json) {
   if (lockConfig === true) {
-    toast(
-      "error",
-      `This configuartion changed while you were working on it. Cannot save without refresh or ${lockConfigCount} more attempt${
-        lockConfigCount != 1 ? "s" : ""
-      } at saving to force it.`,
-      5000
-    );
-    lockConfigCount--;
-    if (lockConfigCount <= 0) {
-      clearLockConfig();
+    if (lockConfigCount != false) {
+      toast(
+        "error",
+        `This configuartion changed while you were working on it. Cannot save without refresh or ${lockConfigCount} more attempt${
+          lockConfigCount != 1 ? "s" : ""
+        } at saving to force it.`,
+        5000
+      );
+      lockConfigCount--;
+      if (lockConfigCount <= 0) {
+        clearLockConfig();
+      }
+    } else {
+      toast(
+        "error",
+        `This configuartion changed while you were working on it. Cannot save without refresh.`,
+        5000
+      );
     }
     return;
   }
@@ -3115,7 +3135,7 @@ function setLockConfig(type) {
   clearLockConfig(type);
   lockConfig = true;
   lockConfigTypes[type || "main"] = false;
-  lockConfigCount = 4;
+  lockConfigCount = mmgisglobal.ENABLE_CONFIG_OVERRIDE === "true" ? 4 : false;
 
   toast(
     "warning",

--- a/docs/pages/Setup/ENVs/ENVs.md
+++ b/docs/pages/Setup/ENVs/ENVs.md
@@ -119,3 +119,7 @@ If true, enables the backend MMGIS websockets to tell clients to update layers |
 #### `ENABLE_CONFIG_WEBSOCKETS=`
 
 If true, notifications are sent to /configure users whenever the current mission's configuration object changes out from under them and thne puts (overridable) limits on saving | boolean | default `false`
+
+#### `ENABLE_CONFIG_OVERRIDE=`
+
+For use when `ENABLE_CONFIG_WEBSOCKETS=true` (if `ENABLE_CONFIG_WEBSOCKETS=false`, all saves will freely overwrite already). If true, gives /configure users the ability to override changes made to the configuration while they were working on it with their own. | boolean | default `false`

--- a/sample.env
+++ b/sample.env
@@ -64,3 +64,5 @@ LEADS=["user1"]
 ENABLE_MMGIS_WEBSOCKETS=false
 # If true, notifications are sent to /configure users whenever the configuration objects changes out from under them and puts (overridable) limits on saving.
 ENABLE_CONFIG_WEBSOCKETS=false
+# For use when ENABLE_CONFIG_WEBSOCKETS=true (if ENABLE_CONFIG_WEBSOCKETS=false, all saves will freely overwrite already). If true, gives /configure users the ability to override changes made to the configuration while they were working on it with their own.
+ENABLE_CONFIG_OVERRIDE=false

--- a/views/configure.pug
+++ b/views/configure.pug
@@ -35,6 +35,7 @@ script.
     mmgisglobal.ROOT_PATH = '#{ROOT_PATH}';
     mmgisglobal.PORT = '#{PORT}'
     mmgisglobal.ENABLE_CONFIG_WEBSOCKETS = '#{ENABLE_CONFIG_WEBSOCKETS}'
+    mmgisglobal.ENABLE_CONFIG_OVERRIDE = '#{ENABLE_CONFIG_OVERRIDE}'
 script(type='text/javascript' src='config/js/calls.js')
 script(type='text/javascript' src='config/js/keys.js')
 script(type='text/javascript' src='config/js/datasets.js')
@@ -140,6 +141,10 @@ script(type='text/javascript' src='config/pre/RefreshAuth.js')
           a#delete_mission.modal-trigger.btn.waves-effect.waves-light.red.darken-3.col.s2.push-s2(href='#delete_modal' style='border-radius: 0px; padding: 1px 0.5rem 0 0.5rem; font-size: 12px; line-height: 35px;')
             | Delete Mission
             i.mdi.mdi-delete.mdi-18px(style='float: right; margin-top: -1px;')
+          li.row(style='margin-top: 64px;')
+            a#download_working_config.btn.waves-effect.waves-light.brown.darken-3.col.s2.push-s5(style='border-radius: 0px; padding: 1px 0.5rem 0 0.5rem; font-size: 12px; line-height: 35px;')
+              | Export unsaved config.json
+              i.mdi.mdi-download.mdi-18px(style='float: right; margin-top: -1px;')
       #tab_initial.col.s12
         a.helpFromDocs(href='https://nasa-ammos.github.io/MMGIS/configure/tabs/initial' target='__blank' rel='noopener')
           i.mdi.mdi-help.mdi-14px


### PR DESCRIPTION
## Purpose
- Clear, easy-to-understand sentences outlining the purpose of the PR
## Proposed Changes
- Adds ability to export the current working configuration object from the Overall Tab.
- Changed Save Changes override to be off be default when using `ENABLE_CONFIG_WEBSOCKETS`. It can be reenabled through `ENABLE_CONFIG_OVERRIDE=true`
## Issues
- #341 
- Closes #341 