### PR TITLE
Minor updates for API calls

### DIFF
--- a/API/Backend/Geodatasets/routes/geodatasets.js
+++ b/API/Backend/Geodatasets/routes/geodatasets.js
@@ -311,6 +311,10 @@ router.post("/recreate", function (req, res, next) {
       body: {},
     });
   }
+  if (!features) {
+    //Must be a single feature from an append.  Make an array
+    features = [JSON.parse(req.body.geojson)];
+  }
 
   makeNewGeodatasetTable(
     req.body.name,
@@ -325,8 +329,13 @@ router.post("/recreate", function (req, res, next) {
         return;
       }
 
+      let drop_qry = "TRUNCATE TABLE " + result.table + " RESTART IDENTITY";
+      if (req.body.hasOwnProperty("action") && req.body.action=="append") {
+        drop_qry = "";
+      }
+
       sequelize
-        .query("TRUNCATE TABLE " + result.table + " RESTART IDENTITY")
+        .query(drop_qry)
         .then(() => {
           populateGeodatasetTable(
             result.tableObj,
@@ -343,7 +352,7 @@ router.post("/recreate", function (req, res, next) {
           return null;
         })
         .catch((err) => {
-          logger("error", "Recreation error.", req.originalUrl, req, err);
+          logger("error", "Recreation error.", req.originalUrl, req, err.stack);
           res.send(result);
         });
     },

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -325,7 +325,7 @@ function ensureAdmin(toLoginPage, denyLongTermTokens) {
 }
 
 function validateLongTermToken(token, successCallback, failureCallback) {
-  token = token.replace("Bearer ", "");
+  token = token.replace(/Bearer:?\s+/g, "");
 
   sequelize
     .query('SELECT * FROM "long_term_tokens" WHERE "token"=:token', {


### PR DESCRIPTION
> The first update was to correct a string replacement in token lookup. The simple string replacement in of “Bearer “ was not working because a colon could be present.
> 
> The second update was to allow appending to datasets with the “recreate” command.  The API now allows an “action” variable to be supplied that if set to “append” will not drop the table. 

Thanks Jeff!