### PR TITLE
#380 DrawTool - Fix error saving templateless features

### DIFF
--- a/src/essence/Ancillary/Description.js
+++ b/src/essence/Ancillary/Description.js
@@ -154,6 +154,12 @@ const Description = {
         })
     },
     updatePoint: function (activeLayer) {
+        if (
+            activeLayer == null ||
+            Description.L_.layers.data[activeLayer.options.layerName] == null
+        )
+            return
+
         this.descCont.style('display', 'flex')
         $('.mainDescription').animate(
             {

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -1314,7 +1314,10 @@ function clearOnMapClick(event) {
             }
 
             function checkBounds(layer) {
-                if (layer.feature.geometry.type.toLowerCase() === 'polygon') {
+                if (
+                    layer.feature &&
+                    layer.feature.geometry.type.toLowerCase() === 'polygon'
+                ) {
                     if (
                         L.leafletPip.pointInLayer(
                             [latlng.lng, latlng.lat],

--- a/src/essence/Tools/Draw/DrawTool_Editing.js
+++ b/src/essence/Tools/Draw/DrawTool_Editing.js
@@ -2348,12 +2348,15 @@ var Editing = {
             if (DrawTool.plugins?.Geologic?.custom?.resetGeologic)
                 DrawTool.plugins.Geologic.custom.resetGeologic()
 
-            const templaterProperties = templater.getValues(
-                L_.layers.layer[DrawTool.lastContextLayerIndexFileId.layer],
-                properties,
-                grouping ? true : false
-            )
-            if (templaterProperties === false) return
+            let templaterProperties = {}
+            if (templater) {
+                templaterProperties = templater.getValues(
+                    L_.layers.layer[DrawTool.lastContextLayerIndexFileId.layer],
+                    properties,
+                    grouping ? true : false
+                )
+                if (templaterProperties === false) return
+            }
 
             if (!grouping) {
                 //Then just a regular single save

--- a/src/essence/Tools/Draw/DrawTool_Files.js
+++ b/src/essence/Tools/Draw/DrawTool_Files.js
@@ -154,7 +154,7 @@ var Files = {
                 DrawTool.setDrawingType(drawType)
             } else {
                 CursorInfo.update(
-                    `Please select a file from the list below (by clicking on its name). If none exist, create one with the + above.`,
+                    `Please select a file from the list below (by clicking on its name). If none exist, make one with the create button below.`,
                     6000,
                     false,
                     {


### PR DESCRIPTION
## Purpose
- Fixes issue where users couldn't save a feature if its file had no template assigned to it
- Fixes issue where the Description and InfoTool threw errors when clicking on a DrawTool feature after closing the DrawTool
## Issues
- Closes #380 