### PR TITLE
#602 Support HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .env
 
 /node_modules/
+/ssl/*
+!/ssl/.gitkeep
 /API/logs/*
 /Missions/*
 !/Missions/.gitkeep

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -9,6 +9,7 @@ services:
     restart: on-failure
     volumes:
       - ./Missions:/usr/src/app/Missions
+      - ./ssl:/usr/src/app/ssl
 
   stac-fastapi:
     image: ghcr.io/stac-utils/stac-fastapi-pgstac:3.0.0

--- a/docs/pages/Setup/ENVs/ENVs.md
+++ b/docs/pages/Setup/ENVs/ENVs.md
@@ -64,6 +64,18 @@ Password of Postgres database | string | default `null`
 
 Port to run on | positive integer | default `8888`
 
+#### `HTTPS=`
+
+If true, MMGIS will use an https server with the, now required, `HTTPS_KEY` and `HTTPS_CERT` envs. If false, use a wrapping https proxy server instead and block `PORT` from being public | boolean | false
+
+#### `HTTPS_KEY=`
+
+Relative path to key. If using docker, make sure the key is mounted. Everything under 'ssl/' is gitignored.
+
+#### `HTTPS_CERT=`
+
+Relative path to cert. If using docker, make sure the cert is mounted. Everything under 'ssl/' is gitignored.
+
 #### `DB_POOL_MAX=`
 
 Max number connections in the database's pool. CPUs \* 4 is a good number | integer | default `10`

--- a/docs/pages/Setup/ENVs/ENVs.md
+++ b/docs/pages/Setup/ENVs/ENVs.md
@@ -70,11 +70,11 @@ If true, MMGIS will use an https server with the, now required, `HTTPS_KEY` and 
 
 #### `HTTPS_KEY=`
 
-Relative path to key. If using docker, make sure the key is mounted. Everything under 'ssl/' is gitignored.
+Relative path to key. If using docker, make sure the key is mounted. Everything under './ssl/' is gitignored and './ssl/' is mounted into docker.
 
 #### `HTTPS_CERT=`
 
-Relative path to cert. If using docker, make sure the cert is mounted. Everything under 'ssl/' is gitignored.
+Relative path to cert. If using docker, make sure the cert is mounted. Everything under './ssl/' is gitignored and './ssl/' is mounted into docker.
 
 #### `DB_POOL_MAX=`
 

--- a/sample.env
+++ b/sample.env
@@ -23,11 +23,11 @@ NODE_ENV=development
 # If false, use a wrapping https proxy server instead and block PORT from being public
 HTTPS=false
 
-# Relative path to key. If using docker, make sure the key is mounted. Everything under 'ssl/' is gitignored.
-HTTPS_KEY='ssl/sample-key.pem'
+# Relative path to key. If using docker, make sure the key is mounted.Everything under './ssl/' is gitignored and './ssl/' is mounted into docker.
+HTTPS_KEY='ssl/sample.key'
 
-# Relative path to cert. If using docker, make sure the cert is mounted. Everything under 'ssl/' is gitignored.
-HTTPS_CERT='ssl/sample-cert.cert'
+# Relative path to cert. If using docker, make sure the cert is mounted. Everything under './ssl/' is gitignored and './ssl/' is mounted into docker.
+HTTPS_CERT='ssl/sample.cert'
 
 
 # SECRET

--- a/sample.env
+++ b/sample.env
@@ -2,9 +2,11 @@
 
 # SERVER - node || apache(deprecated)
 SERVER=node
+
 # PORT
 # In development mode only, PORT+1 will also be used for the main site
 PORT=8888
+
 # AUTH - off || none || local || csso
 # off: No authentication. Users cannot sign up or log in. Tools that require log in will not work.
 # none: No authentication. Users can still sign up and log in from within MMGIS
@@ -12,8 +14,22 @@ PORT=8888
 #   (does not work in dev env/build first and npm run start:prod)
 # csso: Use a Cloud Single Sign On service that's proxied in front of MMGIS   
 AUTH=none
+
 # NODE_ENV - development || production
 NODE_ENV=development
+
+# HTTPS - true || false
+# If true, MMGIS will use an https server with the, now required, HTTPS_KEY and HTTPS_CERT envs.
+# If false, use a wrapping https proxy server instead and block PORT from being public
+HTTPS=false
+
+# Relative path to key. If using docker, make sure the key is mounted. Everything under 'ssl/' is gitignored.
+HTTPS_KEY='ssl/sample-key.pem'
+
+# Relative path to cert. If using docker, make sure the cert is mounted. Everything under 'ssl/' is gitignored.
+HTTPS_CERT='ssl/sample-cert.cert'
+
+
 # SECRET
 SECRET=aSecretKey
 

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -2,6 +2,7 @@ require("dotenv").config();
 
 const fs = require("fs");
 const http = require("http");
+const https = require("https");
 const { Pool } = require("pg");
 var path = require("path");
 const packagejson = require("../package.json");
@@ -881,7 +882,16 @@ setups.getBackendSetups(function (setups) {
   //////Setups Init//////
   setups.init(s);
 
-  const httpServer = http.createServer(app);
+  let httpServer;
+  if (process.env.HTTPS == "true") {
+    httpServer = https.createServer(
+      {
+        key: fs.readFileSync("test/fixtures/keys/agent2-key.pem"),
+        cert: fs.readFileSync("test/fixtures/keys/agent2-cert.cert"),
+      },
+      app
+    );
+  } else httpServer = http.createServer(app);
 
   // Start listening for requests.
   httpServer.listen(port, (err) => {

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -886,8 +886,8 @@ setups.getBackendSetups(function (setups) {
   if (process.env.HTTPS == "true") {
     httpServer = https.createServer(
       {
-        key: fs.readFileSync("test/fixtures/keys/agent2-key.pem"),
-        cert: fs.readFileSync("test/fixtures/keys/agent2-cert.cert"),
+        key: fs.readFileSync(process.env.HTTPS_KEY),
+        cert: fs.readFileSync(process.env.HTTPS_CERT),
       },
       app
     );


### PR DESCRIPTION
Closes #602

### Adds ENVs:

#### `HTTPS=`

If true, MMGIS will use an https server with the, now required, `HTTPS_KEY` and `HTTPS_CERT` envs. If false, use a wrapping https proxy server instead and block `PORT` from being public | boolean | false

#### `HTTPS_KEY=`

Relative path to key. If using docker, make sure the key is mounted. Everything under './ssl/' is gitignored and './ssl/' is mounted into docker.

#### `HTTPS_CERT=`