### PR TITLE
#403 rightClickMenuActions - Polygons and WKT

### DIFF
--- a/config/js/config.js
+++ b/config/js/config.js
@@ -225,6 +225,11 @@ function initialize() {
                   name: "The text for this menu entry when users right-click",
                   link: "https://domain?I={ll[0]}&will={ll[1]}&replace={ll[2]}&these={en[0]}&brackets={en[1]}&for={cproj[0]}&you={sproj[0]}&with={rxy[0]}&coordinates={site[2]}",
                 },
+                {
+                  name: "WKT text insertions. Do so only for polygons.",
+                  link: "https://domain?regularWKT={wkt}&wkt_where_commas_are_replaced_with_underscores={wkt_}",
+                  for: "polygon",
+                },
               ],
             },
             null,

--- a/docs/pages/Configure/Tabs/Coordinates/Coordinates_Tab.md
+++ b/docs/pages/Configure/Tabs/Coordinates/Coordinates_Tab.md
@@ -50,6 +50,11 @@ Example:
         {
             "name": "The text for this menu entry when users right-click",
             "link": "https://domain?I={ll[0]}&will={ll[1]}&replace={ll[2]}&these={en[0]}&brackets={en[1]}&for={cproj[0]}&you={sproj[0]}&with={rxy[0]}&coordinates={site[2]}"
+        },
+        {
+            "name": "WKT text insertions. Do so only for polygons.",
+            "link": "https://domain?regularWKT={wkt}&wkt_where_commas_are_replaced_with_underscores={wkt_}",
+            "for": "polygon"
         }
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@eonasdan/tempus-dominus": "^6.2.6",
         "@popperjs/core": "^2.11.6",
         "@svgr/webpack": "4.3.3",
+        "@terraformer/wkt": "^2.2.0",
         "@testing-library/jest-dom": "^4.2.4",
         "@testing-library/react": "^9.5.0",
         "@testing-library/user-event": "^7.2.1",
@@ -2091,6 +2092,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@terraformer/wkt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@terraformer/wkt/-/wkt-2.2.0.tgz",
+      "integrity": "sha512-i33rTSqPtmO4sRdeznI0IEc9gpIZZIXN5kGhZ4rTwVtDccDKL3h4uia9cmWdRJlJMlG4Febxatw5b9ylI5YYuA=="
     },
     "node_modules/@testing-library/dom": {
       "version": "6.16.0",
@@ -23808,6 +23814,11 @@
         "@svgr/plugin-svgo": "^4.3.1",
         "loader-utils": "^1.2.3"
       }
+    },
+    "@terraformer/wkt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@terraformer/wkt/-/wkt-2.2.0.tgz",
+      "integrity": "sha512-i33rTSqPtmO4sRdeznI0IEc9gpIZZIXN5kGhZ4rTwVtDccDKL3h4uia9cmWdRJlJMlG4Febxatw5b9ylI5YYuA=="
     },
     "@testing-library/dom": {
       "version": "6.16.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@eonasdan/tempus-dominus": "^6.2.6",
     "@popperjs/core": "^2.11.6",
     "@svgr/webpack": "4.3.3",
+    "@terraformer/wkt": "^2.2.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/src/essence/Ancillary/ContextMenu.css
+++ b/src/essence/Ancillary/ContextMenu.css
@@ -2,11 +2,11 @@
     position: absolute;
     background: var(--color-a);
     box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, 0.3);
-    border: 1px solid var(--color-i);
     border-radius: 1px;
     font-size: 15px;
     z-index: 1;
     transition: opacity 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
+    overflow-y: auto;
 }
 
 .ContextMenuMap #contextMenuCursor {
@@ -37,12 +37,13 @@
     padding: 0;
 }
 .ContextMenuMap li {
-    padding: 5px 8px 5px 16px;
+    padding: 5px 16px 5px 16px;
     cursor: pointer;
     color: #aaa;
     border-top: 1px solid var(--color-a1);
     display: flex;
     transition: color 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
+    line-height: 18px;
 }
 .ContextMenuMap li:first-child {
     border-top: none;
@@ -53,4 +54,35 @@
 .ContextMenuMap li:hover {
     color: white;
     background: var(--color-a1);
+}
+
+.ContextMenuMap .contextMenuHeader {
+}
+.ContextMenuMap .contextMenuHeader span:nth-child(1) {
+    color: var(--color-h);
+    padding-right: 4px;
+    font-size: 12px;
+    line-height: 18px;
+}
+.ContextMenuMap .contextMenuHeader span:nth-child(2) {
+    color: var(--color-a5);
+    padding-right: 4px;
+}
+.ContextMenuMap .contextMenuHeader span:nth-child(3) {
+    color: var(--color-a4);
+    font-size: 12px;
+    line-height: 18px;
+    padding-left: 4px;
+}
+.ContextMenuMap .contextMenuHeader span:nth-child(4) {
+    padding-left: 4px;
+    color: var(--color-a7);
+}
+
+.ContextMenuMap .contextMenuFeatureItem {
+    margin-left: 15px;
+    padding-left: 15px;
+    font-size: 13px;
+    line-height: 15px;
+    border-left: 1px solid var(--color-a1);
 }

--- a/src/essence/Ancillary/ContextMenu.js
+++ b/src/essence/Ancillary/ContextMenu.js
@@ -27,6 +27,8 @@ function showContextMenuMap(e) {
         []
     )
 
+    console.log(L_.getFeaturesAtPoint(e))
+
     hideContextMenuMap(true)
     var x = e.originalEvent.clientX
     var y = e.originalEvent.clientY

--- a/src/essence/Ancillary/ContextMenu.js
+++ b/src/essence/Ancillary/ContextMenu.js
@@ -5,6 +5,8 @@ import F_ from '../Basics/Formulae_/Formulae_'
 import Map_ from '../Basics/Map_/Map_'
 import Coordinates from './Coordinates'
 
+import { geojsonToWKT } from '@terraformer/wkt'
+
 import './ContextMenu.css'
 
 var ContextMenu = {
@@ -26,22 +28,56 @@ function showContextMenuMap(e) {
         'configData.coordinates.variables.rightClickMenuActions',
         []
     )
+    const contextMenuActionsFull = []
+    e.latlng = e.latlng || Coordinates.getLatLng(true)
 
-    console.log(L_.getFeaturesAtPoint(e))
+    const featuresAtClick = L_.getFeaturesAtPoint(e, true)
+    featuresAtClick.splice(100)
 
     hideContextMenuMap(true)
     var x = e.originalEvent.clientX
     var y = e.originalEvent.clientY
+
     // prettier-ignore
     var markup = [
-        "<div class='ContextMenuMap' style='left: " + x + "px; top: " + y + "px;'>",
+        `<div class='ContextMenuMap' style='left: ${x}px; top: ${y}px; max-height: ${window.innerHeight - y}px;'>`,
             "<div id='contextMenuCursor'>",
                 "<div></div>",
                 "<div></div>",
             "</div>",
             "<ul>",
                 "<li id='contextMenuMapCopyCoords'>Copy Coordinates</li>",
-                contextMenuActions.map((a, idx) => `<li id='contextMenuAction_${idx}'>${a.name}${a.link != null ? `<div><i class='mdi mdi-open-in-new mdi-18px'></i>` : ''}</li>` ).join('\n'),
+                contextMenuActions.map((a, idx) => {
+                    const items = []
+                    if(a.for == null) {
+                            items.push(`<li id='contextMenuAction_${idx}_0'>${a.name}${a.link != null ? `<div><i class='mdi mdi-open-in-new mdi-18px'></i>` : ''}</li>`)
+                            contextMenuActionsFull.push({contextMenuAction: a, idx: idx, idx2: 0})
+                    }
+                    return items.join('\n')
+                } ).join('\n'),
+                featuresAtClick.map((f, idx2) => {
+                    const items = []
+                    const layerName = f.options.layerName
+                    const displayName = L_.layers.data[layerName].display_name
+                    const pv = L_.getLayersChosenNamePropVal(f.feature, layerName)
+                    const key = Object.keys(pv)[0]
+                    const val = pv[key]
+                    items.push(`<li class='contextMenuHeader' id='contextMenuAction_${'head'}_${idx2}'><span>${f.feature.geometry.type}</span><span>${displayName}</span>-<span>${key}</span>:<span>${val}</span></li>`)
+                    contextMenuActionsFull.push({contextMenuAction: { goto: true }, idx: 'head', idx2: idx2, feature: f})
+                    contextMenuActions.map((a, idx) => {
+                        const forLower = a.for ? a.for.toLowerCase() : null
+                        switch(forLower) {
+                            case "polygon":
+                                    if( f.feature.geometry.type.toLowerCase() === forLower) {
+                                        items.push(`<li class='contextMenuFeatureItem' id='contextMenuAction_${idx}_${idx2}'>${a.name}${a.link != null ? `<div><i class='mdi mdi-open-in-new mdi-18px'></i>` : ''}</li>`)
+                                        contextMenuActionsFull.push({contextMenuAction: a, idx: idx, idx2: idx2, feature: f})
+                                    }
+                                break;
+                            default:
+                        }
+                    } )
+                    return items.join('\n')
+                }).join('\n'),
             "</ul>",
         "</div>"
     ].join('\n');
@@ -60,12 +96,14 @@ function showContextMenuMap(e) {
         }, 2000)
     })
 
-    contextMenuActions.forEach((a, idx) => {
-        $(`#contextMenuAction_${idx}`).on('click', function () {
+    contextMenuActionsFull.forEach((c) => {
+        $(`#contextMenuAction_${c.idx}_${c.idx2}`).on('click', function () {
+            const a = c.contextMenuAction
+            const l = featuresAtClick[c.idx2]
             if (a.link) {
                 let link = a.link
-                const lnglat = Coordinates.getLngLat()
 
+                const lnglat = Coordinates.getLngLat()
                 Object.keys(Coordinates.states).forEach((s) => {
                     if (link.indexOf(`{${s}[`) !== -1) {
                         const converted = Coordinates.convertLngLat(
@@ -89,7 +127,27 @@ function showContextMenuMap(e) {
                         )
                     }
                 })
+
+                let wkt
+                if (link.indexOf(`{wkt}`) !== -1) {
+                    wkt = geojsonToWKT(l.feature.geometry)
+                    link = link.replace(new RegExp(`{wkt}`, 'gi'), wkt)
+                }
+                if (link.indexOf(`{wkt_}`) !== -1) {
+                    wkt = geojsonToWKT(l.feature.geometry)
+                    link = link.replace(
+                        new RegExp(`{wkt_}`, 'gi'),
+                        wkt.replace(/,/g, '_')
+                    )
+                }
                 window.open(link, '_blank').focus()
+            }
+            if (a.goto === true) {
+                if (l) {
+                    if (typeof l.getBounds === 'function')
+                        Map_.map.fitBounds(l.getBounds())
+                    else if (l._latlng) Map_.map.panTo(l._latlng)
+                }
             }
         })
     })

--- a/src/essence/Ancillary/Coordinates.js
+++ b/src/essence/Ancillary/Coordinates.js
@@ -328,7 +328,12 @@ const Coordinates = {
     getLngLat: function () {
         return Coordinates.mouseLngLat
     },
-    getLatLng: function () {
+    getLatLng: function (asObject) {
+        if (asObject)
+            return {
+                lat: Coordinates.mouseLngLat[1],
+                lng: Coordinates.mouseLngLat[0],
+            }
         return [Coordinates.mouseLngLat[1], Coordinates.mouseLngLat[0]]
     },
     getAllCoordinates: function () {

--- a/src/essence/Basics/Layers_/LayerConstructors.js
+++ b/src/essence/Basics/Layers_/LayerConstructors.js
@@ -67,10 +67,12 @@ export const constructVectorLayer = (
             if (feature.properties.hasOwnProperty('style')) {
                 let className = layerObj.style.className
                 let layerName = layerObj.style.layerName
+                layerObj.style = Object.assign({}, layerObj.style)
                 layerObj.style = {
-                    ...JSON.parse(JSON.stringify(layerObj.style)),
+                    ...layerObj.style,
                     ...JSON.parse(JSON.stringify(feature.properties.style)),
                 }
+
                 if (className) layerObj.style.className = className
                 if (layerName) layerObj.style.layerName = layerName
             } else {

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -543,13 +543,23 @@ function getLayersChosenNamePropVal(feature, layer) {
             })
         }
     }
-    // Use first key
+
+    // Use first key that is not an object
     if (!foundThroughVariables) {
         for (let key in feature.properties) {
-            //Store the current feature's key
-            propertyNames = [key]
+            //Default to show geometry type
+            propertyNames = ['Type']
+            propertyValues = [feature.geometry.type]
+
             //Be certain we have that key in the feature
-            if (feature.properties.hasOwnProperty(key)) {
+            if (
+                false &&
+                feature.properties.hasOwnProperty(key) &&
+                (typeof feature.properties[key] === 'string' ||
+                    typeof feature.properties[key] === 'number')
+            ) {
+                //Store the current feature's key
+                propertyNames = [key]
                 //Store the current feature's value
                 propertyValues = [feature.properties[key]]
                 //Break out of for loop since we're done

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -513,63 +513,6 @@ let Map_ = {
     allLayersLoaded: allLayersLoaded,
 }
 
-//Specific internal functions likely only to be used once
-function getLayersChosenNamePropVal(feature, layer) {
-    //These are what you'd think they'd be (Name could be thought of as key)
-    let propertyNames, propertyValues
-    let foundThroughVariables = false
-    if (
-        layer.hasOwnProperty('options') &&
-        layer.options.hasOwnProperty('layerName')
-    ) {
-        const l = L_.layers.data[layer.options.layerName]
-        if (
-            l.hasOwnProperty('variables') &&
-            l.variables.hasOwnProperty('useKeyAsName')
-        ) {
-            propertyNames = l.variables['useKeyAsName']
-            if (typeof propertyNames === 'string')
-                propertyNames = [propertyNames]
-            propertyValues = Array(propertyNames.length).fill(null)
-            propertyNames.forEach((propertyName, idx) => {
-                if (feature.properties.hasOwnProperty(propertyName)) {
-                    propertyValues[idx] = F_.getIn(
-                        feature.properties,
-                        propertyName
-                    )
-                    if (propertyValues[idx] != null)
-                        foundThroughVariables = true
-                }
-            })
-        }
-    }
-
-    // Use first key that is not an object
-    if (!foundThroughVariables) {
-        for (let key in feature.properties) {
-            //Default to show geometry type
-            propertyNames = ['Type']
-            propertyValues = [feature.geometry.type]
-
-            //Be certain we have that key in the feature
-            if (
-                false &&
-                feature.properties.hasOwnProperty(key) &&
-                (typeof feature.properties[key] === 'string' ||
-                    typeof feature.properties[key] === 'number')
-            ) {
-                //Store the current feature's key
-                propertyNames = [key]
-                //Store the current feature's value
-                propertyValues = [feature.properties[key]]
-                //Break out of for loop since we're done
-                break
-            }
-        }
-    }
-    return F_.stitchArrays(propertyNames, propertyValues)
-}
-
 //Takes an array of layer objects and makes them map layers
 function makeLayers(layersObj) {
     //Make each layer (backwards to maintain draw order)
@@ -611,7 +554,7 @@ async function makeLayer(layerObj, evenIfOff, forceGeoJSON) {
     //Default is onclick show full properties and onhover show 1st property
     Map_.onEachFeatureDefault = onEachFeatureDefault
     function onEachFeatureDefault(feature, layer) {
-        const pv = getLayersChosenNamePropVal(feature, layer)
+        const pv = L_.getLayersChosenNamePropVal(feature, layer)
 
         layer['useKeyAsName'] = Object.keys(pv)[0]
         if (


### PR DESCRIPTION
Closes #403 

![6578857343](https://github.com/NASA-AMMOS/MMGIS/assets/25355244/fc81108a-74c4-480a-8107-57dd0b600523)

Coordinates Tab Raw Variables Example:

```javascript
{
    "rightClickMenuActions": [
        {
            "name": "The text for this menu entry when users right-click",
            "link": "https://domain?I={ll[0]}&will={ll[1]}&replace={ll[2]}&these={en[0]}&brackets={en[1]}&for={cproj[0]}&you={sproj[0]}&with={rxy[0]}&coordinates={site[2]}"
        },
        {
            "name": "WKT text insertions. Do so only for polygons.",
            "link": "https://domain?regularWKT={wkt}&wkt_where_commas_are_replaced_with_underscores={wkt_}",
            "for": "polygon"
        }
    ]
}
```