### PR TITLE
Added an option to the LegendTool to automatically display on start

### DIFF
--- a/docs/pages/Tools/Legend/Legend.md
+++ b/docs/pages/Tools/Legend/Legend.md
@@ -9,7 +9,13 @@ parent: Tools
 
 A layer can be configured with a legend by pointing its Legend field to a .csv file or by including a JSON `legend` array into the layer's Raw Variables. The Legend Tool renders symbologies and gradient scales for any properly configured on layer.
 
-The Legend Tool takes no raw variable configurations in the Tools Tab.
+On the Configure page, under Tools, you can specify if the expanded legend should automatically be displayed on start:
+
+```javascript
+{
+    "displayOnStart": true
+}
+```
 
 ### legend.csv example:
 

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -1131,6 +1131,20 @@ function allLayersLoaded() {
 
         L_.loaded()
         //OTHER TEMPORARY TEST STUFF THINGS
+
+        // Turn on legend if displayOnStart is true
+        if ('LegendTool' in ToolController_.toolModules) {
+            if (ToolController_.toolModules['LegendTool'].displayOnStart == true) {
+                ToolController_.toolModules['LegendTool'].make('toolContentSeparated_Legend')
+                let _event = new CustomEvent('toggleSeparatedTool', {
+                    detail: {
+                        toggledToolName: 'LegendTool',
+                        visible: true,
+                    },
+                })
+                document.dispatchEvent(_event)
+            }
+        }
     }
 }
 

--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -13,6 +13,11 @@ var LegendTool = {
     MMWebGISInterface: null,
     targetId: null,
     made: false,
+    displayOnStart: false,
+    initialize: function () {
+        //Get tool variables
+        this.displayOnStart = L_.getToolVars('legend')['displayOnStart']
+    },
     make: function (targetId) {
         this.targetId = targetId
         this.MMWebGISInterface = new interfaceWithMMWebGIS()

--- a/src/essence/Tools/Legend/config.json
+++ b/src/essence/Tools/Legend/config.json
@@ -2,7 +2,7 @@
     "defaultIcon": "map-legend",
     "description": "Show a chart mapping colors and symbols to meaning.",
     "descriptionFull": "",
-    "hasVars": false,
+    "hasVars": true,
     "name": "Legend",
     "toolbarPriority": 2,
     "separatedTool": true,


### PR DESCRIPTION
## Purpose
- Some projects like having the legend visible and expanded when the map loads.
## Proposed Changes
- This PR adds an option to the LegendTool to automatically display the legend on start.
## Issues
## Testing
- Tested with LegendTool turned on/off.
- Tested with displayOnStart set to true/false/null/etc.
- Legend behaves as expected.