### PR TITLE
#570 Info with dynamicExtent

### DIFF
--- a/src/essence/Basics/ToolController_/ToolController_.js
+++ b/src/essence/Basics/ToolController_/ToolController_.js
@@ -43,7 +43,7 @@ let ToolController_ = {
             .attr('id', 'toolcontroller_sepdiv')
             .style('position', 'absolute')
             .style('top', '40px')
-            .style('left', '0px')
+            .style('left', '5px')
             .style('z-index', '1004')
 
         for (let i = 0; i < tools.length; i++) {


### PR DESCRIPTION
If the `info` layer raw variable is used with `dynamicExtent`, then it will use the geodatasets `/search` endpoint to query the necessary metadata.