### PR TITLE
Avoid aggressively trimming white space in text boxes in configure-beta

### DIFF
--- a/configure/src/core/Maker.js
+++ b/configure/src/core/Maker.js
@@ -256,10 +256,46 @@ const getComponent = (
           }}
           value={value != null ? value : getIn(directConf, com.field, "")}
           onChange={(e) => {
+            updateConfiguration(forceField || com.field, e.target.value, layer);
+          }}
+          onBlur={(e) => {
             let v = e.target.value;
             // remove surrounding whitespace, " hi " -> "hi"
             if (typeof v === "string") v = v.trim();
             updateConfiguration(forceField || com.field, v, layer);
+          }}
+        />
+      );
+      return (
+        <div>
+          {inlineHelp ? (
+            <>
+              {inner}
+              <div
+                className={c.subtitle2}
+                dangerouslySetInnerHTML={{ __html: com.description || "" }}
+              ></div>
+            </>
+          ) : (
+            <Tooltip title={com.description || ""} placement="top" arrow>
+              {inner}
+            </Tooltip>
+          )}
+        </div>
+      );
+    case "textnotrim":
+      inner = (
+        <TextField
+          className={c.text}
+          label={com.name}
+          variant="filled"
+          size="small"
+          inputProps={{
+            autoComplete: "off",
+          }}
+          value={value != null ? value : getIn(directConf, com.field, "")}
+          onChange={(e) => {
+            updateConfiguration(forceField || com.field, e.target.value, layer);
           }}
         />
       );

--- a/configure/src/metaconfigs/layer-data-config.json
+++ b/configure/src/metaconfigs/layer-data-config.json
@@ -27,7 +27,7 @@
               "field": "name",
               "name": "Layer Name",
               "description": "",
-              "type": "text",
+              "type": "textnotrim",
               "width": 8
             },
             {

--- a/configure/src/metaconfigs/layer-header-config.json
+++ b/configure/src/metaconfigs/layer-header-config.json
@@ -27,7 +27,7 @@
               "field": "name",
               "name": "Layer Name",
               "description": "",
-              "type": "text",
+              "type": "textnotrim",
               "width": 8
             }
           ]

--- a/configure/src/metaconfigs/layer-model-config.json
+++ b/configure/src/metaconfigs/layer-model-config.json
@@ -27,7 +27,7 @@
               "field": "name",
               "name": "Layer Name",
               "description": "A display name for the layer.",
-              "type": "text",
+              "type": "textnotrim",
               "width": 6
             },
             {

--- a/configure/src/metaconfigs/layer-query-config.json
+++ b/configure/src/metaconfigs/layer-query-config.json
@@ -27,7 +27,7 @@
               "field": "name",
               "name": "Layer Name",
               "description": "A display name for the layer.",
-              "type": "text",
+              "type": "textnotrim",
               "width": 6
             },
             {

--- a/configure/src/metaconfigs/layer-tile-config.json
+++ b/configure/src/metaconfigs/layer-tile-config.json
@@ -27,7 +27,7 @@
               "field": "name",
               "name": "Layer Name",
               "description": "",
-              "type": "text",
+              "type": "textnotrim",
               "width": 4
             },
             {
@@ -201,7 +201,7 @@
               "field": "cogUnits",
               "name": "Units",
               "description": "Units string by which to suffix values. For instance if the units are meters, use 'm' so that values are displayed as '100m'.",
-              "type": "text",
+              "type": "textnotrim",
               "width": 2
             },
             {

--- a/configure/src/metaconfigs/layer-vector-config.json
+++ b/configure/src/metaconfigs/layer-vector-config.json
@@ -27,7 +27,7 @@
               "field": "name",
               "name": "Layer Name",
               "description": "A display name for the layer.",
-              "type": "text",
+              "type": "textnotrim",
               "width": 6
             },
             {

--- a/configure/src/metaconfigs/layer-vectortile-config.json
+++ b/configure/src/metaconfigs/layer-vectortile-config.json
@@ -27,7 +27,7 @@
               "field": "name",
               "name": "Layer Name",
               "description": "A display name for the layer.",
-              "type": "text",
+              "type": "textnotrim",
               "width": 6
             },
             {

--- a/configure/src/metaconfigs/layer-velocity-config.json
+++ b/configure/src/metaconfigs/layer-velocity-config.json
@@ -27,7 +27,7 @@
               "field": "name",
               "name": "Layer Name",
               "description": "A display name for the layer.",
-              "type": "text",
+              "type": "textnotrim",
               "width": 6
             },
             {


### PR DESCRIPTION
This fixes the bug for the "text" input box type where it did not allow adding spaces at the end of the text block. This adds a new input type that does not trim whitespace from text boxes in configure-beta. For now, we want to allow white spaces for layer names and units.