### PR TITLE
#616 LINK_PREVIEW envs

### DIFF
--- a/configuration/env.js
+++ b/configuration/env.js
@@ -98,6 +98,8 @@ function getClientEnvironment(publicUrl) {
         AUTH: process.env.AUTH,
         VERSION: packagejson.version,
         CLEARANCE_NUMBER: process.env.CLEARANCE_NUMBER,
+        LINK_PREVIEW_TITLE: process.env.LINK_PREVIEW_TITLE,
+        LINK_PREVIEW_DESCRIPTION: process.env.LINK_PREVIEW_DESCRIPTION,
         HOSTS: JSON.stringify({
           scienceIntent: process.env.SCIENCE_INTENT_HOST,
         }),

--- a/docs/pages/Setup/ENVs/ENVs.md
+++ b/docs/pages/Setup/ENVs/ENVs.md
@@ -124,6 +124,14 @@ Overrides ROOT_PATH's use when the client connects via websocket. Websocket url:
 
 Sets a clearance for the website | string | default `CL##-####`
 
+#### `LINK_PREVIEW_TITLE=`
+
+Initial HTML page title. When sharing a link to MMGIS in an application that supports link previews, the title to be used | string | default `MMGIS`
+
+#### `LINK_PREVIEW_DESCRIPTION=`
+
+Initial HTML page description. When sharing a link to MMGIS in an application that supports link previews, the description to be used | string | default `A web-based mapping and localization solution for science operation on planetary missions.`
+
 #### `DISABLE_LINK_SHORTENER=`
 
 If true, users that use the 'Copy Link' feature will receive a full-length deep link. Writing new short links will be disabled but expanding existing ones will still work. | bool | default `false`

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>MMGIS</title>
+    <title>#{LINK_PREVIEW_TITLE}</title>
     <meta charset="utf-8" />
     <link
       id="favicon"
@@ -13,10 +13,7 @@
       content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0"
     />
     <meta name="theme-color" content="#1d1f20" />
-    <meta
-      name="description"
-      content="A web-based mapping and localization solution for science operation on planetary missions."
-    />
+    <meta name="description" content="#{LINK_PREVIEW_DESCRIPTION}" />
     <style>
       html,
       body {
@@ -319,6 +316,8 @@
       </div>
     </div>
     <script>
+      if(document.title.indexOf('LINK_PREVIEW_TITLE') != -1)
+        document.title = "MMGIS";
       const NODE_ENV = "%NODE_ENV%";
       mmgisglobal = {};
       mmgisglobal.name = "MMGIS";

--- a/sample.env
+++ b/sample.env
@@ -70,6 +70,11 @@ WEBSOCKET_ROOT_PATH=
 # Sets a clearance number for the website
 CLEARANCE_NUMBER=
 
+# Initial HTML page title. When sharing a link to MMGIS in an application that supports link previews, the title to be used | string | default `MMGIS`
+LINK_PREVIEW_TITLE=
+# Initial HTML page description. When sharing a link to MMGIS in an application that supports link previews, the description to be used | string | default `A web-based mapping and localization solution for science operation on planetary missions.`
+LINK_PREVIEW_DESCRIPTION=
+
 # If true, users that use the 'Copy Link' feature will receive a full-length deep link.
 # Writing new short links will be disabled but expanding existing ones will still work. default false
 DISABLE_LINK_SHORTENER=false

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -111,7 +111,10 @@ checkBrowsers(paths.appPath, isInteractive)
       );
       fs.writeFileSync(
         path.join(__dirname, "..", "build/index.pug"),
-        html2pug(htmlStr, {})
+        html2pug(htmlStr, {}).replace(
+          "'#{LINK_PREVIEW_DESCRIPTION}'",
+          "LINK_PREVIEW_DESCRIPTION"
+        )
       );
 
       printHostingInstructions(

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -916,7 +916,7 @@ setups.getBackendSetups(function (setups) {
           let permission = "000";
           if (process.env.AUTH === "csso") permission = "001";
           if (req.session.permission) permission = req.session.permission;
-          console.log("process.env.IS_DOCKER", process.env.IS_DOCKER);
+
           const groups = req.groups ? Object.keys(req.groups) : [];
           res.render("../build/index.pug", {
             user: user,
@@ -927,6 +927,10 @@ setups.getBackendSetups(function (setups) {
             VERSION: packagejson.version,
             FORCE_CONFIG_PATH: process.env.FORCE_CONFIG_PATH,
             CLEARANCE_NUMBER: process.env.CLEARANCE_NUMBER,
+            LINK_PREVIEW_TITLE: process.env.LINK_PREVIEW_TITLE || "MMGIS",
+            LINK_PREVIEW_DESCRIPTION:
+              process.env.LINK_PREVIEW_DESCRIPTION ||
+              "A web-based mapping and localization solution for science operation on planetary missions.",
             ENABLE_MMGIS_WEBSOCKETS: process.env.ENABLE_MMGIS_WEBSOCKETS,
             MAIN_MISSION: process.env.MAIN_MISSION,
             IS_DOCKER: process.env.IS_DOCKER,


### PR DESCRIPTION
Closes #616 

Adds the following new ENVs:

#### `LINK_PREVIEW_TITLE=`

Initial HTML page title. When sharing a link to MMGIS in an application that supports link previews, the title to be used | string | default `MMGIS`

#### `LINK_PREVIEW_DESCRIPTION=`

Initial HTML page description. When sharing a link to MMGIS in an application that supports link previews, the description to be used | string | default `A web-based mapping and localization solution for science operation on planetary missions.`


Previews only work in production build.