### PR TITLE
Added max-width to legend to prevent long text from filling screen

### DIFF
--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -225,9 +225,11 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity) {
                 .style('height', '100%')
                 .style('line-height', '19px')
                 .style('font-size', '14px')
-                .style('overflow', 'auto')
+                .style('overflow', 'hidden')
                 .style('white-space', 'nowrap')
                 .style('max-width', '270px')
+                .style('text-overflow', 'ellipsis')
+                .attr('title', _legend[d].value)
                 .text(_legend[d].value)
         } else if (shape == 'continuous' || shape == 'discreet') {
             if (lastShape != shape) {

--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -227,6 +227,7 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity) {
                 .style('font-size', '14px')
                 .style('overflow', 'auto')
                 .style('white-space', 'nowrap')
+                .style('max-width', '270px')
                 .text(_legend[d].value)
         } else if (shape == 'continuous' || shape == 'discreet') {
             if (lastShape != shape) {


### PR DESCRIPTION
## Purpose
- I have legend values with long descriptive text that are expanding the legend to fill nearly the entire screen.
## Proposed Changes
- Added a max-width property to limit the expansion of text.
## Issues
## Testing
- Tested different legends with various css values to find a good compromise.