### PR TITLE
Fix bug with fill min/max when modifying color scale in image layer

### DIFF
--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -1594,7 +1594,8 @@ function interfaceWithMMGIS(fromInit) {
                 layer.currentCogMin == null
                     ? layer.cogMin || 0
                     : layer.currentCogMin,
-                L_.layers.layer[layer.name].currentCogMax)
+                layer.currentCogMax
+            )
         }
         LayersTool.populateCogScale(layer.name)
         LegendTool.refreshLegends()


### PR DESCRIPTION
This fixes a bug in #636, where if the "fill min/max" option was unchecked in the configuration options for image layers, the maximum value display is incorrect when adjusting the color scale values in the LayerTool.