### PR TITLE
#518 time={starttime} in a WMS URL is filled with endtime

### DIFF
--- a/src/essence/Basics/Layers_/leaflet-tilelayer-middleware.js
+++ b/src/essence/Basics/Layers_/leaflet-tilelayer-middleware.js
@@ -25,8 +25,25 @@ var colorFilterExtension = {
             .replace(/{starttime}/g, this.options.starttime)
             .replace(/{endtime}/g, this.options.endtime)
         if (this.options.time && this.options.tileFormat === 'tms') {
-            url += `?starttime=${this.options.starttime}&time=${this.options.endtime}`
-            if (this.options.compositeTile === true) url += `&composite=true`
+            let paramDelimiter = '?'
+            let urlParams = {}
+            if (url.indexOf('?') !== -1) {
+                urlParams = new URLSearchParams(url.split('?')[1])
+                paramDelimiter = '&'
+            }
+
+            if (!urlParams.has('starttime')) {
+                url += `${paramDelimiter}starttime=${this.options.starttime}`
+                paramDelimiter = '&'
+            }
+            if (!urlParams.has('time')) {
+                url += `${paramDelimiter}time=${this.options.endtime}`
+                paramDelimiter = '&'
+            }
+            if (!urlParams.has('composite')) {
+                if (this.options.compositeTile === true)
+                    url += `&${paramDelimiter}omposite=true`
+            }
         }
         return url
     },

--- a/src/essence/Basics/Layers_/leaflet-tilelayer-middleware.js
+++ b/src/essence/Basics/Layers_/leaflet-tilelayer-middleware.js
@@ -26,23 +26,23 @@ var colorFilterExtension = {
             .replace(/{endtime}/g, this.options.endtime)
         if (this.options.time && this.options.tileFormat === 'tms') {
             let paramDelimiter = '?'
-            let urlParams = {}
+            let urlParams = false
             if (url.indexOf('?') !== -1) {
                 urlParams = new URLSearchParams(url.split('?')[1])
                 paramDelimiter = '&'
             }
 
-            if (!urlParams.has('starttime')) {
+            if (urlParams == false || !urlParams.has('starttime')) {
                 url += `${paramDelimiter}starttime=${this.options.starttime}`
                 paramDelimiter = '&'
             }
-            if (!urlParams.has('time')) {
+            if (urlParams == false || !urlParams.has('time')) {
                 url += `${paramDelimiter}time=${this.options.endtime}`
                 paramDelimiter = '&'
             }
-            if (!urlParams.has('composite')) {
+            if (urlParams == false || !urlParams.has('composite')) {
                 if (this.options.compositeTile === true)
-                    url += `&${paramDelimiter}omposite=true`
+                    url += `${paramDelimiter}composite=true`
             }
         }
         return url
@@ -189,15 +189,15 @@ var wmsExtension = {
         uppercase: true,
     },
 
-    initialize: function (url, options) {
+    initialize: function (url, options, wmsOptions) {
         this._url = url
 
         var wmsParams = L.extend({}, this.defaultWmsParams)
 
         // all keys that are not TileLayer options go to WMS params
-        for (var i in options) {
+        for (var i in wmsOptions) {
             if (!(i in this.extensionOptions)) {
-                wmsParams[i] = options[i]
+                wmsParams[i] = wmsOptions[i]
             }
         }
         options = L.setOptions(this, options)
@@ -310,10 +310,11 @@ L.tileLayer.colorFilter = function (url, options) {
                 `WARNING: WMS layer has no "layers" parameter in the url - ${url}`
             )
 
-        return new L.TileLayer.WMSColorFilter(urlBaseString, {
-            ...options,
-            ...wmsOptions,
-        })
+        return new L.TileLayer.WMSColorFilter(
+            urlBaseString,
+            options,
+            wmsOptions
+        )
     }
 
     url = url.replace(/{t}/g, '_time_')


### PR DESCRIPTION
Closes #518 

Issue was that by spread merging WMS layer and WMS options in this commit https://github.com/NASA-AMMOS/MMGIS/commit/22a990164cbe1d98e483ef1af18b95fecdbd2570 in order to pass the proper zoom limit parameters to the layer, the user set URL parameter TIME/time would get overridden by the layer options' `time` (which is always end time).

Given the times:
- startTime= 2024-11-12T00:00Z
- endTime = 2024-11-12T02:00Z
- And a configured layer URL with `time={starttime}`

### Old generated WMS URL:
http://localhost:8889/Missions/Time/Layers/Gale_HiRISE/Gale_HiRISE/16/57775/33618.png
?SERVICE=WMS
&REQUEST=GetMap
&FORMAT=image%2Fpng
&TRANSPARENT=true
&VERSION=1.1.1
&MINZOOM=0
&MAXZOOM=28
&MAXNATIVEZOOM=18
&TILEFORMAT=wms
&TMS=false
&CONTINUOUSWORLD=true
&REUSETILES=true
&BOUNDS=null
&TIMEENABLED=true
**&TIME=2024-11-12T02%3A00%3A00.000Z**
&COMPOSITETILE=false
&STARTTIME=2024-11-12T00%3A00%3A00.000Z
&ENDTIME=  2024-11-12T02%3A00%3A00.000Z
&VARIABLES=%5Bobject%20Object%5D
&LAYERS=luna_sun_2024
&TIME=2024-11-12T00%3A00%3A00Z
&HEIGHT=256
&WIDTH=256
&SRS=EPSG%3A3857
&BBOX=15291686.130619224,-520383.28856547945,15292297.626845505,-519771.7923391975

### New generated WMS URL:
http://localhost:8889/Missions/Time/Layers/Gale_HiRISE/Gale_HiRISE/16/57775/33618.png
?SERVICE=WMS
&REQUEST=GetMap
&FORMAT=image%2Fpng
&TRANSPARENT=true
&VERSION=1.1.1
&LAYERS=luna_sun_2024
**&TIME=2024-11-12T00%3A00%3A00Z**
&HEIGHT=256
&WIDTH=256
&SRS=EPSG%3A3857
&BBOX=15291686.130619224,-520383.28856547945,15292297.626845505,-519771.7923391975

_Note that the Old TIME parameter is hour 2 (the end time) instead of the proper New TIME parameter being hour 0 (the start time). Also cleans up the mistakenly added extra WMS parameters._