### PR TITLE
#432 Image Overlay Fixes

### DIFF
--- a/src/essence/Basics/Layers_/LayerConstructors.js
+++ b/src/essence/Basics/Layers_/LayerConstructors.js
@@ -1238,16 +1238,28 @@ const imageOverlays = (geojson, layerObj, leafletLayerObject) => {
                         L.imageTransform(imageSettings.image, anchors, {
                             opacity: 1,
                             clip: anchors,
+                            id: `${layerObj.name}${
+                                imageSettings.image
+                            }${angle}${JSON.stringify(center)}`,
                         }),
                     ])
                 },
             }
+        let existingOn = null
+        if (L_.layers.attachments[L_.asLayerUUID(layerObj.name)])
+            existingOn =
+                L_.layers.attachments[L_.asLayerUUID(layerObj.name)]
+                    .image_overlays.on
+
+        const isOn =
+            existingOn != null
+                ? existingOn
+                : imageVar.initialVisibility != null
+                ? imageVar.initialVisibility
+                : true
         return imageShow === 'always'
             ? {
-                  on:
-                      imageVar.initialVisibility != null
-                          ? imageVar.initialVisibility
-                          : true,
+                  on: isOn,
                   layer: L.geoJson(geojson, leafletLayerObjectImageOverlay),
                   title: 'Map rendered image overlays.',
               }

--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -2591,7 +2591,7 @@ const L_ = {
                 return
             }
             L_.syncSublayerData(layerName)
-            L_.globeLithoLayerHelper(L_.layersNamed[layerName])
+            L_.globeLithoLayerHelper(L_.layers.layer[layerName])
         } else {
             console.warn(
                 'Warning: Unable to update vector layer as it does not exist: ' +

--- a/src/external/Leaflet/leaflet-imageoverlay-rotated.js
+++ b/src/external/Leaflet/leaflet-imageoverlay-rotated.js
@@ -1,145 +1,169 @@
-
 L.ImageOverlay.Rotated = L.ImageOverlay.extend({
+    initialize: function (image, topleft, topright, bottomleft, options) {
+        if (typeof image === 'string') {
+            this._url = image
+        } else {
+            // Assume that the first parameter is an instance of HTMLImage or HTMLCanvas
+            this._rawImage = image
+        }
 
-	initialize: function (image, topleft, topright, bottomleft, options) {
+        this._topLeft = L.latLng(topleft)
+        this._topRight = L.latLng(topright)
+        this._bottomLeft = L.latLng(bottomleft)
 
-		if (typeof(image) === 'string') {
-			this._url = image;
-		} else {
-			// Assume that the first parameter is an instance of HTMLImage or HTMLCanvas
-			this._rawImage = image;
-		}
-
-		this._topLeft    = L.latLng(topleft);
-		this._topRight   = L.latLng(topright);
-		this._bottomLeft = L.latLng(bottomleft);
-
-		L.setOptions(this, options);
-	},
-
-
-	onAdd: function (map) {
-		if (!this._image) {
-			this._initImage();
-
-			if (this.options.opacity < 1) {
-				this._updateOpacity();
-			}
-		}
-
-		if (this.options.interactive) {
-			L.DomUtil.addClass(this._rawImage, 'leaflet-interactive');
-			this.addInteractiveTarget(this._rawImage);
-		}
-
-		map.on('zoomend resetview', this._reset, this);
-
-		this.getPane().appendChild(this._image);
-		this._reset();
-	},
-
-
-    onRemove: function(map) {
-        map.off('zoomend resetview', this._reset, this);
-        L.ImageOverlay.prototype.onRemove.call(this, map);
+        L.setOptions(this, options)
     },
-	
-	
-	_initImage: function () {
-		var img = this._rawImage;
-		if (this._url) {
-			img = L.DomUtil.create('img');
-			img.style.display = 'none';	// Hide while the first transform (zero or one frames) is being done
 
-			if (this.options.crossOrigin) {
-				img.crossOrigin = '';
-			}
+    onAdd: function (map) {
+        if (!this._image) {
+            this._initImage()
 
-			img.src = this._url;
-			this._rawImage = img;
-		}
-		L.DomUtil.addClass(img, 'leaflet-image-layer');
+            if (this.options.opacity < 1) {
+                this._updateOpacity()
+            }
+        }
 
-		// this._image is reused by some of the methods of the parent class and
-		// must keep the name, even if it is counter-intuitive.
-		var div = this._image = L.DomUtil.create('div',
-				'leaflet-image-layer ' + (this._zoomAnimated ? 'leaflet-zoom-animated' : ''));
+        if (this.options.interactive) {
+            L.DomUtil.addClass(this._rawImage, 'leaflet-interactive')
+            this.addInteractiveTarget(this._rawImage)
+        }
 
-		div.appendChild(img);
+        map.on('zoomend resetview', this._reset, this)
 
-		div.onselectstart = L.Util.falseFn;
-		div.onmousemove = L.Util.falseFn;
+        this.getPane().appendChild(this._image)
+        this._reset()
+    },
 
-		img.onload = function(){
-			this._reset();
-			img.style.display = 'block';
-			this.fire('load');
-		}.bind(this);
+    onRemove: function (map) {
+        map.off('zoomend resetview', this._reset, this)
+        L.ImageOverlay.prototype.onRemove.call(this, map)
+    },
 
-		img.alt = this.options.alt;
-	},
+    _initImage: function () {
+        var img = this._rawImage
+        if (this._url) {
+            img = L.DomUtil.create('img')
+            img.style.display = 'none' // Hide while the first transform (zero or one frames) is being done
 
+            if (this.options.crossOrigin) {
+                img.crossOrigin = ''
+            }
 
-	_reset: function () {
-		var div = this._image;
+            img.src = this._url
+            this._rawImage = img
+        }
+        L.DomUtil.addClass(img, 'leaflet-image-layer')
 
-		// Project control points to container-pixel coordinates
-		var pxTopLeft    = this._map.latLngToLayerPoint(this._topLeft);
-		var pxTopRight   = this._map.latLngToLayerPoint(this._topRight);
-		var pxBottomLeft = this._map.latLngToLayerPoint(this._bottomLeft);
+        // this._image is reused by some of the methods of the parent class and
+        // must keep the name, even if it is counter-intuitive.
+        var div = (this._image = L.DomUtil.create(
+            'div',
+            'leaflet-image-layer ' +
+                (this._zoomAnimated ? 'leaflet-zoom-animated' : '')
+        ))
 
-		// Infer coordinate of bottom right
-		var pxBottomRight = pxTopRight.subtract(pxTopLeft).add(pxBottomLeft);
+        div.appendChild(img)
 
-		// pxBounds is mostly for positioning the <div> container
-		var pxBounds = L.bounds([pxTopLeft, pxTopRight, pxBottomLeft, pxBottomRight]);
-		var size = pxBounds.getSize();
-		var pxTopLeftInDiv = pxTopLeft.subtract(pxBounds.min);
+        div.onselectstart = L.Util.falseFn
+        div.onmousemove = L.Util.falseFn
 
-		// Calculate the skew angles, both in X and Y
-		var vectorX = pxTopRight.subtract(pxTopLeft);
-		var vectorY = pxBottomLeft.subtract(pxTopLeft);
-		var skewX = Math.atan2( vectorX.y, vectorX.x );
-		var skewY = Math.atan2( vectorY.x, vectorY.y );
+        img.onload = function () {
+            this._reset()
+            img.style.display = 'block'
+            this.fire('load')
+        }.bind(this)
 
-		// LatLngBounds used for animations
-		this._bounds = L.latLngBounds( this._map.layerPointToLatLng(pxBounds.min),
-		                               this._map.layerPointToLatLng(pxBounds.max) );
+        img.alt = this.options.alt
+    },
 
-		L.DomUtil.setPosition(div, pxBounds.min);
+    _reset: function () {
+        var div = this._image
 
-		div.style.width  = size.x + 'px';
-		div.style.height = size.y + 'px';
+        // Project control points to container-pixel coordinates
+        var pxTopLeft = this._map.latLngToLayerPoint(this._topLeft)
+        var pxTopRight = this._map.latLngToLayerPoint(this._topRight)
+        var pxBottomLeft = this._map.latLngToLayerPoint(this._bottomLeft)
 
-		var imgW = this._rawImage.width;
-		var imgH = this._rawImage.height;
-		if (!imgW || !imgH) {
-			return;	// Probably because the image hasn't loaded yet.
-		}
+        // Infer coordinate of bottom right
+        var pxBottomRight = pxTopRight.subtract(pxTopLeft).add(pxBottomLeft)
 
-		var scaleX = pxTopLeft.distanceTo(pxTopRight)   / imgW * Math.cos(skewX);
-		var scaleY = pxTopLeft.distanceTo(pxBottomLeft) / imgH * Math.cos(skewY);
+        // pxBounds is mostly for positioning the <div> container
+        var pxBounds = L.bounds([
+            pxTopLeft,
+            pxTopRight,
+            pxBottomLeft,
+            pxBottomRight,
+        ])
+        var size = pxBounds.getSize()
+        var pxTopLeftInDiv = pxTopLeft.subtract(pxBounds.min)
 
-		this._rawImage.style.transformOrigin = '0 0';
+        // Calculate the skew angles, both in X and Y
+        var vectorX = pxTopRight.subtract(pxTopLeft)
+        var vectorY = pxBottomLeft.subtract(pxTopLeft)
+        var skewX = Math.atan2(vectorX.y, vectorX.x)
+        var skewY = Math.atan2(vectorY.x, vectorY.y)
 
-		this._rawImage.style.transform =
-			'translate(' + pxTopLeftInDiv.x + 'px, ' + pxTopLeftInDiv.y + 'px)' +
-			'skew(' + skewY + 'rad, ' + skewX + 'rad) ' +
-			'scale(' + scaleX + ', ' + scaleY + ') ';
-	},
+        // LatLngBounds used for animations
+        this._bounds = L.latLngBounds(
+            this._map.layerPointToLatLng(pxBounds.min),
+            this._map.layerPointToLatLng(pxBounds.max)
+        )
 
+        L.DomUtil.setPosition(div, pxBounds.min)
 
-	reposition: function(topleft, topright, bottomleft) {
-		this._topLeft    = L.latLng(topleft);
-		this._topRight   = L.latLng(topright);
-		this._bottomLeft = L.latLng(bottomleft);
-		this._reset();
-	}
+        div.style.width = size.x + 'px'
+        div.style.height = size.y + 'px'
 
-});
+        var imgW = this._rawImage.width
+        var imgH = this._rawImage.height
+        if (!imgW || !imgH) {
+            return // Probably because the image hasn't loaded yet.
+        }
 
+        var scaleX = (pxTopLeft.distanceTo(pxTopRight) / imgW) * Math.cos(skewX)
+        var scaleY =
+            (pxTopLeft.distanceTo(pxBottomLeft) / imgH) * Math.cos(skewY)
 
+        this._rawImage.style.transformOrigin = '0 0'
 
-L.imageOverlay.rotated = function(imgSrc, topleft, topright, bottomleft, options) {
-	return new L.ImageOverlay.Rotated(imgSrc, topleft, topright, bottomleft, options);
-};
+        this._rawImage.style.transform =
+            'translate(' +
+            pxTopLeftInDiv.x +
+            'px, ' +
+            pxTopLeftInDiv.y +
+            'px)' +
+            'skew(' +
+            skewY +
+            'rad, ' +
+            skewX +
+            'rad) ' +
+            'scale(' +
+            scaleX +
+            ', ' +
+            scaleY +
+            ') '
+    },
+
+    reposition: function (topleft, topright, bottomleft) {
+        this._topLeft = L.latLng(topleft)
+        this._topRight = L.latLng(topright)
+        this._bottomLeft = L.latLng(bottomleft)
+        this._reset()
+    },
+})
+
+L.imageOverlay.rotated = function (
+    imgSrc,
+    topleft,
+    topright,
+    bottomleft,
+    options
+) {
+    return new L.ImageOverlay.Rotated(
+        imgSrc,
+        topleft,
+        topright,
+        bottomleft,
+        options
+    )
+}


### PR DESCRIPTION
Closes #432 

Wraps up:
- Updating vector layer features causing image-overlay toggle to go out of sync
- Flickering with updateVectorLayer
- #200 
  - Won't fix. Converting to a blob and loading the blob takes longer and still shows a network request. Regular cached images will be okay. 
- #382
  - Not sure what's wrong of if this is an MMGIS problem or data problem. I did verify that the Image Overlay yaws are accounting for map projection

@khalidadil