### PR TITLE
Added downloadURL variable to allow users to download raster layers #546

### DIFF
--- a/docs/pages/Configure/Layers/Data/Data.md
+++ b/docs/pages/Configure/Layers/Data/Data.md
@@ -79,6 +79,7 @@ Data layers need a configured `shader` raw variable to be effective. Supported s
   - ramps: An array of arrays of hex color strings. "transparent" is a special keyword for a fully transparent ramp color.
 - "image": (Default) Simply shows the underlying raw data in an image form. Mainly for testing, it can also be useful for development for internal pass-tile-canvas-instead-of-url layers.
 
+
 Example:
 
 ```javascript
@@ -97,6 +98,9 @@ Example:
                 "#0000FF"
             ]
         ]
-    }
+    },
+    "downloadURL": "(str) url_to_data/data.tif"
 }
 ```
+
+- `downloadURL`: Provides a menu option for users to download the specified source data file for the layer.

--- a/docs/pages/Configure/Layers/Tile/Tile.md
+++ b/docs/pages/Configure/Layers/Tile/Tile.md
@@ -115,6 +115,7 @@ Example:
           "value_in_response_to_replace_with.use.dot.notation.to.traverse.objects",
       },
     },
+    "downloadURL": "(str) url_to_data/data.tif",
     "tools": {
       "measure": {
         "layerDems": [
@@ -141,3 +142,4 @@ Example:
 
 - `shortcutSuffix`: A single letter to 'ALT + {letter}' toggle the layer on and off. Please verify that your chosen shortcut does not conflict with other system or browser-level keyboard shortcuts.
 - `urlReplacements`: For the case where parts or all of a tileset's url comes from intermediary endpoints. For example a service may require sending a query to a server that then returns a uuid and that uuid is required in the tileset's url to query it.
+- `downloadURL`: Provides a menu option for users to download the specified source data file for the layer.

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -300,23 +300,26 @@ function interfaceWithMMGIS(fromInit) {
                         '</ul>',
                     ].join('\n')
                     break
+                case 'data':
+                case 'tile':
+                    layerExport = ''
+                    // Add download URL for raster layers
+                    if(node[i].hasOwnProperty('variables')) {
+                        if(node[i].variables.hasOwnProperty('downloadURL')) {
+                            layerExport = [
+                                '<ul>',
+                                    '<li>',
+                                        '<div class="layersToolExportSourceGeoJSON">',
+                                            `<div><a href="` + node[i].variables.downloadURL + `" target="_blank">Download Data</a></div>`,
+                                        '</div>',
+                                    '</li>',
+                                '</ul>',
+                            ].join('\n')
+                        }
+                    }
+                    break 
                 default:
                     layerExport = ''
-            }
-
-            // Add download URL for raster layers
-            if(node[i].hasOwnProperty('variables')) {
-                if(node[i].variables.hasOwnProperty('downloadURL')) {
-                    layerExport = [
-                        '<ul>',
-                            '<li>',
-                                '<div class="layersToolExportSourceGeoJSON">',
-                                    `<div><a href="` + node[i].variables.downloadURL + `" target="_blank">Download Data</a></div>`,
-                                '</div>',
-                            '</li>',
-                        '</ul>',
-                    ].join('\n')
-                }
             }
 
             // Build timeDisplay

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -304,6 +304,21 @@ function interfaceWithMMGIS(fromInit) {
                     layerExport = ''
             }
 
+            // Add download URL for raster layers
+            if(node[i].hasOwnProperty('variables')) {
+                if(node[i].variables.hasOwnProperty('downloadURL')) {
+                    layerExport = [
+                        '<ul>',
+                            '<li>',
+                                '<div class="layersToolExportSourceGeoJSON">',
+                                    `<div><a href="` + node[i].variables.downloadURL + `" target="_blank">Download Data</a></div>`,
+                                '</div>',
+                            '</li>',
+                        '</ul>',
+                    ].join('\n')
+                }
+            }
+
             // Build timeDisplay
             var timeDisplay = ''
             if (node[i].time != null) {


### PR DESCRIPTION
## Purpose
- Mission has a need to allow users to download the source data file (e.g. GeoTIFF) for raster layers
## Proposed Changes
- Added downloadURL variable to allow users to download raster layers from the Layer Tool
## Issues
- #546 Implement a way to download the source data for raster layers 
## Testing
- Configured several layers with the downloadURL variable, download button shows up next to the layer in the tool, source file is able to be downloaded.