### PR TITLE
Fix clearOnMapClick function for layers with no fill

### DIFF
--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -1281,10 +1281,27 @@ function clearOnMapClick(event) {
                     const _layer = layer.getLayers()
                     for (let x in _layer) {
                         found = checkBounds(_layer[x])
-                        if (found) break
+                        // We should bubble down further for layers that have no fill, as it is possible
+                        // for there to be layers with features under the transparent fill
+                        if (found) {
+                            if (layer.options.fill) {
+                                break
+                            } else {
+                                found = false
+                            }
+                        }
                     }
                 } else {
                     found = checkBounds(layer)
+                    if (found) {
+                        // We should bubble down further for layers that have no fill, as it is possible
+                        // for there to be layers with features under the transparent fill
+                        if (layer.options.fill) {
+                            break
+                        } else {
+                            found = false
+                        }
+                    }
                 }
 
                 if (found) break


### PR DESCRIPTION
## Purpose
This fixes a bug with the `clearOnMapClick` function, which clears a selected feature if clicking anywhere on the map where there are no features. The bug is that if a large feature with no fill (i.e. an outlined feature with no fill) is above smaller features, clicking a small feature within the outlined feature and then clicking outside the map will not clear the highlighted small feature.

## Proposed Changes
- This fixes the bug by adding a check to determine whether a feature is filled or not. Filled features should behave as before while we should ignore unfilled features when determining if we want to clear the selected feature or not.

## Issues
None


## Testing

### Before fix
![mmgis_fill_fix_01](https://user-images.githubusercontent.com/8588858/221978873-a75c8eca-8dd1-4075-b66f-d984e2835f3d.gif)
- Click on a feature then click outside the feature but within the blue box
    - See that the feature is not deselected
- click outside the feature and outside the blue box
    - See that the feature is deselected



### After fix
![mmgis_fill_fix_02](https://user-images.githubusercontent.com/8588858/221978861-eb994c78-85c1-4bd0-b7a7-ba46d9be2978.gif)
- Click on a feature then click outside the feature but within the blue box 
    - See that the feature is deselected


