### PR TITLE
Indentifier tool vsicurl support

### DIFF
--- a/scripts/server.js
+++ b/scripts/server.js
@@ -655,7 +655,13 @@ setups.getBackendSetups(function (setups) {
           1,
         ],
         function (error, stdout, stderr) {
-          res.send(stdout);
+          if (error) {
+            logger("warn", error)
+            res.status(400).send();
+          }
+          else {
+            res.send(stdout);
+          }
         }
       );
     }
@@ -677,7 +683,13 @@ setups.getBackendSetups(function (setups) {
         "python",
         ["private/api/BandsToProfile.py", path, x, y, xyorll, bands],
         function (error, stdout, stderr) {
-          res.send(stdout);
+          if (error) {
+            logger("warn", error)
+            res.status(400).send();
+          }
+          else {
+            res.send(stdout);
+          }
         }
       );
     }

--- a/src/essence/Tools/Identifier/IdentifierTool.js
+++ b/src/essence/Tools/Identifier/IdentifierTool.js
@@ -439,6 +439,13 @@ function bestMatchInLegend(rgba, legendData) {
 
 function queryDataValue(url, lng, lat, numBands, callback) {
     numBands = numBands || 1
+    var dataPath
+    if (url.startsWith("/vsicurl/")) {
+        dataPath = url
+    }
+    else {
+        dataPath = 'Missions/' + L_.mission + '/' + url
+    }
     calls.api(
         'getbands',
         {
@@ -447,7 +454,7 @@ function queryDataValue(url, lng, lat, numBands, callback) {
             y: lng,
             xyorll: 'll',
             bands: '[[1,' + numBands + ']]',
-            path: 'Missions/' + L_.mission + '/' + url,
+            path: dataPath,
         },
         function (data) {
             //Convert python's Nones to nulls


### PR DESCRIPTION
## Purpose
- This pull request modifies the IdentifierTool to add support for [remote virtual layers](https://nasa-ammos.github.io/MMGIS/configure/formats/remote-virtual-layer) through GDAL's vsicurl.

## Proposed Changes
- [CHANGE] Add special case handling for /vsicurl/ URLs to IdentifierTool.  The 'getbands' API already fully supports this, so all that's needed is for the frontend to provide the proper URL.
- [CHANGE] (optional): During testing, I noticed that the 'getbands' and 'getprofile' API endpoints return an empty 200 response if there is an error inside the script or invalid parameters are provided.  I modified these to return a 400 and log the error if one occurs.

## Testing
I've tested this PR with our local development environment.  We have a WMS server that serves floating point geotiffs, and I created a gdal_wms.xml remote layer description file.  The following simple Identifier Tool config works to retrieve point values from the remote layer.

```
{
    "layer_name": {
        "url": "/vsicurl/https://mapserver/static/gdal_wms.xml",
        "bands": 1,
    }
}
```