### PR TITLE
#452 Updated Identifier tool to be a separated floating tool

### DIFF
--- a/src/essence/Tools/Identifier/IdentifierTool.js
+++ b/src/essence/Tools/Identifier/IdentifierTool.js
@@ -467,6 +467,7 @@ function interfaceWithMMWebGIS() {
     //tools.html( markup );
 
     //Add event functions and whatnot
+    var previousCursor = d3.select('#map').style('cursor')
     d3.select('#map').style('cursor', 'crosshair')
 
     Map_.map.on('mousemove', IdentifierTool.idPixelMap)
@@ -496,9 +497,6 @@ function interfaceWithMMWebGIS() {
 
     function separateFromMMWebGIS() {
         CursorInfo.hide()
-
-        d3.select('#map').style('cursor', 'grab')
-
         Map_.map.off('mousemove', IdentifierTool.idPixelMap)
         //Globe_.shouldRaycastSprites = true
         if (L_.hasGlobe) {
@@ -508,25 +506,29 @@ function interfaceWithMMWebGIS() {
                 .removeEventListener('mousemove', IdentifierTool.idPixelGlobe)
         }
 
-        let tools = d3.select(
-            IdentifierTool.targetId ? `#${IdentifierTool.targetId}` : '#toolPanel'
-        )
-        tools.style('background', 'var(--color-k)')
-        //Clear it
-        tools.selectAll('*').remove()
-
-        var prevActive = $(
-            '#toolcontroller_sepdiv #' +
-                'Identifier' +
-                'Tool'
-        )
-        prevActive.removeClass('active').css({
-            color: ToolController_.defaultColor,
-            background: 'none',
-        })
-        prevActive.parent().css({
-            background: 'none',
-        })
+        if (IdentifierTool.targetId === 'toolContentSeparated_Identifier') {
+            d3.select('#map').style('cursor', 'grab')
+            let tools = d3.select(
+                IdentifierTool.targetId ? `#${IdentifierTool.targetId}` : '#toolPanel'
+            )
+            tools.style('background', 'var(--color-k)')
+            //Clear it
+            tools.selectAll('*').remove()
+            var prevActive = $(
+                '#toolcontroller_sepdiv #' +
+                    'Identifier' +
+                    'Tool'
+            )
+            prevActive.removeClass('active').css({
+                color: ToolController_.defaultColor,
+                background: 'none',
+            })
+            prevActive.parent().css({
+                background: 'none',
+            })
+        } else {
+            d3.select('#map').style('cursor', previousCursor)
+        }
     }
 }
 

--- a/src/essence/Tools/Identifier/IdentifierTool.js
+++ b/src/essence/Tools/Identifier/IdentifierTool.js
@@ -34,7 +34,21 @@ var IdentifierTool = {
         //Get tool variables and UI adjustments
         this.justification = L_.getToolVars('identifier')['justification']
         var toolContent = d3.select('#toolSeparated_Identifier')
-        toolContent.style('bottom', '2px')    
+        toolContent.style('bottom', '2px')
+        if (this.justification == 'right') {
+            var toolController = d3.select('#toolcontroller_sepdiv')
+            toolController.style('top', '110px')
+            toolController.style('left', null)
+            toolController.style('right', '5px')
+            toolContent.style('left', null)
+            toolContent.style('right', '0px')
+        } else if (this.justification != L_.getToolVars('legend')['justification']) {
+            var toolController = d3.select('#toolcontroller_sepdiv').clone(false).attr('id', 'toolcontroller_sepdiv_left')
+            $('#toolSeparated_Identifier').appendTo('#toolcontroller_sepdiv_left')
+            toolController.style('top', '40px')
+            toolController.style('left', '5px')
+            toolController.style('right', null)
+        }
     },   
     make: function (targetId) {
         this.MMWebGISInterface = new interfaceWithMMWebGIS()

--- a/src/essence/Tools/Identifier/config.json
+++ b/src/essence/Tools/Identifier/config.json
@@ -16,6 +16,8 @@
     },
     "hasVars": true,
     "name": "Identifier",
+    "toolbarPriority": 1,
+    "separatedTool": true,
     "paths": {
         "IdentifierTool": "essence/Tools/Identifier/IdentifierTool"
     }

--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -27,7 +27,13 @@ var LegendTool = {
             toolController.style('right', '5px')
             toolContent.style('left', null)
             toolContent.style('right', '0px')
-        }        
+        } else if (this.justification != L_.getToolVars('identifier')['justification']) {
+            var toolController = d3.select('#toolcontroller_sepdiv').clone(false).attr('id', 'toolcontroller_sepdiv_left')
+            $('#toolSeparated_Legend').appendTo('#toolcontroller_sepdiv_left')
+            toolController.style('top', '40px')
+            toolController.style('left', '5px')
+            toolController.style('right', null)
+        }
     },
     make: function (targetId) {
         this.targetId = targetId


### PR DESCRIPTION
## Purpose
- Updated Identifier tool to be a separated floating tool
## Proposed Changes
## Issues
- #452 
## Testing
- Currently being used by one mission and works as expected with tools on the right-side of the UI
- Clicking on tool icon activates tool, allows user to hover over data to see values, tool remains activated with Layer tool open and user switching between layers, clicking again on tool icon deactivates tool

- Need to test different UI combinations with other separated tools
- We may possibly want an option to make the tool not be separated to maintain compatibility