### PR TITLE
Patch #669 and #680 Merge For STAC Prefix

### DIFF
--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -3631,6 +3631,15 @@ async function parseConfig(configData, urlOnLayers) {
 
         //Iterate over each layer
         for (let i = 0; i < d.length; i++) {
+            // If sourceType, prefix onto url
+            if (
+                d[i].sourceType != null &&
+                d[i].sourceType !== 'url' &&
+                d[i].url.indexOf(`${d[i].sourceType}:`) !== 0
+            ) {
+                d[i].url = `${d[i].sourceType}:${d[i].url}`
+            }
+
             // check if this is a vector STAC catalog or collection
             // if so, prefetch the data and replace this entry
             if (d[i].type === 'vector' && stacRegex.test(d[i].url)) {
@@ -3647,15 +3656,6 @@ async function parseConfig(configData, urlOnLayers) {
             }
             d[i] = { display_name: d[i].name, ...d[i] }
             d[i].name = d[i].uuid || d[i].name
-
-            // If sourceType, prefix onto url
-            if (
-                d[i].sourceType != null &&
-                d[i].sourceType !== 'url' &&
-                d[i].url.indexOf(`${d[i].sourceType}:`) !== 0
-            ) {
-                d[i].url = `${d[i].sourceType}:${d[i].url}`
-            }
 
             // Create parsed layers named
             L_.layers.data[d[i].name] = d[i]
@@ -3947,7 +3947,7 @@ async function parseConfig(configData, urlOnLayers) {
                     error: (resp) => {
                         console.warn(resp)
                         resolve(d)
-                    }
+                    },
                 })
             } else {
                 resolve(d)


### PR DESCRIPTION
## Purpose
- #669 introduced parsing URL prefix during config ingestion and #680 introduced a source_type -> URL prefix conversion during config ingestion, while the code changes didn't conflict, they were actually in the wrong order of events. This fixes that.
## Proposed Changes
- [FIX] `expandLayers()` to convert source_type to a URL prefix before then parsing that prefix