### PR TITLE
#525 Make dynamicExtent requery timeEnabled aware.

### DIFF
--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -784,10 +784,11 @@ async function makeVectorLayer(
                 add,
                 (f) => {
                     Map_.map.on('moveend', f)
-                    L_.subscribeTimeChange(
-                        `dynamicgeodataset_${layerObj.name}`,
-                        f
-                    )
+                    if (layerObj.time?.enabled === true)
+                        L_.subscribeTimeChange(
+                            `dynamicgeodataset_${layerObj.name}`,
+                            f
+                        )
                     L_.subscribeOnSpecificLayerToggle(
                         `dynamicgeodataset_${layerObj.name}`,
                         layerObj.name,

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -784,7 +784,10 @@ async function makeVectorLayer(
                 add,
                 (f) => {
                     Map_.map.on('moveend', f)
-                    if (layerObj.time?.enabled === true)
+                    if (
+                        layerObj.time?.enabled === true &&
+                        layerObj.controlled !== true
+                    )
                         L_.subscribeTimeChange(
                             `dynamicgeodataset_${layerObj.name}`,
                             f


### PR DESCRIPTION
Closes #525

On dynamicExtent vector layers that are:
- time-enabled
- and uncontrolled
requery when the times change.