### PR TITLE
#477 DrawTool - Filter state management

### DIFF
--- a/config/css/config.css
+++ b/config/css/config.css
@@ -477,6 +477,10 @@ textarea {
   margin: 0;
 }
 
+.l_title {
+  text-transform: none;
+}
+
 [type="radio"]:checked + label:after,
 [type="radio"].with-gap:checked + label:after {
   background-color: #1565c0;

--- a/docs/pages/Tools/Draw/Draw.md
+++ b/docs/pages/Tools/Draw/Draw.md
@@ -33,7 +33,11 @@ There are five files that are group editable with the correct permission. The gr
         "plan2",
         "done"
     ],
-    "hoverLengthOnLines": false
+    "hoverLengthOnLines": false,
+    "defaultDrawClipping": "over || under || off",
+    "defaultPublicFilter": false,
+    "defaultYoursOnlyFilter": true,
+    "defaultOnFilter": false,
     "leadsCanEditFileInfo": false,
     "templates": {
         "example_1": [
@@ -111,6 +115,10 @@ There are five files that are group editable with the correct permission. The gr
 _"intents"_: The names in quotes will be the group file names.  
 _"preferredTags"_: Users can attach tags or keyword to files to organize them. Preferred Tags are curated tags and promoted over user generated ones.  
 _"hoverLengthOnLines"_: If true, the hover text for line features will include the total length of the line in meters.
+_"defaultDrawClipping"_: Default clipping mode for drawing: "over || under || off".
+_"defaultPublicFilter"_: When the DrawTool first opens, filter the file list down to only public files or not. default: false
+_"defaultYoursOnlyFilter"_: When the DrawTool first opens, filter the file list down to only files you own or not. default: true.
+_"defaultOnFilter"_: When the DrawTool first opens, filter the file list down to only files that are on or not. default: false.
 _"leadsCanEditFileInfo"_: If true, lead roles can edit the file info, (name, description, tags, folder, make private) of any user's public file.
 _"templates"_: Templates create forms for feature properties. For instance, all features in a given draw file could, in the feature's edit panel, have the field "Reviewed" be togglable via a checkbox. Users may make their own templates too but the ones configured here are promoted and cannot be delete.
 

--- a/src/essence/Tools/Draw/DrawTool_Files.js
+++ b/src/essence/Tools/Draw/DrawTool_Files.js
@@ -190,8 +190,15 @@ var Files = {
         $('#drawToolDrawSortDiv > div').off('click')
         $('#drawToolDrawSortDiv > div').on('click', function (e) {
             $(this).toggleClass('active')
+            window._toolStates = window._toolStates || {}
+            window._toolStates.draw = window._toolStates.draw || {}
+            window._toolStates.draw.filter =
+                window._toolStates.draw.filter || {}
+            window._toolStates.draw.filter[$(this).attr('type')] =
+                $(this).hasClass('active')
             fileFilter()
         })
+
         $('#drawToolDrawFilter').off('keydown')
         $('#drawToolDrawFilter').on('keydown', function (e) {
             if (e.which === 13)

--- a/src/essence/Tools/Draw/DrawTool_Shapes.css
+++ b/src/essence/Tools/Draw/DrawTool_Shapes.css
@@ -1,4 +1,3 @@
-
 #drawToolShapesCopyDiv {
     background: var(--color-a);
     display: flex;
@@ -68,7 +67,6 @@
     transition: opacity 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
 }
 
-
 #drawToolShapesFilterDiv {
     background: var(--color-a);
     display: flex;
@@ -93,7 +91,7 @@
     background: var(--color-a1);
     height: 30px;
     cursor: pointer;
-    transition: color 0.2s ease-in-out
+    transition: color 0.2s ease-in-out;
 }
 
 #drawToolShapesFilterAdvanced > i,
@@ -108,7 +106,9 @@
 #drawToolShapesFilterClear:hover > i {
     color: var(--color-a7) !important;
 }
-
+#drawToolShapesFilterAdvanced {
+    border-right: 1px solid var(--color-a-5);
+}
 #drawToolShapesFilterAdvanced.on {
     background: var(--color-a2) !important;
 }
@@ -136,10 +136,8 @@
     max-height: 50vh;
 }
 
-
-
 #drawToolShapes {
-    height: 100%; 
+    height: 100%;
     display: flex;
     flex-flow: column;
 }
@@ -227,7 +225,6 @@
     text-align: center;
 }
 
-
 /*Filter*/
 #drawToolShapes_filtering {
     background: var(--color-a2);
@@ -248,9 +245,10 @@
     display: flex;
 }
 #drawToolShapes_filtering_title {
-    font-size: 16px;
-    padding-left: 14px;
+    font-size: 14px;
+    padding-left: 8px;
     line-height: 31px;
+    color: var(--color-a6);
 }
 #drawToolShapes_filtering_count {
     font-size: 12px;
@@ -291,7 +289,6 @@
     background: var(--color-a1);
     color: #fff;
 }
-
 
 #drawToolShapes_filtering_footer {
     display: flex;
@@ -389,13 +386,15 @@
     width: 22px;
 }
 #drawToolShapes_filtering_clear {
-    padding: 0px 14px;
+    padding: 0px 8px;
+    font-size: 13px;
 }
 #drawToolShapes_filtering_clear:hover {
     background: var(--color-red2);
 }
 #drawToolShapes_filtering_submit {
     padding: 0px 8px;
+    font-size: 13px;
     transition: background 0.2s cubic-bezier(0.785, 0.135, 0.15, 0.86);
 }
 #drawToolShapes_filtering_submit.active {

--- a/src/essence/Tools/Draw/DrawTool_Shapes.js
+++ b/src/essence/Tools/Draw/DrawTool_Shapes.js
@@ -15,6 +15,7 @@ var Shapes = {
         DrawTool = tool
         DrawTool.populateShapes = Shapes.populateShapes
         DrawTool.updateCopyTo = Shapes.updateCopyTo
+        DrawTool.setSubmitButtonState = Shapes.setSubmitButtonState
     },
     populateShapes: function (fileId, selectedFeatureIds) {
         //If we get an array of fileIds, split them
@@ -103,10 +104,9 @@ var Shapes = {
         $('#drawToolShapesFilterAdvanced').on('click', function () {
             $('#drawToolShapesFilterAdvanced').toggleClass('on')
             $('#drawToolShapesFilterAdvancedDiv').toggleClass('on')
-            if ($('#drawToolShapesFilterAdvancedDiv').hasClass('on'))
-                $('#drawToolDrawShapesList').css('height', 'calc(100% - 265px)')
-            else $('#drawToolDrawShapesList').css('height', 'calc(100% - 65px)')
-            //shapeFilter()
+            if (!$('#drawToolShapesFilterAdvanced').hasClass('on')) {
+                $(`#drawToolShapes_filtering_clear`).click()
+            }
         })
         $('#drawToolShapesFilterClear').off('click')
         $('#drawToolShapesFilterClear').on('click', function () {
@@ -901,6 +901,7 @@ var Shapes = {
         $(`#drawToolShapes_filtering_clear`).off('click')
         $(`#drawToolShapes_filtering_clear`).on('click', async () => {
             $(`#drawToolShapes_filtering_submit_loading`).addClass('active')
+            Shapes.setSubmitButtonState(true)
 
             // Clear value filter elements
             Shapes.filters.values = Shapes.filters.values.filter((v) => {
@@ -910,7 +911,6 @@ var Shapes = {
 
             $(`.drawToolContextMenuHeaderClose`).click()
             fileIds.forEach((fileId) => {
-                console.log(Shapes.filters)
                 // Refilter to show all
                 const filter = {
                     values: JSON.parse(JSON.stringify(Shapes.filters.values)),

--- a/src/essence/Tools/Draw/config.json
+++ b/src/essence/Tools/Draw/config.json
@@ -13,6 +13,9 @@
                 "All_Alias"
             ],
             "defaultDrawClipping": "over || under || off",
+            "defaultPublicFilter": false,
+            "defaultYoursOnlyFilter": true,
+            "defaultOnFilter": false,
             "leadsCanEditFileInfo": false,
             "hoverLengthOnLines": false,
             "templates": {


### PR DESCRIPTION
Closes #477 

- Can set default state of DrawTool filters from configure page
- Saving url saves the state of the DrawTool filters in it.
- Closing and opening the DrawTool has the filter states persist