### PR TITLE
#498 Layer loading UI issues

### DIFF
--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -600,6 +600,13 @@ function interfaceWithMMGIS(fromInit) {
     }
 
     async function toggleLayer(checkbox) {
+        if (checkbox.hasClass('loading')) {
+            console.warn(
+                'LayersTool - Cannot toggle layer that is still loading.'
+            )
+            return
+        }
+
         let li = checkbox.parent().parent().parent()
         if (li.attr('type') !== 'header') {
             const layerName = li.attr('name')


### PR DESCRIPTION
Closes #498 

Simple fix to prevent a loading layer to be retoggled in the LayersTool.

The following from #486 may also help by ensuring that the same layer doesn't get made twice because the existing makeLayer hasn't finished:
> ⚠️ BREAKING: To avoid odd race conditions of async function calls, mmgis.reloadLayer and mmgis.updateVectorLayer will fail and return false if the layer is directly in the process of being reloaded, queried, updated or made. ⚠️