### PR TITLE
#634 Fix empty Draw over/under history list SQL replacements

### DIFF
--- a/API/Backend/Draw/routes/draw.js
+++ b/API/Backend/Draw/routes/draw.js
@@ -204,7 +204,7 @@ const clipOver = function (
           historyIndex: lastHistory[0].history_id + 1,
           history: lastHistory[0].history,
         };
-      } else return { historyIndex: 0, history: [] };
+      } else return { historyIndex: 0, history: null };
     })
     .then((historyObj) => {
       let history = historyObj.history;
@@ -335,7 +335,7 @@ const clipUnder = function (
           historyIndex: lastHistory[0].history_id + 1,
           history: lastHistory[0].history,
         };
-      } else return { historyIndex: 0, history: [] };
+      } else return { historyIndex: 0, history: null };
     })
     .then((historyObj) => {
       let history = historyObj.history;


### PR DESCRIPTION
Polygons could not be drawn into new files because sequelize SQL replacements were replacing `history = []` into `(:history)` like `()` (which is invalid SQL). The change was to set empty history arrays to `null` such that `(:history)` then gets replaced to be `(null)`

The affected only Draw Over and Draw Under.

Bug was introduced in #593

Closes #634