### PR TITLE
#496 Support Symbols in DrawTool Folders and Tags

### DIFF
--- a/src/essence/Tools/Draw/DrawTool.js
+++ b/src/essence/Tools/Draw/DrawTool.js
@@ -925,17 +925,17 @@ var DrawTool = {
         }
         if (typeof file_description !== 'string') return []
 
-        const tags = file_description.match(/~#\w+/g) || []
+        const tags = file_description.match(/~#([^\s])+/g) || []
         const uniqueTags = [...tags]
         // remove '#'s
         tagFolders.tags = uniqueTags.map((t) => t.substring(2)) || []
 
-        const folders = file_description.match(/~@\w+/g) || []
+        const folders = file_description.match(/~@([^\s])+/g) || []
         const uniqueFolders = [...folders]
         // remove '@'s
         tagFolders.folders = uniqueFolders.map((t) => t.substring(2)) || []
 
-        const efolders = file_description.match(/~\^\w+/g) || []
+        const efolders = file_description.match(/~\^([^\s])+/g) || []
         const uniqueEFolders = [...efolders]
         // remove '^'s
         tagFolders.efolders = uniqueEFolders.map((t) => t.substring(2)) || []
@@ -975,15 +975,14 @@ var DrawTool = {
                 .concat(tagFolders.folders)
                 .concat(tagFolders.efolders)
         }
-
         return tagFolders
     },
     stripTagsFromDescription(file_description) {
         if (typeof file_description !== 'string') return ''
         return file_description
-            .replaceAll(/~#\w+/g, '')
-            .replaceAll(/~@\w+/g, '')
-            .replaceAll(/~\^\w+/g, '')
+            .replaceAll(/~#([^\s])+/g, '')
+            .replaceAll(/~@([^\s])+/g, '')
+            .replaceAll(/~\^([^\s])+/g, '')
             .trimStart()
             .trimEnd()
     },
@@ -1015,6 +1014,8 @@ var DrawTool = {
 
                     // Add tags and folders
                     for (let i = 0; i < DrawTool.files.length; i++) {
+                        DrawTool.files[i].file_description =
+                            DrawTool.files[i].file_description || ''
                         DrawTool.files[i]._tagFolders =
                             DrawTool.getTagsFoldersFromFileDescription(
                                 DrawTool.files[i]

--- a/src/essence/Tools/Draw/DrawTool_Files.js
+++ b/src/essence/Tools/Draw/DrawTool_Files.js
@@ -41,6 +41,7 @@ var Files = {
             'type'
         )
         const filesInGroupOrder = JSON.parse(JSON.stringify(DrawTool.files))
+
         if (groupingType != 'none') {
             filesInGroupOrder.sort((a, b) => {
                 if (
@@ -414,22 +415,23 @@ var Files = {
             } else {
                 if (file._tagFolders[groupingType]) {
                     file._tagFolders[groupingType].forEach((g) => {
+                        const gEnc = encodeURIComponent(g)
+
                         const group = d3.select(
-                            `#drawToolDrawFilesList > .drawToolDrawFilesGroupElem[group_name="${g}"]`
+                            `#drawToolDrawFilesList > .drawToolDrawFilesGroupElem[group_name="${gEnc}"]`
                         )
 
                         let iconClass =
                             Files.getGroupingIcons(groupingType).closed
-
                         if (group.size() === 0) {
                             // prettier-ignore
                             d3.select('#drawToolDrawFilesList')
                             .append('div')
                             .attr('class', `drawToolDrawFilesGroupElem`)
-                            .attr('group_name', g)
+                            .attr('group_name', gEnc)
                             .html(
                                 [
-                                    `<div class='drawToolDrawFilesGroupElemHead' state='off' group_name='${g}' groupingtype='${groupingType}'>`,
+                                    `<div class='drawToolDrawFilesGroupElemHead' state='off' group_name='${gEnc}' groupingtype='${groupingType}'>`,
                                         `<div class='${g === 'unassigned' || g === 'untagged' ? 'drawToolDrawFilesGroupElemUn' : ''}'>`,
                                             `<div class='drawToolDrawFilesGroupElemChevron'><i class='mdi ${iconClass} mdi-18px'></i></div>`,
                                             `<div>${groupingType === 'alphabetical' ? g.substring(1) : g}</div>`,
@@ -442,11 +444,11 @@ var Files = {
                         }
                         if (
                             $(
-                                `.drawToolDrawFilesGroupElem[group_name="${g}"] .drawToolDrawFilesGroupListElem > .drawToolDrawFilesListElem[file_id="${file.id}"]`
+                                `.drawToolDrawFilesGroupElem[group_name="${gEnc}"] .drawToolDrawFilesGroupListElem > .drawToolDrawFilesListElem[file_id="${file.id}"]`
                             ).length === 0
                         ) {
                             d3.select(
-                                `.drawToolDrawFilesGroupElem[group_name="${g}"] .drawToolDrawFilesGroupListElem`
+                                `.drawToolDrawFilesGroupElem[group_name="${gEnc}"] .drawToolDrawFilesGroupListElem`
                             )
                                 .append('li')
                                 .attr(
@@ -515,7 +517,9 @@ var Files = {
 
         if (Files.currentOpenFolderName != null)
             $(
-                `.drawToolDrawFilesGroupElemHead[group_name=${Files.currentOpenFolderName}]`
+                `.drawToolDrawFilesGroupElemHead[group_name="${decodeURIComponent(
+                    Files.currentOpenFolderName
+                )}"]`
             ).trigger('click')
 
         //Li Elem Context Menu
@@ -528,23 +532,25 @@ var Files = {
             e.preventDefault()
             let elm = $(this)
             const isPub = elm.attr('id') === 'drawToolDrawPublished'
-            const activeTagFolType = $(
+            let activeTagFolType = $(
                 '#drawToolDrawGroupingDiv > div.active'
             ).attr('type')
             const isHead = elm.hasClass('drawToolDrawFilesGroupElemHead')
-            const headGroup = elm.attr('group_name')
+            if (isHead) activeTagFolType = elm.attr('groupingtype')
+            const headGroup = decodeURIComponent(elm.attr('group_name'))
 
             const isLead = DrawTool.userGroups.indexOf('mmgis-group') != -1
+
             const leadIsEdit =
                 isLead && DrawTool.vars.leadsCanEditFileInfo === true
 
             if (
                 isHead &&
-                (!(
+                !(
                     activeTagFolType === 'tags' ||
                     activeTagFolType === 'folders'
-                ) ||
-                    !leadIsEdit)
+                ) &&
+                !leadIsEdit
             )
                 return
 
@@ -1271,11 +1277,15 @@ var Files = {
                         if (newTag.length === 0) return
 
                         // not alphanumeric
-                        if (newTag.match(/^[a-z0-9_]+$/i) == null) {
+                        if (
+                            newTag.indexOf(' ') > -1 ||
+                            newTag.indexOf('~') > -1 ||
+                            newTag.indexOf('$') > -1
+                        ) {
                             CursorInfo.update(
                                 `${
                                     type === 'tag' ? 'Tags' : 'Folders'
-                                } may only contain alphanumerics and underscores!`,
+                                } may not contain spaces, dollar-signs or tildes!`,
                                 3500,
                                 true,
                                 {
@@ -1421,7 +1431,6 @@ var Files = {
                         if (!description.replace(/\s/g, '').length) {
                             description = ''
                         }
-
                         var body = {
                             id: fileid,
                             file_name: filename,


### PR DESCRIPTION
Closes #496 

Efolders, folders and tags in the DrawToll can now contains any symbol except for:
- spaces ` `
- tildes `~`
- dollar-signs `$`