### PR TITLE
#356 DrawTool Templating - Incrementer field

### DIFF
--- a/docs/pages/Tools/Draw/Draw.md
+++ b/docs/pages/Tools/Draw/Draw.md
@@ -86,8 +86,13 @@ There are five files that are group editable with the correct permission. The gr
                 "default": "No"
             },
             {
-                "type": "date",
+                "type": "incrementer",
                 "field": "g",
+                "default": "ID-#"
+            },
+            {
+                "type": "date",
+                "field": "h",
                 "format": "YYYY-MM-DDTHH:mm:ss",
                 "default": "2000-01-01T00:00:00" // Can be "NOW", "STARTTIME" or "ENDTIME" too for dynamic defaults
             }
@@ -95,7 +100,7 @@ There are five files that are group editable with the correct permission. The gr
         "example_2": [
             {
                 "type": "checkbox",
-                "field": "h",
+                "field": "i",
                 "default": false
             }
         ]

--- a/src/essence/Ancillary/Coordinates.js
+++ b/src/essence/Ancillary/Coordinates.js
@@ -775,9 +775,10 @@ function urlClick(e) {
 }
 
 function toggleTimeUI() {
-    const active = $(this).hasClass('active')
-    $(this).toggleClass('active')
+    const active = $('#toggleTimeUI').hasClass('active')
+    $('#toggleTimeUI').toggleClass('active')
     $('#timeUI').toggleClass('active')
+
     const newBottom = active ? 0 : 40
     const timeBottom = active ? -40 : 0
 

--- a/src/essence/Tools/Draw/DrawTool.js
+++ b/src/essence/Tools/Draw/DrawTool.js
@@ -5,6 +5,7 @@ import DrawTool_History from './DrawTool_History'
 import DrawTool_Publish from './DrawTool_Publish'
 import DrawTool_Shapes from './DrawTool_Shapes'
 import DrawTool_FileModal from './DrawTool_FileModal'
+import DrawTool_Templater from './DrawTool_Templater'
 
 import $ from 'jquery'
 import * as d3 from 'd3'
@@ -1077,6 +1078,19 @@ var DrawTool = {
         )
     },
     addDrawing: function (body, callback, failure) {
+        // Add template property defaults
+        const file = DrawTool.getFileObjectWithId(body.file_id)
+        if (file?.template?.template && body?.properties) {
+            let newProps = JSON.parse(body.properties)
+            const templateDefaults = DrawTool_Templater.getTemplateDefaults(
+                file?.template?.template,
+                L_.layers.layer[`DrawTool_${body.file_id}`]
+            )
+
+            newProps = { ...newProps, ...templateDefaults }
+            body.properties = JSON.stringify(newProps)
+        }
+
         if (body.file_id == null) {
             CursorInfo.update(
                 'No file chosen. Please select or make a file for drawings.',

--- a/src/essence/Tools/Draw/DrawTool_Editing.js
+++ b/src/essence/Tools/Draw/DrawTool_Editing.js
@@ -2350,7 +2350,10 @@ var Editing = {
             if (DrawTool.plugins?.Geologic?.custom?.resetGeologic)
                 DrawTool.plugins.Geologic.custom.resetGeologic()
 
-            const templaterProperties = templater.getValues()
+            const templaterProperties = templater.getValues(
+                L_.layers.layer[DrawTool.lastContextLayerIndexFileId.layer],
+                properties
+            )
             if (templaterProperties === false) return
 
             if (!grouping) {

--- a/src/essence/Tools/Draw/DrawTool_Templater.css
+++ b/src/essence/Tools/Draw/DrawTool_Templater.css
@@ -276,3 +276,6 @@
 .drawToolTemplaterLiBody_dropdown_default input[type='number'] {
     width: 90px !important;
 }
+.drawToolTemplaterLiBody_incrementer_default {
+    width: 100%;
+}

--- a/src/essence/Tools/Draw/config.json
+++ b/src/essence/Tools/Draw/config.json
@@ -61,8 +61,13 @@
                         "default": "No"
                     },
                     {
-                        "type": "date",
+                        "type": "incrementer",
                         "field": "g",
+                        "default": "ID-#"
+                    },
+                    {
+                        "type": "date",
+                        "field": "h",
                         "format": "HH:mm:ss",
                         "default": "now"
                     }


### PR DESCRIPTION
## Purpose
- Adds a new field to DrawTool templating that auto-increments
  - Contains a # and an optional string portion. i.e. "PC-#"
  - Users can manually edit as long as still unique
  - Incremented value is the next available integer up from 0
- Default template fields are added to the feature's properties on first draw (instead of only when editing)
## Issues
- #356