### PR TITLE
#568 fix Deeplink to selected point or polygon

### DIFF
--- a/docs/pages/Configure/Layers/Vector/Vector.md
+++ b/docs/pages/Configure/Layers/Vector/Vector.md
@@ -127,6 +127,7 @@ Example:
 ```javascript
 {
     "useKeyAsName": "propKey || [propKey1, propKey2, ...]",
+    "useKeyAsId": "propKey",
     "dynamicExtent": false,
     "dynamicExtentMoveThreshold": "100000000/z",
     "shortcutSuffix": "single letter to 'ATL + {letter}' toggle the layer on and off",
@@ -257,6 +258,7 @@ Example:
 ```
 
 - `useKeyAsName`: The property key whose value should be the hover text of each feature. If left unset, the hover key and value will be the first one listed in the feature's properties. This may also be an array of keys.
+- `useKeyAsId`: In the case of deeplinking to certain features, a properties key/field name is needed that points to a unique id in order to reselect it.
 - `dynamicExtent`: If true, tries to only query the vector features present in the user's current map viewport. Pan and zooming causes requeries. If used with a geodataset, the time and extent queries will work out-of-the-box. Otherwise, if using an external server, the following parameters in `{}` will be automatically replaced on query in the url: `starttime={starttime}&endtime={endtime}&startprop={startprop}&endprop={endprop}&crscode={crscode}&zoom={zoom}&minx={minx}&miny={miny}&maxx={maxx}&maxy={maxy}`
 - `dynamicExtentMoveThreshold`: If `dynamicExtent` is true, only requery if the map was panned past the stated threshold. Unit is in meters. If a zoom-dependent threshold is desired, set this value to a string ending in `/z`. This will then internally use `dynamicExtentMoveThreshold / Math.pow(2, zoom)` as the threshold value.
 - `shortcutSuffix`: A single letter to 'ALT + {letter}' toggle the layer on and off. Please verify that your chosen shortcut does not conflict with other system or browser-level keyboard shortcuts.

--- a/src/essence/Ancillary/QueryURL.js
+++ b/src/essence/Ancillary/QueryURL.js
@@ -360,17 +360,6 @@ var QueryURL = {
         if (L_.lastActiveFeature.layerName != null) {
             if (L_.layers.on[L_.lastActiveFeature.layerName])
                 if (
-                    L_.lastActiveFeature.lat != null &&
-                    L_.lastActiveFeature.lon != null
-                )
-                    urlAppendage +=
-                        '&selected=' +
-                        L_.lastActiveFeature.layerName +
-                        ',' +
-                        L_.lastActiveFeature.lat +
-                        ',' +
-                        L_.lastActiveFeature.lon
-                else if (
                     L_.lastActiveFeature.key != null &&
                     L_.lastActiveFeature.value != null
                 ) {
@@ -381,7 +370,17 @@ var QueryURL = {
                         L_.lastActiveFeature.key +
                         ',' +
                         L_.lastActiveFeature.value
-                }
+                } else if (
+                    L_.lastActiveFeature.lat != null &&
+                    L_.lastActiveFeature.lon != null
+                )
+                    urlAppendage +=
+                        '&selected=' +
+                        L_.lastActiveFeature.layerName +
+                        ',' +
+                        L_.lastActiveFeature.lat +
+                        ',' +
+                        L_.lastActiveFeature.lon
         }
 
         //viewer

--- a/src/essence/Ancillary/QueryURL.js
+++ b/src/essence/Ancillary/QueryURL.js
@@ -357,15 +357,31 @@ var QueryURL = {
         if (layersOnString.length > 0) urlAppendage += '&on=' + layersOnString
 
         //selected
-        if (L_.lastActivePoint.layerName != null) {
-            if (L_.layers.on[L_.lastActivePoint.layerName])
-                urlAppendage +=
-                    '&selected=' +
-                    L_.lastActivePoint.layerName +
-                    ',' +
-                    L_.lastActivePoint.lat +
-                    ',' +
-                    L_.lastActivePoint.lon
+        if (L_.lastActiveFeature.layerName != null) {
+            if (L_.layers.on[L_.lastActiveFeature.layerName])
+                if (
+                    L_.lastActiveFeature.lat != null &&
+                    L_.lastActiveFeature.lon != null
+                )
+                    urlAppendage +=
+                        '&selected=' +
+                        L_.lastActiveFeature.layerName +
+                        ',' +
+                        L_.lastActiveFeature.lat +
+                        ',' +
+                        L_.lastActiveFeature.lon
+                else if (
+                    L_.lastActiveFeature.key != null &&
+                    L_.lastActiveFeature.value != null
+                ) {
+                    urlAppendage +=
+                        '&selected=' +
+                        L_.lastActiveFeature.layerName +
+                        ',' +
+                        L_.lastActiveFeature.key +
+                        ',' +
+                        L_.lastActiveFeature.value
+                }
         }
 
         //viewer

--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -61,10 +61,13 @@ const L_ = {
     toolsLoaded: false,
     addedfiles: {}, //filename -> null (not null if added)
     activeFeature: null,
-    lastActivePoint: {
+    lastActiveFeature: {
         layerName: null,
+        type: null, // point, line, polygon
         lat: null,
         lon: null,
+        key: null, // if not a point, a property field to a unique value
+        value: null,
     },
     // features manually turned off
     toggledOffFeatures: [],
@@ -128,10 +131,12 @@ const L_ = {
         L_.searchFile = null
         L_.toolsLoaded = false
         L_.activeFeature = null
-        L_.lastActivePoint = {
+        L_.lastActiveFeature = {
             layerName: null,
             lat: null,
             lon: null,
+            key: null,
+            value: null,
         }
     },
     fina: function (
@@ -1004,7 +1009,7 @@ const L_ = {
             }
         else L_.activeFeature = null
 
-        L_.setLastActivePoint(layer)
+        L_.setLastActiveFeature(layer)
         L_.resetLayerFills()
         L_.highlight(layer)
         L_.Map_.activeLayer = layer
@@ -1885,28 +1890,40 @@ const L_ = {
     /**
      * @param {object} layer - leaflet layer object
      */
-    setLastActivePoint: function (layer) {
-        let layerName, lat, lon
+    setLastActiveFeature: function (layer) {
+        let layerName, lat, lon, key, value
         if (layer) {
             layerName = layer.hasOwnProperty('options')
                 ? layer.options.layerName
                 : null
             lat = layer.hasOwnProperty('_latlng') ? layer._latlng.lat : null
             lon = layer.hasOwnProperty('_latlng') ? layer._latlng.lng : null
+
+            if (L_.layers.data[layerName]?.variables?.useKeyAsId) {
+                key = L_.layers.data[layerName].variables.useKeyAsId
+
+                value = F_.getIn(layer.feature.properties, key)
+            }
         }
 
-        if (layerName != null && lat != null && layerName != null) {
-            L_.lastActivePoint = {
+        if (layerName != null && key != null && value != null) {
+            L_.lastActiveFeature = {
+                layerName: layerName,
+                lat: null,
+                lon: null,
+                key: key,
+                value: value,
+            }
+        } else if (layerName != null && lat != null && lon != null) {
+            L_.lastActiveFeature = {
                 layerName: layerName,
                 lat: lat,
                 lon: lon,
+                key: null,
+                value: null,
             }
         } else {
-            L_.lastActivePoint = {
-                layerName: null,
-                lat: null,
-                lon: null,
-            }
+            console.warn('Failed to set Last Active Feature.')
         }
     },
     selectFeature(layerName, feature) {
@@ -2012,6 +2029,8 @@ const L_ = {
                 let g = L_.layers.layer[activePoint.layerUUID]._layers
                 for (let l in g) {
                     if (
+                        g[l]?.feature?.geometry?.type &&
+                        g[l].feature.geometry.type.toLowerCase() === 'point' &&
                         g[l]._latlng.lat == activePoint.lat &&
                         g[l]._latlng.lng == activePoint.lon
                     ) {

--- a/src/essence/Tools/Draw/DrawTool.js
+++ b/src/essence/Tools/Draw/DrawTool.js
@@ -723,7 +723,7 @@ var DrawTool = {
                                         }
                                     }
 
-                                    L_.setLastActivePoint(layer)
+                                    L_.setLastActiveFeature(layer)
                                     L_.resetLayerFills()
                                     L_.highlight(layer)
                                     Map_.activeLayer = layer


### PR DESCRIPTION
- Adds better field checking for points
- Adds vector raw-variable `useKeyAsId` to help select unique features. (Point feature's were working based on lat,lng but passing all latlngs for a polygon in a url is unfeasible) `useKeyAsName` takes precedence over latlng deeplink selections,