### PR TITLE
Enabled scalefactor and improved text readout for Identifier tool

### DIFF
--- a/docs/pages/Tools/Identifier/Identifier.md
+++ b/docs/pages/Tools/Identifier/Identifier.md
@@ -19,6 +19,7 @@ The following is an example of the Sites Tool's Tool Tab configuration:
         "url": "(str) path_to_data/data.tif",
         "bands": "(int) how many bands to query from",
         "sigfigs": "(int) how many digits after the decimal",
+        "scalefactor": "(float) number to multiply value",
         "unit": "(str) whatever string unit",
         "timeFormat": "(str) for formatting injected '{starttime}' and '{endtime}' in url."
     },
@@ -30,5 +31,6 @@ The following is an example of the Sites Tool's Tool Tab configuration:
 - `url`: This can be a relative path to a file under the Mission name or a full url path. The former is preferred is the file is large. Can use '{starttime}' and '{endtime}' if the layer is time enabled.
 - `bands`: Allows you to specify how many bands to return data from. Default is 1.
 - `sigfigs`: Sets the decimal precision.
+- `scalefactor`: A float number that will multiply the value to scale.
 - `unit`: A string that is appended to your returned value. e.g. " m" would be appended on a raw value ("41") and show "41 m". If it was "m", it would return "41m", without a space.
 - `timeFormat`: A string for formatting the injected '{starttime}' and '{endtime}' in the url. See syntax in https://d3js.org/d3-time-format#locale_format

--- a/src/essence/Tools/Identifier/IdentifierTool.js
+++ b/src/essence/Tools/Identifier/IdentifierTool.js
@@ -34,6 +34,7 @@ var IdentifierTool = {
         //Get tool variables and UI adjustments
         this.justification = L_.getToolVars('identifier')['justification']
         var toolContent = d3.select('#toolSeparated_Identifier')
+        toolContent.style('bottom', '2px')
 
         if (this.justification == 'right') {
             var toolController = d3.select('#toolcontroller_sepdiv')
@@ -351,17 +352,25 @@ var IdentifierTool = {
                                             var valueParsed =
                                                 parseValue(
                                                     value[v][1],
-                                                    d2.sigfigs
+                                                    d2.sigfigs,
+                                                    d2.scalefactor
                                                 ) +
                                                 '' +
                                                 unit
 
-                                            htmlValues +=
-                                                '<div style="display: flex; justify-content: space-between;"><div style="margin-right: 15px; color: var(--color-a5); font-size: 12px;">' +
-                                                value[v][0] +
-                                                '</div><div style="color: var(--color-a6); font-size: 14px;">' +
-                                                valueParsed +
-                                                '</div></div>'
+                                            if (value.length > 1) {
+                                                htmlValues +=
+                                                    '<div style="display: flex; justify-content: space-between;"><div style="margin-right: 15px; color: var(--color-a5); font-size: 12px;">' +
+                                                    value[v][0] +
+                                                    '</div><div style="color: var(--color-a6); font-size: 14px;">' +
+                                                    valueParsed +
+                                                    '</div></div>'
+                                            } else {
+                                                htmlValues +=
+                                                    '<div style="display: flex; justify-content: space-between;"><div style="color: var(--color-a6); font-size: 16px;">' +
+                                                    valueParsed +
+                                                    '</div></div>'
+                                            }
                                             cnt++
                                         }
                                         $(
@@ -441,7 +450,7 @@ var IdentifierTool = {
             }, 150)
         }
 
-        function parseValue(v, sigfigs) {
+        function parseValue(v, sigfigs, scalefactor) {
             var ed = 10
             if (typeof v === 'string') {
                 return v
@@ -450,6 +459,7 @@ var IdentifierTool = {
                 return v
             } else if (v.toString().indexOf('e') != -1) {
                 if (sigfigs != undefined) ed = sigfigs
+                if (scalefactor != undefined) v = v * parseFloat(scalefactor)
                 v = parseFloat(v)
                 return v.toExponential(ed)
             } else {
@@ -457,6 +467,7 @@ var IdentifierTool = {
                 var decPlacesBefore = decSplit[0] ? decSplit[0].length : 0
                 var decPlacesAfter = decSplit[1] ? decSplit[1].length : 0
                 if (decPlacesBefore <= 5) {
+                    if (scalefactor != undefined) v = v * parseFloat(scalefactor)
                     if (sigfigs != undefined) v = v.toFixed(sigfigs)
                 }
                 v = parseFloat(v)


### PR DESCRIPTION
## Purpose
- Improvements to the Identifier tool to allow a scale factor for specified layers and better text alignment in data readouts.
## Proposed Changes
- Add support for a "scalefactor" Identifier tool variable.
- Change data readout when there is just a single band value.
## Issues
- Consistent text alignment in Identifier Tool readouts #555
- Apply scale factor to Identifier Tool source data readouts #556
## Testing
- Added scalefactor to a few layers and tested existing layers without new variable.
- Viewed text readouts to ensure data accuracy