### PR TITLE
#471 Additional Body Metadata for Draw Webhooks

### DIFF
--- a/API/Backend/Webhooks/processes/triggerwebhooks.js
+++ b/API/Backend/Webhooks/processes/triggerwebhooks.js
@@ -166,6 +166,8 @@ function getInjectableVariables(type, file, res) {
       injectableVariables.file_id = injectableVariables.id;
 
       if (typeof injectableVariables.file_description === "string") {
+        injectableVariables.raw_file_description =
+          injectableVariables.file_description;
         const tags = injectableVariables.file_description.match(/~#\w+/g) || [];
         const uniqueTags = [...tags];
         // remove '#'s

--- a/config/js/webhooks.js
+++ b/config/js/webhooks.js
@@ -126,7 +126,7 @@ function makeWebhookCard(data) {
                 "</li>" +
                 "<li class='row'>" +
                     "<div class='inject-label input-field col s9' id='webhookUrlEl'>" +
-                        "<label style='top: 0px; font-size: 14px;'>Valid injectable variables for URL and Body fields: {created_on}, {file_description}, {file_id}, {file_name}, {file_owner}, {file_owner_group}, {hidden}, {intent}, {is_master}, {public}, {public_editors}, {publicity_type}, {template}, {updated_on}, {geojson}</label>" +
+                        "<label style='top: 0px; font-size: 14px;'>Valid injectable variables for URL and Body fields: {created_on}, {efolders}, {file_description}, {file_id}, {file_name}, {file_owner}, {file_owner_group}, {folders}, {geojson}, {hidden}, {intent}, {is_master}, {public}, {public_editors}, {publicity_type}, {tags}, {template}, {updated_on}</label>" +
                     "</div>" +
                     "<div class='col s3 push-s1' id='deleteWebhook_" + webhooksCounter +"'>" +
                         "<a class='btn waves-effect' style='color: black; background: white;'>Delete<i class='mdi mdi-delete mdi-24px' style='float: right; margin-top: 1px;'></i></a>" +

--- a/config/js/webhooks.js
+++ b/config/js/webhooks.js
@@ -126,7 +126,7 @@ function makeWebhookCard(data) {
                 "</li>" +
                 "<li class='row'>" +
                     "<div class='inject-label input-field col s9' id='webhookUrlEl'>" +
-                        "<label>Valid injectable variables for URL and Body fields: {file_id}, {file_name}, {file_owner}, {geojson}</label>" +
+                        "<label style='top: 0px; font-size: 14px;'>Valid injectable variables for URL and Body fields: {created_on}, {file_description}, {file_id}, {file_name}, {file_owner}, {file_owner_group}, {hidden}, {intent}, {is_master}, {public}, {public_editors}, {publicity_type}, {template}, {updated_on}, {geojson}</label>" +
                     "</div>" +
                     "<div class='col s3 push-s1' id='deleteWebhook_" + webhooksCounter +"'>" +
                         "<a class='btn waves-effect' style='color: black; background: white;'>Delete<i class='mdi mdi-delete mdi-24px' style='float: right; margin-top: 1px;'></i></a>" +

--- a/config/js/webhooks.js
+++ b/config/js/webhooks.js
@@ -126,7 +126,7 @@ function makeWebhookCard(data) {
                 "</li>" +
                 "<li class='row'>" +
                     "<div class='inject-label input-field col s9' id='webhookUrlEl'>" +
-                        "<label style='top: 0px; font-size: 14px;'>Valid injectable variables for URL and Body fields: {created_on}, {efolders}, {file_description}, {file_id}, {file_name}, {file_owner}, {file_owner_group}, {folders}, {geojson}, {hidden}, {intent}, {is_master}, {public}, {public_editors}, {publicity_type}, {tags}, {template}, {updated_on}</label>" +
+                        "<label style='top: 0px; font-size: 14px;'>Valid injectable variables for URL and Body fields: {created_on}, {efolders}, {file_description}, {file_id}, {file_name}, {file_owner}, {file_owner_group}, {folders}, {geojson}, {hidden}, {intent}, {is_master}, {public}, {public_editors}, {publicity_type}, {raw_file_description}, {tags}, {template}, {updated_on}</label>" +
                     "</div>" +
                     "<div class='col s3 push-s1' id='deleteWebhook_" + webhooksCounter +"'>" +
                         "<a class='btn waves-effect' style='color: black; background: white;'>Delete<i class='mdi mdi-delete mdi-24px' style='float: right; margin-top: 1px;'></i></a>" +

--- a/configuration/webpack.config.js
+++ b/configuration/webpack.config.js
@@ -42,10 +42,6 @@ crypto.createHash = (algorithm) =>
   crypto_orig_createHash(algorithm === "md4" ? "sha256" : algorithm);
 // end hack
 
-console.log(
-  process.env.GENERATE_SOURCEMAP,
-  typeof process.env.GENERATE_SOURCEMAP
-);
 // Source maps are resource heavy and can cause out of memory issue for large source files.
 const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP === "true";
 // Some apps do not need the benefits of saving a web request, so not inlining the chunk

--- a/private/api/spice/chronos.py
+++ b/private/api/spice/chronos.py
@@ -58,3 +58,4 @@ try:
     print(chronos(target, fromFormat, fromtype, to, totype, time))
 except:
     print(json.dumps({"error": True, "message": 'Error: ' + str(sys.exc_info()[0])}))
+    


### PR DESCRIPTION
All DrawFile* webhook actions now support the following valid injectable variables for URL and Body fields:
```
{created_on},
{efolders}, 
{file_description}, 
{file_id}, 
{file_name}, 
{file_owner},
{file_owner_group}, 
{folders}, 
{geojson}, 
{hidden}, 
{intent},
{is_master},
{public}, 
{public_editors},
{publicity_type}, 
{raw_file_description},
{tags}, 
{template}, 
{updated_on}
```