### PR TITLE
#387 DrawTool - Group Editing

### DIFF
--- a/API/Backend/Draw/models/filehistories.js
+++ b/API/Backend/Draw/models/filehistories.js
@@ -43,6 +43,11 @@ const attributes = {
     type: Sequelize.DataTypes.ARRAY(Sequelize.DataTypes.INTEGER),
     allowNull: true,
   },
+  author: {
+    type: Sequelize.STRING,
+    unique: false,
+    allowNull: true,
+  },
 };
 
 const options = {
@@ -57,5 +62,27 @@ var FilehistoriesTEST = sequelize.define(
   options
 );
 
+// Adds to the table, never removes
+const up = async () => {
+  // author column
+  await sequelize
+    .query(
+      `ALTER TABLE file_histories ADD COLUMN IF NOT EXISTS author varchar(255) NULL;`
+    )
+    .then(() => {
+      return null;
+    })
+    .catch((err) => {
+      logger(
+        "error",
+        `Failed to adding file_histories.author column. DB tables may be out of sync!`,
+        "file_histories",
+        null,
+        err
+      );
+      return null;
+    });
+};
+
 // export Filehistories model for use in other files.
-module.exports = { Filehistories, FilehistoriesTEST };
+module.exports = { Filehistories, FilehistoriesTEST, up };

--- a/API/Backend/Draw/models/userfiles.js
+++ b/API/Backend/Draw/models/userfiles.js
@@ -84,6 +84,16 @@ const attributes = {
     allowNull: true,
     defaultValue: null,
   },
+  publicity_type: {
+    type: Sequelize.STRING,
+    unique: false,
+    allowNull: true,
+  },
+  public_editors: {
+    type: Sequelize.ARRAY(Sequelize.TEXT),
+    unique: false,
+    allowNull: true,
+  },
 };
 
 const options = {
@@ -147,6 +157,44 @@ const up = async () => {
       logger(
         "error",
         `Failed to adding user_files.template column. DB tables may be out of sync!`,
+        "user_files",
+        null,
+        err
+      );
+      return null;
+    });
+
+  // publicity_type column
+  await sequelize
+    .query(
+      `ALTER TABLE user_files ADD COLUMN IF NOT EXISTS publicity_type varchar(255) NULL;`
+    )
+    .then(() => {
+      return null;
+    })
+    .catch((err) => {
+      logger(
+        "error",
+        `Failed to adding user_files.publicity_type column. DB tables may be out of sync!`,
+        "user_files",
+        null,
+        err
+      );
+      return null;
+    });
+
+  // public_editors column
+  await sequelize
+    .query(
+      `ALTER TABLE user_files ADD COLUMN IF NOT EXISTS public_editors text[] NULL;`
+    )
+    .then(() => {
+      return null;
+    })
+    .catch((err) => {
+      logger(
+        "error",
+        `Failed to adding user_files.public_editors column. DB tables may be out of sync!`,
         "user_files",
         null,
         err

--- a/API/Backend/Draw/setup.js
+++ b/API/Backend/Draw/setup.js
@@ -2,6 +2,7 @@ const routeFiles = require("./routes/files");
 const routerFiles = routeFiles.router;
 const routerDraw = require("./routes/draw").router;
 const ufiles = require("./models/userfiles");
+const file_histories = require("./models/filehistories");
 
 let setup = {
   //Once the app initializes
@@ -28,6 +29,9 @@ let setup = {
   onceStarted: (s) => {},
   //Once all tables sync
   onceSynced: (s) => {
+    if (typeof file_histories.up === "function") {
+      file_histories.up();
+    }
     if (typeof ufiles.up === "function") {
       ufiles.up();
     }

--- a/src/essence/Basics/Formulae_/Formulae_.js
+++ b/src/essence/Basics/Formulae_/Formulae_.js
@@ -1757,7 +1757,7 @@ var Formulae_ = {
         image.style.color = stringToTest
         return image.style.color !== 'rgb(255, 255, 255)'
     },
-    timestampToDate(timestamp) {
+    timestampToDate(timestamp, small) {
         var a = new Date(timestamp * 1000)
         var months = [
             'Jan',
@@ -1784,6 +1784,19 @@ var Formulae_ = {
         var sec =
             a.getUTCSeconds() < 10 ? '0' + a.getUTCSeconds() : a.getUTCSeconds()
 
+        if (small) {
+            return (
+                month +
+                '/' +
+                date +
+                '/' +
+                (year + '').slice(-2) +
+                ' ' +
+                hour +
+                ':' +
+                min
+            )
+        }
         return (
             monthName +
             ' ' +

--- a/src/essence/Tools/Draw/DrawTool.css
+++ b/src/essence/Tools/Draw/DrawTool.css
@@ -1364,6 +1364,32 @@
     font-size: 12px;
     padding: 0px 5px 0px 9px;
 }
+.drawToolFileEditListEditors {
+    height: 31px;
+    display: flex;
+    justify-content: space-between;
+    border-top: 1px solid black;
+    border-bottom: 1px solid black;
+    box-sizing: initial;
+}
+.drawToolFileEditListEditors > div {
+    line-height: 31px;
+    padding: 0px 8px;
+    font-size: 12px;
+    color: var(--color-a4);
+}
+.drawToolFileEditListEditors > input {
+    width: 180px;
+    height: 31px;
+    background: var(--color-a1-5);
+    border: none;
+    padding: 0px 8px;
+    font-size: 14px;
+    color: var(--color-mw2);
+    flex: 1 1;
+    border-left: 1px solid black;
+    transition: background 0.2s ease-out, border 0.2s ease-out;
+}
 .drawToolFileEditOnDescription {
     display: flex;
     justify-content: space-between;
@@ -2001,7 +2027,6 @@
     transition: height 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 #drawToolHistorySequenceList {
-    margin: 0px 2px 0px 5px;
     flex: 1;
     overflow-y: auto;
 }
@@ -2015,8 +2040,8 @@
 #drawToolHistorySequenceList > ul > li {
     color: var(--color-f);
     background: rgba(0, 0, 0, 0);
-    border-bottom: 1px solid rgba(0, 0, 17, 0.25);
-    padding: 2px 5px;
+    border-top: 1px solid var(--color-a1-5);
+    padding: 3px 8px;
     font-size: 13px;
     cursor: pointer;
     transition: background 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);

--- a/src/essence/Tools/Draw/DrawTool_History.js
+++ b/src/essence/Tools/Draw/DrawTool_History.js
@@ -90,7 +90,10 @@ var History = {
             var markup = [
                     "<div class='flexbetween' time=" + h.time + ">",
                         "<span>" + h.message + "</span>",
-                        "<span>" + F_.timestampToDate(h.time / 1000) + "</span>",
+                        "<span style='white-space: nowrap;'>",
+                            `<span style='color: var(--color-a5); font-size: 12px;'>${h.author ? `${h.author} - ` : ''}</span>`,
+                            `<span>${F_.timestampToDate(h.time / 1000, true)}</span>`,
+                        "</span>",
                     "</div>"
                 ].join('\n');
 

--- a/src/essence/Tools/Draw/DrawTool_Shapes.js
+++ b/src/essence/Tools/Draw/DrawTool_Shapes.js
@@ -660,6 +660,23 @@ var Shapes = {
             })
 
             for (var i = 0; i < DrawTool.files.length; i++) {
+                const file = DrawTool.files[i]
+                let ownedByUser = false
+                if (
+                    mmgisglobal.user == file.file_owner ||
+                    (file.file_owner_group &&
+                        F_.diff(file.file_owner_group, DrawTool.userGroups)
+                            .length > 0)
+                )
+                    ownedByUser = true
+                const isListEdit =
+                    file.public == '1' &&
+                    file.publicity_type == 'list_edit' &&
+                    typeof file.public_editors?.includes === 'function' &&
+                    (file.public_editors.includes(mmgisglobal.user) ||
+                        ownedByUser)
+                const isAllEdit =
+                    file.public == '1' && file.publicity_type == 'all_edit'
                 //Lead Files
                 if (
                     DrawTool.userGroups.indexOf('mmgis-group') != -1 &&
@@ -684,7 +701,9 @@ var Shapes = {
                         .attr('value', DrawTool.files[i].id)
                         .text(DrawTool.files[i].file_name + ' [Lead]')
                 } else if (
-                    mmgisglobal.user == DrawTool.files[i].file_owner &&
+                    (mmgisglobal.user == DrawTool.files[i].file_owner ||
+                        isListEdit ||
+                        isAllEdit) &&
                     filenames.indexOf(DrawTool.files[i].file_name) == -1 &&
                     intent == DrawTool.files[i].intent &&
                     DrawTool.files[i].hidden == '0'

--- a/src/essence/essence.js
+++ b/src/essence/essence.js
@@ -104,7 +104,7 @@ $(document).keyup(function (e) {
     // On tab, add tab styles
     if (e.which == '9' && !tabFocusAdded) {
         document.styleSheets[0].insertRule(
-            '.toolButton:focus,#barBottom > i:focus,#topBarTitleName:focus,.mainInfo > div:focus,#mainDescription:focus,#SearchType:focus,#auto_search:focus,#loginoutButton:focus,#mapSplitInnerLeft:focus,#mapSplitInnerRight:focus,#globeSplitInnerLeft:focus,#globeSplitInnerRight:focus {border: 2px solid var(--color-mmgis) !important;}',
+            '.toolButton:focus,#barBottom > i:focus,#topBarTitleName:focus,.mainInfo > div:focus,#mainDescription:focus,#SearchType:focus,#auto_search:focus,#loginoutButton:focus,#mapSplitInnerLeft:focus,#mapSplitInnerRight:focus,#globeSplitInnerLeft:focus,#globeSplitInnerRight:focus {box-shadow: inset 0px 0px 0px 2px var(--color-mmgis) !important;}',
             1
         )
         tabFocusAdded = true


### PR DESCRIPTION
## Purpose
Users are asking to allow editing of their DrawTool files by other team members to maintain primary maps of features of interest that do not rise to the level of a strategic 'Lead Map'

Private 0
Public-read-only 1
Public-list-edit 2 (by default all users in the list can edit the list of users granted access)
Public-all-edit 3

File history shall now show which user performed edits.
SELs can see and edit private files.

## Proposed Changes
- Adds three new db columns:
    - user_files.publicity_type
    - user_files.public_editors 
    - file_histories.author

## Issues
- Closes #387

## Testing
- Log in as different users (lead, file owner, other user) and compare drawing abilities of each in some file.
- Could not test concurrent draws in the same file on my own.