### PR TITLE
#412 Add Configuration Option to set TimeUI Extent

### DIFF
--- a/config/js/config.js
+++ b/config/js/config.js
@@ -691,6 +691,12 @@ function initialize() {
                 $("#tab_time #time_initialend").val(
                   cData.time ? cData.time.initialend : "now"
                 );
+                $("#tab_time #time_initialwindowstart").val(
+                  cData.time ? cData.time.initialwindowstart : ""
+                );
+                $("#tab_time #time_initialwindowend").val(
+                  cData.time ? cData.time.initialwindowend : "now"
+                );
 
                 //tools
                 //uncheck all tools
@@ -2194,6 +2200,10 @@ function save(returnJSON) {
     json.time.format = $("#tab_time #time_format").val();
     json.time.initialstart = $("#tab_time #time_initialstart").val();
     json.time.initialend = $("#tab_time #time_initialend").val();
+    json.time.initialwindowstart = $(
+      "#tab_time #time_initialwindowstart"
+    ).val();
+    json.time.initialwindowend = $("#tab_time #time_initialwindowend").val();
 
     //Tools
     for (var i = 0; i < tData.length; i++) {

--- a/docs/pages/Configure/Tabs/Time/Time_Tab.md
+++ b/docs/pages/Configure/Tabs/Time/Time_Tab.md
@@ -27,3 +27,27 @@ If enabled and visible, the Time UI will be initially open on the bottom of the 
 The time format to be displayed on the Time UI. Uses D3 time format specifiers: https://github.com/d3/d3-time-format
 
 Default: `%Y-%m-%dT%H:%M:%SZ`
+
+## Initial Start Time
+
+The initial start time. Should be before `Initial End Time`.
+
+Default: 1 month before `Initial End Time`
+
+## Initial End Time
+
+The initial end time. Should be after `Initial Start Time`. Use `now` to have the end time be the present.
+
+Default: `now`
+
+## Initial Window Start Time
+
+This does not control the time range for queries. This only allows the initial time window of the time line to differ from just being the Start Time to the End Time. A use-case for this would be to set the window times to fit the full extent of the temporal data but only set the Initial Start and End Times as a subset of that so as not to query everything on load.
+
+Default: `Initial Start Time`
+
+## Initial Window End Time
+
+This does not control the time range for queries. This only allows the initial time window of the time line to differ from just being the Start Time to the End Time. Should be after `Initial Window End Time` Use `now` to have the end time be the present.
+
+Default: `Initial End Time`

--- a/src/essence/Ancillary/TimeUI.js
+++ b/src/essence/Ancillary/TimeUI.js
@@ -411,6 +411,19 @@ const TimeUI = {
             } else TimeUI._initialEnd = dateStaged
         } else TimeUI._initialEnd = new Date()
 
+        // Initial Timeline window end
+        if (
+            L_.configData.time.initialwindowend != null &&
+            L_.configData.time.initialwindowend != 'now'
+        ) {
+            const dateStaged = new Date(L_.configData.time.initialwindowend)
+            if (dateStaged == 'Invalid Date') {
+                console.warn(
+                    "Invalid 'Initial Window End Time' provided. Defaulting to 'now'."
+                )
+            } else TimeUI._timelineEndTimestamp = dateStaged.getTime()
+        }
+
         // Initial start
         // Start 1 month ago
         TimeUI._initialStart = new Date(TimeUI._initialEnd)
@@ -438,6 +451,21 @@ const TimeUI = {
                     "'Initial Start Time' cannot be later than the end time. Defaulting to 1 month before the end time."
                 )
             } else TimeUI._initialStart = dateStaged
+        }
+
+        // Initial Timeline window start
+        if (L_.configData.time.initialwindowstart != null) {
+            const dateStaged = new Date(L_.configData.time.initialwindowstart)
+            if (dateStaged == 'Invalid Date') {
+                console.warn("Invalid 'Initial Window Start Time' provided.")
+            } else if (
+                TimeUI._timelineEndTimestamp == null ||
+                dateStaged.getTime() > TimeUI._timelineEndTimestamp
+            ) {
+                console.warn(
+                    "'Initial Window Start Time' cannot be later than the Initial Window End Time."
+                )
+            } else TimeUI._timelineStartTimestamp = dateStaged.getTime()
         }
 
         // Initialize the time control times, but don't trigger events

--- a/views/configure.pug
+++ b/views/configure.pug
@@ -505,12 +505,20 @@ script(type='text/javascript' src='config/pre/RefreshAuth.js')
             #time_format_row.input-field.col.s3.push-s2
               input#time_format.validate(type='text' value='%Y-%m-%dT%H:%M:%SZ')
               label(for='time_format') Time Format
+          li.row
             #time_initialstartEl.input-field.col.s3.push-s2
               input#time_initialstart.validate(type='text' value='' title="Parsable time (defaults to a month before the end time)")
               label(for='time_initialstart') Initial Start Time
             #time_initialendEl.input-field.col.s3.push-s2
               input#time_initialend.validate(type='text' value='now' title="Parsable time (default to 'now')")
               label(for='time_initialend') Initial End Time
+          li.row   
+            #time_initialwindowstartEl.input-field.col.s3.push-s2
+              input#time_initialwindowstart.validate(type='text' value='' title="Parsable time (defaults to the Initial Start Time)")
+              label(for='time_initialwindowstart') Initial Timeline Window Start Time
+            #time_initialwindowendEl.input-field.col.s3.push-s2
+              input#time_initialwindowend.validate(type='text' value='now' title="Parsable time (default to the Initial End TIme)")
+              label(for='time_initialwindowend') Initial Timeline Window End Time
 
       #tab_tools.col.s12
         a.helpFromDocs(href='https://nasa-ammos.github.io/MMGIS/configure/tabs/tools' target='__blank' rel='noopener')


### PR DESCRIPTION
Closes #412 

Adds Initial Window Start and End Times to the Time Tab:

![24373427643574537](https://github.com/NASA-AMMOS/MMGIS/assets/25355244/483f8e61-7ff3-4629-9236-1fbd799b993e)

Which yields:

![4583457345828](https://github.com/NASA-AMMOS/MMGIS/assets/25355244/5044d2d6-e9a5-49af-a753-1a82fd2d6509)
