### PR TITLE
Adds ShapeImage and ShapeIcon fields to display custom marker icons in the legend

### DIFF
--- a/configure/src/metaconfigs/layer-vector-config.json
+++ b/configure/src/metaconfigs/layer-vector-config.json
@@ -497,11 +497,18 @@
                   "width": 2
                 },
                 {
+                  "field": "value",
+                  "name": "Label",
+                  "description": "A label description for this legend entry.",
+                  "type": "text",
+                  "width": 8
+                },
+                {
                   "field": "shape",
                   "name": "Shape",
                   "description": "The symbol for which to use for this legend entry. Discreet and continuous describe scales. These scales are broken into groups by a change in shape value. For instance, 'discreet, discreet, discreet, circle, discreet, discreet' represents a discreet scales of three colors, a circle and then a discreet scale of two colors.",
                   "type": "dropdown",
-                  "width": 5,
+                  "width": 4,
                   "options": [
                     "circle",
                     "square",
@@ -512,24 +519,18 @@
                   ]
                 },
                 {
-                  "field": "value",
-                  "name": "Label",
-                  "description": "A label description for this legend entry.",
+                  "field": "shapeIcon",
+                  "name": "Shape From Icon",
+                  "description": "Shape but taken from the Material Design Icon (mdi) library. Takes priority over the value in the 'shape' field. See <a target='_blank' href='https://pictogrammers.com/library/mdi/'>https://pictogrammers.com/library/mdi/</a>",
                   "type": "text",
-                  "width": 3
-                },
-                {
-                  "field": "",
-                  "name": "",
-                  "description": "",
                   "width": 4
                 },
                 {
-                  "field": "shapeOverride",
-                  "name": "Shape Override",
-                  "description": "A URL to a custom symbol for which to use for this legend entry. If the path is relative, it will be relative to the mission's directory. This field will override values in the Shape field.",
+                  "field": "shapeImage",
+                  "name": "Shape From Image",
+                  "description": "A URL to a custom image (.png or .svg) for which to use for this legend entry. If the path is relative, it will be relative to the mission's directory. This field will override values in the Shape and Shape From Icon fields.",
                   "type": "text",
-                  "width": 8
+                  "width": 4
                 }
               ]
             }

--- a/configure/src/metaconfigs/layer-vector-config.json
+++ b/configure/src/metaconfigs/layer-vector-config.json
@@ -528,7 +528,7 @@
                 {
                   "field": "shapeImage",
                   "name": "Shape From Image",
-                  "description": "A URL to a custom image (.png or .svg) for which to use for this legend entry. If the path is relative, it will be relative to the mission's directory. This field will override values in the Shape and Shape From Icon fields.",
+                  "description": "A URL to a custom image (jpeg|jpg|gif|png|svg|webp) for which to use for this legend entry. If the path is relative, it will be relative to the mission's directory. This field will override values in the Shape and Shape From Icon fields.",
                   "type": "text",
                   "width": 4
                 }

--- a/configure/src/metaconfigs/layer-vector-config.json
+++ b/configure/src/metaconfigs/layer-vector-config.json
@@ -499,7 +499,7 @@
                 {
                   "field": "shape",
                   "name": "Shape",
-                  "description": "The symbol for which to us for this legend entry. Discreet and continuous describe scales. These scales are broken into groups by a change in shape value. For instance, 'discreet, discreet, discreet, circle, discreet, discreet' represents a discreet scales of three colors, a circle and then a discreet scale of two colors.",
+                  "description": "The symbol for which to use for this legend entry. Discreet and continuous describe scales. These scales are broken into groups by a change in shape value. For instance, 'discreet, discreet, discreet, circle, discreet, discreet' represents a discreet scales of three colors, a circle and then a discreet scale of two colors.",
                   "type": "dropdown",
                   "width": 5,
                   "options": [
@@ -517,6 +517,19 @@
                   "description": "A label description for this legend entry.",
                   "type": "text",
                   "width": 3
+                },
+                {
+                  "field": "",
+                  "name": "",
+                  "description": "",
+                  "width": 4
+                },
+                {
+                  "field": "shapeOverride",
+                  "name": "Shape Override",
+                  "description": "A URL to a custom symbol for which to use for this legend entry. If the path is relative, it will be relative to the mission's directory. This field will override values in the Shape field.",
+                  "type": "text",
+                  "width": 8
                 }
               ]
             }

--- a/configure/src/metaconfigs/layer-vectortile-config.json
+++ b/configure/src/metaconfigs/layer-vectortile-config.json
@@ -501,7 +501,7 @@
                 {
                   "field": "shapeImage",
                   "name": "Shape From Image",
-                  "description": "A URL to a custom image (.png or .svg) for which to use for this legend entry. If the path is relative, it will be relative to the mission's directory. This field will override values in the Shape and Shape From Icon fields.",
+                  "description": "A URL to a custom image (jpeg|jpg|gif|png|svg|webp) for which to use for this legend entry. If the path is relative, it will be relative to the mission's directory. This field will override values in the Shape and Shape From Icon fields.",
                   "type": "text",
                   "width": 4
                 }

--- a/configure/src/metaconfigs/layer-vectortile-config.json
+++ b/configure/src/metaconfigs/layer-vectortile-config.json
@@ -472,7 +472,7 @@
                 {
                   "field": "shape",
                   "name": "Shape",
-                  "description": "The symbol for which to us for this legend entry. Discreet and continuous describe scales. These scales are broken into groups by a change in shape value. For instance, 'discreet, discreet, discreet, circle, discreet, discreet' represents a discreet scales of three colors, a circle and then a discreet scale of two colors.",
+                  "description": "The symbol for which to use for this legend entry. Discreet and continuous describe scales. These scales are broken into groups by a change in shape value. For instance, 'discreet, discreet, discreet, circle, discreet, discreet' represents a discreet scales of three colors, a circle and then a discreet scale of two colors.",
                   "type": "dropdown",
                   "width": 5,
                   "options": [
@@ -490,6 +490,19 @@
                   "description": "A label description for this legend entry.",
                   "type": "text",
                   "width": 3
+                },
+                {
+                  "field": "",
+                  "name": "",
+                  "description": "",
+                  "width": 4
+                },
+                {
+                  "field": "shapeOverride",
+                  "name": "Shape Override",
+                  "description": "A URL to a custom symbol for which to use for this legend entry. If the path is relative, it will be relative to the mission's directory. This field will override values in the Shape field.",
+                  "type": "text",
+                  "width": 8
                 }
               ]
             }

--- a/configure/src/metaconfigs/layer-vectortile-config.json
+++ b/configure/src/metaconfigs/layer-vectortile-config.json
@@ -470,11 +470,18 @@
                   "width": 2
                 },
                 {
+                  "field": "value",
+                  "name": "Label",
+                  "description": "A label description for this legend entry.",
+                  "type": "text",
+                  "width": 8
+                },
+                {
                   "field": "shape",
                   "name": "Shape",
                   "description": "The symbol for which to use for this legend entry. Discreet and continuous describe scales. These scales are broken into groups by a change in shape value. For instance, 'discreet, discreet, discreet, circle, discreet, discreet' represents a discreet scales of three colors, a circle and then a discreet scale of two colors.",
                   "type": "dropdown",
-                  "width": 5,
+                  "width": 4,
                   "options": [
                     "circle",
                     "square",
@@ -485,24 +492,18 @@
                   ]
                 },
                 {
-                  "field": "value",
-                  "name": "Label",
-                  "description": "A label description for this legend entry.",
+                  "field": "shapeIcon",
+                  "name": "Shape From Icon",
+                  "description": "Shape but taken from the Material Design Icon (mdi) library. Takes priority over the value in the 'shape' field. See <a target='_blank' href='https://pictogrammers.com/library/mdi/'>https://pictogrammers.com/library/mdi/</a>",
                   "type": "text",
-                  "width": 3
-                },
-                {
-                  "field": "",
-                  "name": "",
-                  "description": "",
                   "width": 4
                 },
                 {
-                  "field": "shapeOverride",
-                  "name": "Shape Override",
-                  "description": "A URL to a custom symbol for which to use for this legend entry. If the path is relative, it will be relative to the mission's directory. This field will override values in the Shape field.",
+                  "field": "shapeImage",
+                  "name": "Shape From Image",
+                  "description": "A URL to a custom image (.png or .svg) for which to use for this legend entry. If the path is relative, it will be relative to the mission's directory. This field will override values in the Shape and Shape From Icon fields.",
                   "type": "text",
-                  "width": 8
+                  "width": 4
                 }
               ]
             }

--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -217,71 +217,10 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity) {
     let lastContinues = []
     let lastShape = ''
     for (let d in _legend) {
-        var shape = _legend[d].shapeOverride && _legend[d].shapeOverride.trim()
-            ? _legend[d].shapeOverride : _legend[d].shape
-        if (
-            shape == 'circle' ||
-            shape == 'square' ||
-            shape == 'rect' ||
-            shape == 'triangle'
-        ) {
-            // finalize discreet and continuous
-            if (lastContinues.length > 0) {
-                pushScale(lastContinues)
-                lastContinues = []
-            }
-
-            var r = c
-                .append('div')
-                .attr('class', 'row')
-                .style('display', 'flex')
-                .style('margin', '0px 0px 8px 9px')
-
-            switch (shape) {
-                case 'circle':
-                    r.append('div')
-                        .attr('class', layerUUID + '_legendshape')
-                        .style('width', '18px')
-                        .style('height', '18px')
-                        .style('background', _legend[d].color)
-                        .style('opacity', opacity)
-                        .style('border', `1px solid ${_legend[d].strokecolor}`)
-                        .style('border-radius', '50%')
-                    break
-                case 'square':
-                    r.append('div')
-                        .attr('class', layerUUID + '_legendshape')
-                        .style('width', '18px')
-                        .style('height', '18px')
-                        .style('background', _legend[d].color)
-                        .style('opacity', opacity)
-                        .style('border', `1px solid ${_legend[d].strokecolor}`)
-                    break
-                case 'rect':
-                    r.append('div')
-                        .attr('class', layerUUID + '_legendshape')
-                        .style('width', '18px')
-                        .style('height', '8px')
-                        .style('margin', '5px 0px 5px 0px')
-                        .style('background', _legend[d].color)
-                        .style('opacity', opacity)
-                        .style('border', `1px solid ${_legend[d].strokecolor}`)
-                    break
-                default:
-            }
-
-            r.append('div')
-                .style('margin-left', '5px')
-                .style('height', '100%')
-                .style('line-height', '19px')
-                .style('font-size', '14px')
-                .style('overflow', 'hidden')
-                .style('white-space', 'nowrap')
-                .style('max-width', '270px')
-                .style('text-overflow', 'ellipsis')
-                .attr('title', _legend[d].value)
-                .text(_legend[d].value)
-        } else if (shape == 'continuous' || shape == 'discreet') {
+        var shape = _legend[d].shapeImage && _legend[d].shapeImage.trim()
+            ? _legend[d].shapeImage : _legend[d].shapeIcon && _legend[d].shapeIcon.trim()
+            ? _legend[d].shapeIcon : _legend[d].shape
+        if (shape == 'continuous' || shape == 'discreet') {
             if (lastShape != shape) {
                 if (lastContinues.length > 0) {
                     pushScale(lastContinues)
@@ -294,37 +233,91 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity) {
                 value: _legend[d].value,
             })
             lastShape = shape
-        } else if ( String(shape).endsWith('.png') || String(shape).endsWith('.svg')) {
-            // PNG or SVG markers
+        } else {
+            
+            // finalize discreet and continuous
+            if (lastContinues.length > 0) {
+                pushScale(lastContinues)
+                lastContinues = []
+            }
             var r = c
                 .append('div')
                 .attr('class', 'row')
                 .style('display', 'flex')
-                .style('margin', '0px 0px 8px 9px')     
+                .style('margin', '0px 0px 8px 9px')
+
+            if (
+                shape == 'circle' ||
+                shape == 'square' ||
+                shape == 'rect' ||
+                shape == 'triangle'
+            ) {
+                switch (shape) {
+                    case 'circle':
+                        r.append('div')
+                            .attr('class', layerUUID + '_legendshape')
+                            .style('width', '18px')
+                            .style('height', '18px')
+                            .style('background', _legend[d].color)
+                            .style('opacity', opacity)
+                            .style('border', `1px solid ${_legend[d].strokecolor}`)
+                            .style('border-radius', '50%')
+                        break
+                    case 'square':
+                        r.append('div')
+                            .attr('class', layerUUID + '_legendshape')
+                            .style('width', '18px')
+                            .style('height', '18px')
+                            .style('background', _legend[d].color)
+                            .style('opacity', opacity)
+                            .style('border', `1px solid ${_legend[d].strokecolor}`)
+                        break
+                    case 'rect':
+                        r.append('div')
+                            .attr('class', layerUUID + '_legendshape')
+                            .style('width', '18px')
+                            .style('height', '8px')
+                            .style('margin', '5px 0px 5px 0px')
+                            .style('background', _legend[d].color)
+                            .style('opacity', opacity)
+                            .style('border', `1px solid ${_legend[d].strokecolor}`)
+                        break
+                    default:
+                }
+            } else if ( String(shape).endsWith('.png') || String(shape).endsWith('.svg')) {
+                // PNG or SVG markers   
+                r.append('div')
+                    .attr('class', layerUUID + '_legendcustom')
+                    .style('width', '24px')
+                    .style('height', '24px')
+                    .style('background', _legend[d].color)
+                    .style('opacity', opacity)
+                    .style('border', `1px solid ${_legend[d].strokecolor}`)
+                    .style('background-image', `url(${shape.startsWith("http") 
+                        ? shape : L_.missionPath + shape})`)
+                    .style('background-size', 'contain')
+                    .style('background-repeat', 'no-repeat')
+            } else { // try using shape from Material Design Icon (mdi) library    
+                r.append('div')
+                    .attr('class', layerUUID + '_legendicon' + ' mdi mdi-18px mdi-' + shape)
+                    .style('width', '18px')
+                    .style('height', '18px')
+                    .style('background', _legend[d].color)
+                    .style('opacity', opacity)
+                    .style('border', `1px solid ${_legend[d].strokecolor}`)
+            }
 
             r.append('div')
-                .attr('class', layerUUID + '_legendcustom')
-                .style('width', '24px')
-                .style('height', '24px')
-                .style('background', _legend[d].color)
-                .style('opacity', opacity)
-                .style('border', `1px solid ${_legend[d].strokecolor}`)
-                .style('background-image', `url(${L_.missionPath + shape})`)
-                .style('background-size', 'contain')
-                .style('background-repeat', 'no-repeat')
-
-            r.append('div')
-                .style('margin-left', '5px')
-                .style('height', '100%')
-                .style('line-height', '19px')
-                .style('font-size', '14px')
-                .style('overflow', 'hidden')
-                .style('white-space', 'nowrap')
-                .style('max-width', '270px')
-                .style('text-overflow', 'ellipsis')
-                .attr('title', _legend[d].value)
-                .text(_legend[d].value)
-            
+            .style('margin-left', '5px')
+            .style('height', '100%')
+            .style('line-height', '19px')
+            .style('font-size', '14px')
+            .style('overflow', 'hidden')
+            .style('white-space', 'nowrap')
+            .style('max-width', '270px')
+            .style('text-overflow', 'ellipsis')
+            .attr('title', _legend[d].value)
+            .text(_legend[d].value)
         }
     }
     if (lastContinues.length > 0) {

--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -217,7 +217,8 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity) {
     let lastContinues = []
     let lastShape = ''
     for (let d in _legend) {
-        var shape = _legend[d].shape
+        var shape = _legend[d].shapeOverride && _legend[d].shapeOverride.trim()
+            ? _legend[d].shapeOverride : _legend[d].shape
         if (
             shape == 'circle' ||
             shape == 'square' ||
@@ -293,6 +294,37 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity) {
                 value: _legend[d].value,
             })
             lastShape = shape
+        } else if ( String(shape).endsWith('.png') || String(shape).endsWith('.svg')) {
+            // PNG or SVG markers
+            var r = c
+                .append('div')
+                .attr('class', 'row')
+                .style('display', 'flex')
+                .style('margin', '0px 0px 8px 9px')     
+
+            r.append('div')
+                .attr('class', layerUUID + '_legendcustom')
+                .style('width', '24px')
+                .style('height', '24px')
+                .style('background', _legend[d].color)
+                .style('opacity', opacity)
+                .style('border', `1px solid ${_legend[d].strokecolor}`)
+                .style('background-image', `url(${L_.missionPath + shape})`)
+                .style('background-size', 'contain')
+                .style('background-repeat', 'no-repeat')
+
+            r.append('div')
+                .style('margin-left', '5px')
+                .style('height', '100%')
+                .style('line-height', '19px')
+                .style('font-size', '14px')
+                .style('overflow', 'hidden')
+                .style('white-space', 'nowrap')
+                .style('max-width', '270px')
+                .style('text-overflow', 'ellipsis')
+                .attr('title', _legend[d].value)
+                .text(_legend[d].value)
+            
         }
     }
     if (lastContinues.length > 0) {

--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -283,8 +283,8 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity) {
                         break
                     default:
                 }
-            } else if ( String(shape).endsWith('.png') || String(shape).endsWith('.svg')) {
-                // PNG or SVG markers   
+            } else if (String(shape).toLowerCase().match(/\.(jpeg|jpg|gif|png|svg|webp)$/) != null) {
+                // Image markers   
                 r.append('div')
                     .attr('class', layerUUID + '_legendcustom')
                     .style('width', '24px')

--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -249,8 +249,7 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity) {
             if (
                 shape == 'circle' ||
                 shape == 'square' ||
-                shape == 'rect' ||
-                shape == 'triangle'
+                shape == 'rect'
             ) {
                 switch (shape) {
                     case 'circle':
@@ -299,12 +298,14 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity) {
                     .style('background-repeat', 'no-repeat')
             } else { // try using shape from Material Design Icon (mdi) library    
                 r.append('div')
-                    .attr('class', layerUUID + '_legendicon' + ' mdi mdi-18px mdi-' + shape)
+                    .attr('class', layerUUID + '_legendicon')
                     .style('width', '18px')
                     .style('height', '18px')
-                    .style('background', _legend[d].color)
-                    .style('opacity', opacity)
-                    .style('border', `1px solid ${_legend[d].strokecolor}`)
+                    .append('i')
+                        .attr('class', 'mdi mdi-18px mdi-' + shape)
+                        .style('color', _legend[d].color)
+                        .style('opacity', opacity)
+                        .style('border', `1px solid ${_legend[d].strokecolor}`)
             }
 
             r.append('div')


### PR DESCRIPTION
## Purpose
- Display custom marker icons in the legend.
## Proposed Changes
- Adds ShapeImage and ShapeIcon fields to display custom marker icons in the legend
## Issues
- #657 
## Testing
- Tested with png and svg icons in the ShapeImage and ShapeIcon fields for vector and vector tile layers (I don't think this would apply to other layer types). Tested removing ShapeImage and ShapeIcon values to make sure regular Shapes still work.