### PR TITLE
#489 DrawTool - Move

### DIFF
--- a/src/essence/Tools/Draw/DrawTool_Editing.js
+++ b/src/essence/Tools/Draw/DrawTool_Editing.js
@@ -904,6 +904,17 @@ var Editing = {
                 'editable:editing',
                 updateSelectionLayer
             )
+            DrawTool.contextMenuLayer.off('editable:drag')
+            DrawTool.contextMenuLayer.on('editable:drag', updateSelectionLayer)
+
+            DrawTool.contextMenuLayer.off('editable:dragstart')
+            DrawTool.contextMenuLayer.on('editable:dragstart', () => {
+                $('#drawToolMouseoverText').removeClass('active')
+            })
+            DrawTool.contextMenuLayer.off('editable:dragend')
+            DrawTool.contextMenuLayer.on('editable:dragend', () => {
+                $('#drawToolMouseoverText').removeClass('active')
+            })
         }
 
         function updateSelectionLayer() {
@@ -2776,7 +2787,8 @@ var Editing = {
         Map_.map.off('mouseup', DrawTool.cmLayerUp)
         Map_.map.off('mousemove', DrawTool.cmLayerMove)
 
-        DrawTool.contextMenuLayer.dragging = false
+        if (DrawTool.contextMenuLayer.dragging === true)
+            DrawTool.contextMenuLayer.dragging = false
         Map_.map.dragging.enable()
     },
     cmLayerDown: function () {

--- a/src/essence/Tools/Draw/DrawTool_Shapes.js
+++ b/src/essence/Tools/Draw/DrawTool_Shapes.js
@@ -198,7 +198,6 @@ var Shapes = {
             )
                 //if it's a non point layer
                 f = shape._layers[Object.keys(shape._layers)[0]]
-
             var properties = f.feature.properties
 
             if (f.hasOwnProperty('_layers')) f = f._layers

--- a/src/external/Leaflet/Path.Drag.js
+++ b/src/external/Leaflet/Path.Drag.js
@@ -1,0 +1,144 @@
+'use strict'
+
+/* A Draggable that does not update the element position
+and takes care of only bubbling to targetted path in Canvas mode. */
+L.PathDraggable = L.Draggable.extend({
+    initialize: function (path) {
+        this._path = path
+        this._canvas = path._map.getRenderer(path) instanceof L.Canvas
+        var element = this._canvas
+            ? this._path._map.getRenderer(this._path)._container
+            : this._path._path
+        L.Draggable.prototype.initialize.call(this, element, element, true)
+    },
+
+    _updatePosition: function () {
+        var e = { originalEvent: this._lastEvent }
+        this.fire('drag', e)
+    },
+
+    _onDown: function (e) {
+        var first = e.touches ? e.touches[0] : e
+        this._startPoint = new L.Point(first.clientX, first.clientY)
+        if (
+            this._canvas &&
+            !this._path._containsPoint(
+                this._path._map.mouseEventToLayerPoint(first)
+            )
+        ) {
+            return
+        }
+        L.Draggable.prototype._onDown.call(this, e)
+    },
+})
+
+L.Handler.PathDrag = L.Handler.extend({
+    initialize: function (path) {
+        this._path = path
+    },
+
+    getEvents: function () {
+        return {
+            dragstart: this._onDragStart,
+            drag: this._onDrag,
+            dragend: this._onDragEnd,
+        }
+    },
+
+    addHooks: function () {
+        if (!this._draggable) {
+            this._draggable = new L.PathDraggable(this._path)
+        }
+        this._draggable.on(this.getEvents(), this).enable()
+        L.DomUtil.addClass(this._draggable._element, 'leaflet-path-draggable')
+    },
+
+    removeHooks: function () {
+        this._draggable.off(this.getEvents(), this).disable()
+        L.DomUtil.removeClass(
+            this._draggable._element,
+            'leaflet-path-draggable'
+        )
+    },
+
+    moved: function () {
+        return this._draggable && this._draggable._moved
+    },
+
+    _onDragStart: function () {
+        this._startPoint = this._draggable._startPoint
+        this._path.closePopup().fire('movestart').fire('dragstart')
+    },
+
+    _onDrag: function (e) {
+        var path = this._path,
+            event =
+                e.originalEvent.touches && e.originalEvent.touches.length === 1
+                    ? e.originalEvent.touches[0]
+                    : e.originalEvent,
+            newPoint = L.point(event.clientX, event.clientY),
+            latlng = path._map.layerPointToLatLng(newPoint)
+
+        this._offset = newPoint.subtract(this._startPoint)
+        this._startPoint = newPoint
+
+        this._path.eachLatLng(this.updateLatLng, this)
+        path.redraw()
+
+        e.latlng = latlng
+        e.offset = this._offset
+        path.fire('drag', e)
+        e.latlng = this._path.getCenter
+            ? this._path.getCenter()
+            : this._path.getLatLng()
+        path.fire('move', e)
+    },
+
+    _onDragEnd: function (e) {
+        if (this._path._bounds) this.resetBounds()
+        this._path.fire('moveend').fire('dragend', e)
+    },
+
+    latLngToLayerPoint: function (latlng) {
+        // Same as map.latLngToLayerPoint, but without the round().
+        var projectedPoint = this._path._map.project(L.latLng(latlng))
+        return projectedPoint._subtract(this._path._map.getPixelOrigin())
+    },
+
+    updateLatLng: function (latlng) {
+        var oldPoint = this.latLngToLayerPoint(latlng)
+        oldPoint._add(this._offset)
+        var newLatLng = this._path._map.layerPointToLatLng(oldPoint)
+        latlng.lat = newLatLng.lat
+        latlng.lng = newLatLng.lng
+    },
+
+    resetBounds: function () {
+        this._path._bounds = new L.LatLngBounds()
+        this._path.eachLatLng(function (latlng) {
+            this._bounds.extend(latlng)
+        })
+    },
+})
+
+L.Path.include({
+    eachLatLng: function (callback, context) {
+        context = context || this
+        var loop = function (latlngs) {
+            for (var i = 0; i < latlngs.length; i++) {
+                if (L.Util.isArray(latlngs[i])) loop(latlngs[i])
+                else callback.call(context, latlngs[i])
+            }
+        }
+        loop(this.getLatLngs ? this.getLatLngs() : [this.getLatLng()])
+    },
+})
+
+L.Path.addInitHook(function () {
+    this.dragging = new L.Handler.PathDrag(this)
+    if (this.options.draggable) {
+        this.once('add', function () {
+            this.dragging.enable()
+        })
+    }
+})

--- a/src/external/Leaflet/leaflet-editable.js
+++ b/src/external/Leaflet/leaflet-editable.js
@@ -1841,7 +1841,9 @@
         // 🍂method enableEdit(map?: L.Map): this.editor
         // Enable editing, by creating an editor if not existing, and then calling `enable` on it.
         enableEdit: function (map) {
-            if (!this.editor) this.createEditor(map)
+            if (!this.editor) {
+                this.createEditor(map)
+            }
             this.editor.enable()
             return this.editor
         },

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import RefreshAuth from './pre/RefreshAuth'
 import $ from 'jquery'
 import L from './external/Leaflet/leaflet1.5.1' // './external/Leaflet/leaflet1.5.1_DEBUG' //
 import ld from './external/Leaflet/leaflet.draw'
+import pd from './external/Leaflet/Path.Drag'
 import lgu from './external/Leaflet/leaflet.geometryutil'
 import ls from './external/Leaflet/leaflet.snap'
 import lc from './external/Leaflet/leaflet-corridor'


### PR DESCRIPTION
## Adds
- Ability to drag entire polygons, lines and arrows (points and text were already supported)
  - The ability to drag entire polygons and lines requires the edit-snapping UI setting to be off 
## Issues
Closes #489 
## Testing
For each drawing type:
- Draw
- Select to edit and open panel
- Close panel without saving
- Select again
- Drag vertices and drag center to move whole shape
- Close panel without saving (feature should go back to original position)
- Select and drag vertices and entire feature again
- Save