### PR TITLE
#628 configure-beta defaults and cleaned layer objects

### DIFF
--- a/configure/src/components/Tabs/Layers/Modals/LayerModal/LayerModal.js
+++ b/configure/src/components/Tabs/Layers/Modals/LayerModal/LayerModal.js
@@ -5,6 +5,8 @@ import {
   getLayerByUUID,
   traverseLayers,
   insertLayerAfterUUID,
+  getIn,
+  setIn,
 } from "../../../../../core/utils";
 
 import {
@@ -160,11 +162,6 @@ const LayerModal = (props) => {
 
   const dispatch = useDispatch();
 
-  const handleClose = () => {
-    // close modal
-    dispatch(setModal({ name: MODAL_NAME, on: false }));
-  };
-
   let config = {};
   switch (layer.type) {
     case "data":
@@ -204,6 +201,84 @@ const LayerModal = (props) => {
   }
 
   config = inject(config);
+
+  const handleClose = () => {
+    const nextConfiguration = JSON.parse(JSON.stringify(configuration));
+    traverseLayers(nextConfiguration.layers, (l, path, index) => {
+      if (layer.uuid === l.uuid) {
+        // We're repopulating all the layers values to trim it exactly to its spec
+        // (otherwise defaults may be missing and switching layer types would mix parameters)
+        let completedLayer = {
+          uuid: l.uuid,
+          sublayers: l.sublayers || [],
+        };
+        config.tabs.forEach((t) => {
+          t.rows.forEach((r) => {
+            r.components.forEach((c) => {
+              // Skip non-field components (such as the map)
+              if (c.field == null) return;
+
+              const currentValue = getIn(l, c.field.split("."), null);
+              if (currentValue != null)
+                setIn(completedLayer, c.field.split("."), currentValue, true);
+
+              if (c.type === "dropdown" || c.type === "colordropdown") {
+                const currentValue = getIn(l, c.field);
+                if (currentValue == null) {
+                  setIn(completedLayer, c.field.split("."), c.options[0], true);
+                }
+              } else if (c.type === "checkbox" || c.type === "switch") {
+                const currentValue = getIn(l, c.field);
+                if (currentValue == null && c.defaultChecked != null) {
+                  setIn(
+                    completedLayer,
+                    c.field.split("."),
+                    c.defaultChecked,
+                    true
+                  );
+                }
+              } else if (c.type === "slider") {
+                const currentValue = getIn(l, c.field);
+                if (currentValue == null && c.default != null) {
+                  setIn(
+                    completedLayer,
+                    c.field.split("."),
+                    c.default || c.min || 0,
+                    true
+                  );
+                }
+              } else if (c.type === "colorpicker") {
+                const currentValue = getIn(l, c.field);
+                if (currentValue == null) {
+                  setIn(
+                    completedLayer,
+                    c.field.split("."),
+                    c.default || "#FFFFFF",
+                    true
+                  );
+                }
+              }
+            });
+          });
+        });
+
+        // Clear and copy while maintaining reference
+        Object.keys(l).forEach((key) => {
+          delete l[key];
+        });
+        // Setting these here just so that the show up first in the object
+        l.name = completedLayer.name;
+        l.uuid = completedLayer.uuid;
+        Object.keys(completedLayer).forEach((key) => {
+          l[key] = completedLayer[key];
+        });
+      }
+    });
+    dispatch(setConfiguration(nextConfiguration));
+
+    // close modal
+    dispatch(setModal({ name: MODAL_NAME, on: false }));
+  };
 
   return (
     <Dialog

--- a/configure/src/core/Maker.js
+++ b/configure/src/core/Maker.js
@@ -538,11 +538,19 @@ const getComponent = (
         <Box>
           <Grid container spacing={2} className={c.slider}>
             <Typography className={c.sliderName} id="input-slider" gutterBottom>
-              {com.name}
+              {`${com.name} (${
+                value != null
+                  ? value
+                  : getIn(directConf, com.field, com.default || "")
+              })`}
             </Typography>
             <Grid item xs style={{ margin: "0px 10px" }}>
               <Slider
-                value={value != null ? value : getIn(directConf, com.field, "")}
+                value={
+                  value != null
+                    ? value
+                    : getIn(directConf, com.field, com.default || "")
+                }
                 onChange={(e) => {
                   let v = e.target.value;
                   const min = com.min != null ? com.min : -Infinity;
@@ -716,10 +724,18 @@ const getComponent = (
       );
     case "colorpicker":
       let color;
-      if (tool) color = getIn(tool, com.field.split("."), { hex: "#000000" });
+      if (tool)
+        color = getIn(tool, com.field.split("."), {
+          hex: com.default || "#FFFFFF",
+        });
       else if (layer)
-        color = getIn(layer, com.field.split("."), { hex: "#000000" });
-      else color = getIn(directConf, com.field.split("."), { hex: "#000000" });
+        color = getIn(layer, com.field.split("."), {
+          hex: com.default || "#FFFFFF",
+        });
+      else
+        color = getIn(directConf, com.field.split("."), {
+          hex: com.default || "#FFFFFF",
+        });
 
       inner = (
         <ColorButton

--- a/configure/src/metaconfigs/layer-vector-config.json
+++ b/configure/src/metaconfigs/layer-vector-config.json
@@ -126,6 +126,7 @@
               "name": "Color",
               "description": "The border color of each feature. If the feature is a line, this field is the color of the line.",
               "type": "colorpicker",
+              "default": "#FFFFFF",
               "width": 2
             },
             {
@@ -140,6 +141,7 @@
               "name": "Opacity",
               "description": "Stroke Opacity",
               "type": "slider",
+              "default": 1,
               "min": 0,
               "max": 1,
               "step": 0.01,
@@ -161,6 +163,7 @@
               "name": "Fill Color",
               "description": "Fill Color",
               "type": "colorpicker",
+              "default": "#FFFFFF",
               "width": 2
             },
             {
@@ -175,6 +178,7 @@
               "name": "Fill Opacity",
               "description": "Fill Opacity",
               "type": "slider",
+              "default": 0.8,
               "min": 0,
               "max": 1,
               "step": 0.01,
@@ -196,6 +200,7 @@
               "name": "Weight",
               "description": "Stroke weight in pixels of point features.",
               "type": "slider",
+              "default": 2,
               "min": 0,
               "max": 16,
               "step": 1,
@@ -213,6 +218,7 @@
               "name": "Radius",
               "description": "Radius in pixels of point features.",
               "type": "slider",
+              "default": 6,
               "min": 0,
               "max": 32,
               "step": 1,


### PR DESCRIPTION
Closes #628

Repopulate all the layer object values to trim it exactly to its spec so the defaults are not missing and switching layer types does not mix parameters.