### PR TITLE
Add DB_SSL env var support for PostgreSQL SSL connections (fixes #688)

### DIFF
--- a/scripts/server.js
+++ b/scripts/server.js
@@ -107,6 +107,7 @@ const pool = new Pool({
   database: process.env.DB_NAME,
   password: process.env.DB_PASS,
   port: process.env.DB_PORT || "5432",
+  ...(process.env.DB_SSL === 'true' ? { ssl: { rejectUnauthorized: false } } : {}),
 });
 app.use(
   session({


### PR DESCRIPTION
This PR adds support for SSL connections to the PostgreSQL database by introducing a `DB_SSL` environment variable. When `DB_SSL` is set to `true`, the server will connect to the database using SSL with `rejectUnauthorized: false`. This addresses issue #688.