### PR TITLE
#572 mmgisAPI.getActiveTools

### DIFF
--- a/docs/pages/APIs/JavaScript/Main/Main.md
+++ b/docs/pages/APIs/JavaScript/Main/Main.md
@@ -54,6 +54,7 @@ The `src/essence/mmgisAPI/mmgisAPI.js` file exposes functions that can be called
   - [writeCoordinateURL()](#writecoordinateurl)
   - [onLoaded(onLoadCallback)](#onloadedonloadcallback)
   - [getActiveTool()](#getactivetool)
+  - [getActiveTools()](#getactivetools)
   - [setLoginToken(username, token)](#setlogintoken)
   - [project(lnglat)](#projectlnglat)
   - [unproject(xy)](#unprojectxy)
@@ -829,6 +830,26 @@ The following is an example of how to call the `getActiveTool` function:
 
 ```javascript
 window.mmgisAPI.getActiveTool();
+```
+
+### getActiveTools()
+
+This function returns an object with the currently active tool and the name of the active tool in addition to any active separated tools (such as the Identifier and Legend Tools).
+
+The following is an example of how to call the `getActiveTools` function:
+
+```javascript
+window.mmgisAPI.getActiveTools();
+/* returns (example)
+{
+  activeToolNames: ['InfoTool', 'LegendTool', 'IdentifierTool']
+  activeTools: [
+    {activeTool: {…}, activeToolName: 'InfoTool'},
+    {activeTool: {…}, activeToolName: 'LegendTool'},
+    {activeTool: {…}, activeToolName: 'IdentifierTool'}
+  ]
+}
+*/
 ```
 
 ### initialLogin()

--- a/src/css/mmgis.css
+++ b/src/css/mmgis.css
@@ -306,6 +306,14 @@ body {
 .toolButton:hover {
     background: var(--color-a1-5) !important;
 }
+
+.toolButtonSep.active {
+    color: var(--color-c) !important;
+    border-bottom: 2px solid var(--color-c);
+}
+.toolButtonSep#toolButtonSeparated_Legend.active {
+    border-bottom: none !important;
+}
 .toolButtonSep:hover {
     color: var(--color-c) !important;
 }

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -1169,6 +1169,7 @@ function allLayersLoaded() {
                 ToolController_.toolModules['LegendTool'].make(
                     'toolContentSeparated_Legend'
                 )
+                ToolController_.activeSeparatedTools.push('LegendTool')
                 let _event = new CustomEvent('toggleSeparatedTool', {
                     detail: {
                         toggledToolName: 'LegendTool',

--- a/src/essence/Basics/ToolController_/ToolController_.js
+++ b/src/essence/Basics/ToolController_/ToolController_.js
@@ -10,6 +10,7 @@ let ToolController_ = {
     incToolsDiv: null,
     excToolsDiv: null,
     separatedDiv: null,
+    activeSeparatedTools: [],
     toolModuleNames: [],
     toolModules: toolModules,
     activeTool: null,
@@ -90,11 +91,32 @@ let ToolController_ = {
                                         `${ToolController_.tools[i].name}Tool`
                                     ]
                                 if (tM) {
-                                    if (tM.made === false)
+                                    if (tM.made === false) {
                                         tM.make(
                                             `toolContentSeparated_${ToolController_.tools[i].name}`
                                         )
-                                    else tM.destroy()
+                                        ToolController_.activeSeparatedTools.push(
+                                            ToolController_.tools[i].name +
+                                                'Tool'
+                                        )
+                                        $(
+                                            `#toolButtonSeparated_${tools[i].name}`
+                                        ).addClass('active')
+                                    } else {
+                                        tM.destroy()
+                                        ToolController_.activeSeparatedTools =
+                                            ToolController_.activeSeparatedTools.filter(
+                                                (a) =>
+                                                    a !=
+                                                    ToolController_.tools[i]
+                                                        .name +
+                                                        'Tool'
+                                            )
+
+                                        $(
+                                            `#toolButtonSeparated_${tools[i].name}`
+                                        ).removeClass('active')
+                                    }
 
                                     // Dispatch `toggleSeparatedTool` event
                                     let _event = new CustomEvent(

--- a/src/essence/mmgisAPI/mmgisAPI.js
+++ b/src/essence/mmgisAPI/mmgisAPI.js
@@ -300,6 +300,27 @@ var mmgisAPI_ = {
         }
         return null
     },
+    getActiveTools: function () {
+        if (ToolController_) {
+            const activeTool = mmgisAPI_.getActiveTool()
+            return {
+                activeToolNames: [ToolController_.activeToolName]
+                    .concat(ToolController_.activeSeparatedTools)
+                    .filter(Boolean),
+                activeTools: [activeTool.activeTool != null ? activeTool : null]
+                    .concat(
+                        ToolController_.activeSeparatedTools.map((a) => {
+                            return {
+                                activeTool: ToolController_.getTool(a),
+                                activeToolName: a,
+                            }
+                        })
+                    )
+                    .filter(Boolean),
+            }
+        }
+        return null
+    },
     getLayerConfigs: function (match) {
         if (match) {
             const matchedLayers = {}
@@ -640,6 +661,11 @@ var mmgisAPI = {
      * @returns {object} - The currently active tool and the name of the active tool as an object.
      */
     getActiveTool: mmgisAPI_.getActiveTool,
+
+    /** getActiveTools - returns the currently active tool
+     * @returns {object} - The currently active tool and the name of the active tool as an object.
+     */
+    getActiveTools: mmgisAPI_.getActiveTools,
 
     /** getLayerConfigs - returns an object with the visibility state of all layers
      * @returns {object} - an object containing the visibility state of each layer


### PR DESCRIPTION
Closes #572

Adds:

### getActiveTools()

This function returns an object with the currently active tool and the name of the active tool in addition to any active separated tools (such as the Identifier and Legend Tools).

The following is an example of how to call the `getActiveTools` function:

```javascript
window.mmgisAPI.getActiveTools();
/* returns (example)
{
  activeToolNames: ['InfoTool', 'LegendTool', 'IdentifierTool']
  activeTools: [
    {activeTool: {…}, activeToolName: 'InfoTool'},
    {activeTool: {…}, activeToolName: 'LegendTool'},
    {activeTool: {…}, activeToolName: 'IdentifierTool'}
  ]
}
*/
```

Also colors the separated Identifier Button to indicate to users that it's active.