### PR TITLE
#639 Support marker bearings with configurable icons

### DIFF
--- a/configure/src/metaconfigs/layer-vector-config.json
+++ b/configure/src/metaconfigs/layer-vector-config.json
@@ -260,7 +260,7 @@
             {
               "field": "style.shapeIcon",
               "name": "Shape From Icon",
-              "description": "Shape but taken from the Material Design Icon (mdi) library. akes priority over the value in the 'shape' field. See <a target='_blank' href='https://pictogrammers.com/library/mdi/'>https://pictogrammers.com/library/mdi/</a>",
+              "description": "Shape but taken from the Material Design Icon (mdi) library. Takes priority over the value in the 'shape' field. See <a target='_blank' href='https://pictogrammers.com/library/mdi/'>https://pictogrammers.com/library/mdi/</a>",
               "type": "text",
               "width": 3
             },
@@ -269,6 +269,13 @@
               "name": "Shape From Property",
               "description": "Shape but taken from each individual feature's property. For example 'shape' or 'path.to.prop.in.properties.object'. Takes priority over the value in the 'shape' and 'shape from icon' fields. Shape values are formatted like the dropdown options but all lowercase. Material Design Icon (mdi) icon names are also supported values.",
               "type": "text",
+              "width": 3
+            },
+            {
+              "field": "style.shapeRotationOffset",
+              "name": "Shape Rotation Offset",
+              "description": "A original offset by which the rotate the original shape/icon so that it is natively pointing up. Useful with Attachment - Marker Bearings where, for instance, a plane with a bearing is desired but the plane icon natively points leftward.",
+              "type": "number",
               "width": 3
             }
           ]
@@ -1156,7 +1163,7 @@
             {
               "field": "variables.markerAttachments.bearing.enabled",
               "name": "Enabled",
-              "description": "Sets a bearing direction (clockwise from north) of this layer's point markers (or markerIcons if set). Overrides the layer's shape dropdown value.",
+              "description": "Sets a bearing direction (clockwise from north) of this layer's point markers (or Shape from Icon or Marker Icons if set). Overrides the layer's shape dropdown value.",
               "type": "switch",
               "width": 3,
               "defaultChecked": false
@@ -1183,7 +1190,7 @@
             {
               "field": "variables.markerAttachments.bearing.color",
               "name": "Color",
-              "description": "A color for the directional arrow for non-markerIcon bearings.",
+              "description": "A color for the directional arrow for non-Shape-from-Icon and non-Marker-Icon bearings.",
               "type": "colorpicker",
               "width": 4
             }

--- a/src/essence/Basics/Layers_/LayerConstructors.js
+++ b/src/essence/Basics/Layers_/LayerConstructors.js
@@ -399,7 +399,13 @@ export const constructVectorLayer = (
                             ((layerObj.style.radius || layerObj.radius || 8) *
                                 2) /
                             24
-                        }); text-shadow:  
+                        }) rotate(${
+                            (layerObj.style.shapeRotationOffset != null
+                                ? parseFloat(layerObj.style.shapeRotationOffset)
+                                : 0) + (yaw || 0)
+                        }deg); ${
+                            layerObj.style.weight != 0
+                                ? `text-shadow:  
                             1px 1px 0px ${featureStyle.color}, 
                             -1px -1px 0px ${featureStyle.color}, 
                             1px -1px 0px ${featureStyle.color}, 
@@ -408,7 +414,9 @@ export const constructVectorLayer = (
                             0px 1px 0px ${featureStyle.color}, 
                             -1px 0px 0px ${featureStyle.color}, 
                             0px -1px 0px ${featureStyle.color}, 
-                            1px 0px 0px ${featureStyle.color};
+                            1px 0px 0px ${featureStyle.color}; `
+                                : ''
+                        }
                             display: block;
                             text-align: center;"
                             ><i class='mdi mdi-${finalShape.replace(


### PR DESCRIPTION
Closes #639

Setting 'Shape from Icon' in the Style tab is also used for marker bearings. Additionally a rotation offset option has been added to better be able to orientate icons.

![45688488888](https://github.com/user-attachments/assets/1f54bf44-3d11-439c-80e3-93d1fabec7bc)
