### PR TITLE
#399 Crashes if Layers are valid JSON but not valid GeoJSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "file-saver": "^2.0.2",
         "flat": "^5.0.2",
         "fs-extra": "^8.1.0",
+        "geojson-validation": "^1.0.2",
         "hammerjs": "^2.0.8",
         "helmet": "^4.1.1",
         "html-webpack-plugin": "4.0.0-beta.11",
@@ -10339,6 +10340,14 @@
         "@turf/meta": "6.x",
         "@types/geojson": "7946.0.8",
         "rbush": "^3.0.1"
+      }
+    },
+    "node_modules/geojson-validation": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-validation/-/geojson-validation-1.0.2.tgz",
+      "integrity": "sha512-K5jrJ4wFvORn2pRKeg181LL0QPYuEKn2KHPvfH1m2QtFlAXFLKdseqt0XwBM3ELOY7kNM1fglRQ6ZwUQZ5S00A==",
+      "bin": {
+        "gjv": "bin/gjv"
       }
     },
     "node_modules/get-caller-file": {
@@ -30443,6 +30452,11 @@
         "@types/geojson": "7946.0.8",
         "rbush": "^3.0.1"
       }
+    },
+    "geojson-validation": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-validation/-/geojson-validation-1.0.2.tgz",
+      "integrity": "sha512-K5jrJ4wFvORn2pRKeg181LL0QPYuEKn2KHPvfH1m2QtFlAXFLKdseqt0XwBM3ELOY7kNM1fglRQ6ZwUQZ5S00A=="
     },
     "get-caller-file": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "file-saver": "^2.0.2",
     "flat": "^5.0.2",
     "fs-extra": "^8.1.0",
+    "geojson-validation": "^1.0.2",
     "hammerjs": "^2.0.8",
     "helmet": "^4.1.1",
     "html-webpack-plugin": "4.0.0-beta.11",

--- a/src/essence/Basics/Layers_/LayerCapturer.js
+++ b/src/essence/Basics/Layers_/LayerCapturer.js
@@ -70,7 +70,7 @@ export const captureVector = (layerObj, options, cb) => {
                 },
                 function (data) {
                     console.warn(
-                        'ERROR! ' +
+                        'ERROR: ' +
                             data.status +
                             ' in ' +
                             layerUrl +

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -799,8 +799,21 @@ async function makeLayer(layerObj, evenIfOff, forceGeoJSON) {
                 )
 
             function add(data) {
-                const isValidGeoJSON = gjv.valid(data)
-                if (data == null || data === 'off' || !isValidGeoJSON) {
+                let invalidGeoJSONTrace = gjv.valid(data, true)
+                const allowableErrors = [`position must only contain numbers`]
+                invalidGeoJSONTrace = invalidGeoJSONTrace.filter((t) => {
+                    if (typeof t !== 'string') return false
+                    for (let i = 0; i < allowableErrors.length; i++) {
+                        if (t.toLowerCase().indexOf(allowableErrors[i]) != -1)
+                            return false
+                    }
+                    return true
+                })
+                if (
+                    data == null ||
+                    data === 'off' ||
+                    invalidGeoJSONTrace.length > 0
+                ) {
                     if (data != null && data != 'off') {
                         data = null
                         console.warn(

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -17,6 +17,9 @@ import { Kinds } from '../../../pre/tools'
 import DataShaders from '../../Ancillary/DataShaders'
 import calls from '../../../pre/calls'
 import TimeControl from '../../Ancillary/TimeControl'
+
+import gjv from 'geojson-validation'
+
 let L = window.L
 
 let essenceFina = function () {}
@@ -796,7 +799,14 @@ async function makeLayer(layerObj, evenIfOff, forceGeoJSON) {
                 )
 
             function add(data) {
-                if (data == null || data === 'off') {
+                const isValidGeoJSON = gjv.valid(data)
+                if (data == null || data === 'off' || !isValidGeoJSON) {
+                    if (data != null && data != 'off') {
+                        data = null
+                        console.warn(
+                            `ERROR: ${layerObj.display_name} has invalid GeoJSON!`
+                        )
+                    }
                     L_._layersLoaded[
                         L_._layersOrdered.indexOf(layerObj.name)
                     ] = true
@@ -1134,8 +1144,12 @@ function allLayersLoaded() {
 
         // Turn on legend if displayOnStart is true
         if ('LegendTool' in ToolController_.toolModules) {
-            if (ToolController_.toolModules['LegendTool'].displayOnStart == true) {
-                ToolController_.toolModules['LegendTool'].make('toolContentSeparated_Legend')
+            if (
+                ToolController_.toolModules['LegendTool'].displayOnStart == true
+            ) {
+                ToolController_.toolModules['LegendTool'].make(
+                    'toolContentSeparated_Legend'
+                )
                 let _event = new CustomEvent('toggleSeparatedTool', {
                     detail: {
                         toggledToolName: 'LegendTool',


### PR DESCRIPTION
## Purpose
- Adds GeoJSON validation to the map so that the app does not crash if Layers are valid JSON but not valid GeoJSON.
## Proposed Changes
- Adds [geojson-validation](https://www.npmjs.com/package/geojson-validation) step before passing geojson to leafet.
## Issues
- Fixes #399 
## Testing
- Mess up geojson structure by renaming "features", "geometry", "properties", overload coordinates types and make sure it still works, test it still works in the globe.