### PR TITLE
#519 Fix mmgisAPI.setTime start

### DIFF
--- a/src/essence/Ancillary/TimeControl.js
+++ b/src/essence/Ancillary/TimeControl.js
@@ -114,12 +114,12 @@ var TimeControl = {
                     .toISOString()
                     .split('.')[0] + 'Z'
         }
-        TimeControl.timeUI.updateTimes(
+
+        return TimeControl.timeUI.updateTimes(
             TimeControl.startTime,
             TimeControl.endTime,
             TimeControl.currentTime
         )
-        return true
     },
     setLayerTime: function (layer, startTime, endTime) {
         if (typeof layer == 'string') {

--- a/src/essence/Ancillary/TimeUI.js
+++ b/src/essence/Ancillary/TimeUI.js
@@ -866,25 +866,57 @@ const TimeUI = {
         let date
 
         // Start
+        let offsetStartDate = null
+        let parsedStart = null
         if (start != null) {
             date = new Date(start)
-            const offsetStartDate = TimeUI.addOffset(date)
-            const parsedStart = TimeUI.startTempus.dates.parseInput(
+            offsetStartDate = TimeUI.addOffset(date)
+            parsedStart = TimeUI.startTempus.dates.parseInput(
                 new Date(offsetStartDate)
             )
+        }
+        // End
+        let offsetEndDate = null
+        let parsedEnd = null
+        if (end != null) {
+            date = new Date(end)
+            offsetEndDate = new Date(
+                date.getTime() + date.getTimezoneOffset() * 60000
+            )
+            parsedEnd = TimeUI.endTempus.dates.parseInput(
+                new Date(offsetEndDate)
+            )
+        }
+
+        if (parsedStart != null && parsedEnd != null) {
+            if (offsetStartDate.getTime() > offsetEndDate.getTime()) {
+                console.warn(
+                    `updateTimes: Cannot set start time after end time. ${parsedStart} > ${parseEnd}`
+                )
+                return false
+            }
+        }
+
+        if (parsedStart != null) {
+            TimeUI.endTempus.updateOptions({
+                restrictions: {
+                    minDate: parsedStart,
+                },
+            })
+        }
+        if (parsedEnd != null) {
+            TimeUI.startTempus.updateOptions({
+                restrictions: {
+                    maxDate: parsedEnd,
+                },
+            })
+        }
+
+        if (parsedStart) {
             TimeUI.startTempus.dontChangeNext = true
             TimeUI.startTempus.dates.setValue(parsedStart)
         }
-
-        // End
-        if (end != null) {
-            date = new Date(end)
-            const offsetEndDate = new Date(
-                date.getTime() + date.getTimezoneOffset() * 60000
-            )
-            const parsedEnd = TimeUI.endTempus.dates.parseInput(
-                new Date(offsetEndDate)
-            )
+        if (parsedEnd) {
             TimeUI.endTempus.dontChangeNext = true
             TimeUI.endTempus.dates.setValue(parsedEnd)
         }
@@ -896,6 +928,7 @@ const TimeUI = {
         }
 
         TimeUI.change()
+        return true
     },
     setStartTime(
         ISOString,


### PR DESCRIPTION
Closes #519 

Issue was that the Timeline had min/max date restrictions so that the end time can never be before the start time or vice versa. So, for instance if the `current start time = 1` and the `current end time = 2`, then `mmgisAPI.setTime(3, 4)` would silently fail to set the start time because it occurs after the existing end time.

Solution was to update the time restrictions before finally setting the times.