### PR TITLE
#694 Increase Querying Capabilities of LayersTool filters

### DIFF
--- a/API/Backend/Geodatasets/routes/geodatasets.js
+++ b/API/Backend/Geodatasets/routes/geodatasets.js
@@ -71,7 +71,7 @@ function get(reqtype, req, res, next) {
       const filterSplit = req.query.filters.split(",");
       filters = [];
       filterSplit.forEach((f) => {
-        if (f === "OR" || f === "AND") {
+        if (f === "OR" || f === "AND" || f === "NOT") {
           filters.push({
             isGroup: true,
             op: f,
@@ -247,7 +247,7 @@ function get(reqtype, req, res, next) {
             let filterSQL = [];
             let currentGroupOp = null;
             let currentGroup = [];
-            console.log(filters);
+
             filters.forEach((f, i) => {
               if (f.isGroup === true) {
                 if (
@@ -255,7 +255,13 @@ function get(reqtype, req, res, next) {
                   currentGroupOp != f.op &&
                   currentGroup.length > 0
                 ) {
-                  filterSQL.push(`(${currentGroup.join(` ${f.op} `)})`);
+                  filterSQL.push(
+                    `${
+                      currentGroupOp == "NOT" ? "NOT " : ""
+                    }(${currentGroup.join(
+                      ` ${currentGroupOp == "NOT" ? "AND" : f.op} `
+                    )})`
+                  );
                   currentGroup = [];
                 }
                 currentGroupOp = f.op;
@@ -336,12 +342,17 @@ function get(reqtype, req, res, next) {
             // Final group
             if (currentGroup.length > 0) {
               filterSQL.push(
-                `(${currentGroup.join(` ${currentGroupOp || "AND"} `)})`
+                `${currentGroupOp == "NOT" ? "NOT " : ""}(${currentGroup.join(
+                  ` ${
+                    currentGroupOp === "NOT" ? "AND" : currentGroupOp || "AND"
+                  } `
+                )})`
               );
             }
-            q += `${
-              q.indexOf(" WHERE ") === -1 ? " WHERE " : " AND "
-            }${filterSQL.join(` AND `)}`;
+            if (filterSQL.length > 0)
+              q += `${
+                q.indexOf(" WHERE ") === -1 ? " WHERE " : " AND "
+              }${filterSQL.join(` AND `)}`;
           }
 
           if (
@@ -371,7 +382,6 @@ function get(reqtype, req, res, next) {
 
           q += `;`;
 
-          console.log(q);
           sequelize
             .query(q, {
               replacements: replacements,

--- a/API/Backend/Geodatasets/routes/geodatasets.js
+++ b/API/Backend/Geodatasets/routes/geodatasets.js
@@ -71,13 +71,20 @@ function get(reqtype, req, res, next) {
       const filterSplit = req.query.filters.split(",");
       filters = [];
       filterSplit.forEach((f) => {
-        const fSplit = f.split("+");
-        filters.push({
-          key: fSplit[0],
-          op: fSplit[1],
-          type: fSplit[2],
-          value: fSplit[3],
-        });
+        if (f === "OR" || f === "AND") {
+          filters.push({
+            isGroup: true,
+            op: f,
+          });
+        } else {
+          const fSplit = f.split("+");
+          filters.push({
+            key: fSplit[0],
+            op: fSplit[1],
+            type: fSplit[2],
+            value: fSplit[3],
+          });
+        }
       });
     }
     if (req.query.spatialFilter != null) {
@@ -238,65 +245,100 @@ function get(reqtype, req, res, next) {
           // Filters
           if (filters != null && filters.length > 0) {
             let filterSQL = [];
+            let currentGroupOp = null;
+            let currentGroup = [];
+            console.log(filters);
             filters.forEach((f, i) => {
-              let fkey = f.key;
-              let derivedKey = false;
-              if (fkey === "Latitude (Centroid)") {
-                fkey = `ST_Y(ST_Centroid(geom))`;
-                derivedKey = true;
-              } else if (fkey === "Longitude (Centroid)") {
-                fkey = `ST_X(ST_Centroid(geom))`;
-                derivedKey = true;
-              }
-
-              replacements[`filter_key_${i}`] = fkey;
-              replacements[`filter_value_${i}`] = f.value;
-              let op = "=";
-              switch (f.op) {
-                case ">":
-                  op = ">";
-                  break;
-                case "<":
-                  op = "<";
-                  break;
-                case "in":
-                  op = "IN";
-                  break;
-                case "=":
-                default:
-                  break;
-              }
-              let value = "";
-              if (op === "IN") {
-                const valueSplit = f.value.split("$");
-                const values = [];
-                valueSplit.forEach((v) => {
-                  replacements[`filter_value_${i}_${v}`] = v;
-                  values.push(`:filter_value_${i}_${v}`);
-                });
-                value = `(${values.join(",")})`;
+              if (f.isGroup === true) {
+                if (
+                  currentGroupOp != null &&
+                  currentGroupOp != f.op &&
+                  currentGroup.length > 0
+                ) {
+                  filterSQL.push(`(${currentGroup.join(` ${f.op} `)})`);
+                  currentGroup = [];
+                }
+                currentGroupOp = f.op;
               } else {
+                let fkey = f.key;
+                let derivedKey = false;
+                if (fkey === "Latitude (Centroid)") {
+                  fkey = `ST_Y(ST_Centroid(geom))`;
+                  derivedKey = true;
+                } else if (fkey === "Longitude (Centroid)") {
+                  fkey = `ST_X(ST_Centroid(geom))`;
+                  derivedKey = true;
+                }
+
+                replacements[`filter_key_${i}`] = fkey;
                 replacements[`filter_value_${i}`] = f.value;
-                value = `:filter_value_${i}`;
-              }
-              if (f.type === "number") {
-                filterSQL.push(
-                  `${
+                let op = "=";
+                switch (f.op) {
+                  case ">":
+                    op = ">";
+                    break;
+                  case "<":
+                    op = "<";
+                    break;
+                  case "in":
+                    op = "IN";
+                    break;
+                  case "contains":
+                  case "beginswith":
+                  case "endswith":
+                    op = "LIKE";
+                    break;
+                  case "=":
+                  default:
+                    break;
+                }
+                let value = "";
+                if (op === "IN") {
+                  const valueSplit = f.value.split("$");
+                  const values = [];
+                  valueSplit.forEach((v) => {
+                    replacements[`filter_value_${i}_${v}`] = v;
+                    values.push(`:filter_value_${i}_${v}`);
+                  });
+                  value = `(${values.join(",")})`;
+                } else if (op === "LIKE") {
+                  if (f.op == "contains")
+                    replacements[`filter_value_${i}`] = `%${f.value}%`;
+                  else if (f.op == "beginswith")
+                    replacements[`filter_value_${i}`] = `${f.value}%`;
+                  else if (f.op == "endswith")
+                    replacements[`filter_value_${i}`] = `%${f.value}`;
+
+                  value = `:filter_value_${i}`;
+                } else {
+                  replacements[`filter_value_${i}`] = f.value;
+                  value = `:filter_value_${i}`;
+                }
+                if (f.type === "number" && op !== "LIKE") {
+                  const q1 = `${
                     derivedKey === true
                       ? `${fkey}`
                       : `(properties->>:filter_key_${i})`
-                  }::FLOAT ${op} ${value}`
-                );
-              } else {
-                filterSQL.push(
-                  `${
+                  }::FLOAT ${op} ${value}`;
+                  if (currentGroupOp == null) filterSQL.push(q1);
+                  else currentGroup.push(q1);
+                } else {
+                  const q2 = `${
                     derivedKey === true
                       ? `${fkey}`
                       : `properties->>:filter_key_${i}`
-                  } ${op} ${value}`
-                );
+                  } ${op} ${value}`;
+                  if (currentGroupOp == null) filterSQL.push(q2);
+                  else currentGroup.push(q2);
+                }
               }
             });
+            // Final group
+            if (currentGroup.length > 0) {
+              filterSQL.push(
+                `(${currentGroup.join(` ${currentGroupOp || "AND"} `)})`
+              );
+            }
             q += `${
               q.indexOf(" WHERE ") === -1 ? " WHERE " : " AND "
             }${filterSQL.join(` AND `)}`;
@@ -329,6 +371,7 @@ function get(reqtype, req, res, next) {
 
           q += `;`;
 
+          console.log(q);
           sequelize
             .query(q, {
               replacements: replacements,

--- a/public/helps/LayersTool-Filtering.md
+++ b/public/helps/LayersTool-Filtering.md
@@ -10,36 +10,44 @@ These queries allow you to filter features by property-value equivalencies and r
 
 - The `Property` field auto-completes and must be one of the auto-completed values.
 - The `Operator` dropdown contains the following operators:
-  - `=` - The feature's `Property` must equal `Value` to remain visible.
-  - `in` - The feature's `Property` must equal _at least one of_ of the _comma-separated_ entries of `Value` to remain visible.
-  - `<` - The feature's `Property` must be less than `Value`. If performed on a textual `Property`, the comparison becomes alphabetical.
-  - `>` - The feature's `Property` must be greater than `Value`. If performed on a textual `Property`, the comparison becomes alphabetical.
+  - `=` - _Equals._ The feature's `Property` must equal `Value` to remain visible.
+  - `in` - _In List._ The feature's `Property` must equal _at least one of_ of the _comma-separated_ entries of `Value` to remain visible.
+  - `<` - _Less Than._ The feature's `Property` must be less than `Value`. If performed on a textual `Property`, the comparison becomes alphabetical.
+  - `>` - _Greater Than._ The feature's `Property` must be greater than `Value`. If performed on a textual `Property`, the comparison becomes alphabetical.
+  - `[...]` - _Contains._ The feature's `Property` must contain `Value`. If performed on a numeric `Property`, its value is first parsed into a string.
+  - `[...` - _Begins With._ The feature's `Property` must begin with `Value`. If performed on a numeric `Property`, its value is first parsed into a string.
+  - `...]` - _Ends With._ The feature's `Property` must end with `Value`. If performed on a numeric `Property`, its value is first parsed into a string.
 
 #### Add +
 
-By default one property-value row is provide. To add more, click the top-right "Add +" button. Use a property-value row's right-most "X" to then remove the row.
+By default, one property-value row is provide. To add more, click the top-right "Add +" button. Use a property-value row's right-most "X" to then remove the row.
 
-#### Logical Groupings (Parentheticals)
+#### Group +
 
-In favoring simplicity, not all boolean logic queries are possible. There is no **NOT** operator. All property-value rows are **AND**ed together with the following exception:
+By default, all property-value rows are ANDed together. Adding Operator Groups and dragging to rearrange rows enables modifying this behavior. Each Group is still ANDed together with the other groups. Each Group ends when another Group starts. Groups cannot be nested.
 
-- If there exists multiple instances of the same `Property`, only the `<` and `>` are **AND**ed together and the other operations are **OR**ed together. (See example below)
-
-Rows of the same `Property` are color coded to better visually track this function. Row order has zero bearing on the derived parenthetical groupings.
+- `Match All (AND)` - All property-value rows beneath this row and up until the next Group row or up until the end are ANDed together - they must all be true for a feature to match the query.
+- `Match Any (OR)` - All property-value rows beneath this row and up until the next Group row or up until the end are ORed together - at least one match must be true for a feature to match the query.
+- `Match Inverse (NOT AND)` - All property-value rows beneath this row and up until the next Group row or up until the end are ANDed together and then negated - all matches must be false for a feature to match the query.
 
 #### Example
 
 ```json
+group OR
 sol > 10
 sol < 20
 sol = 25
-drive = 0
+group AND
+site = 3
+drive = 1
+group NOT AND
+pose = 0
 ```
 
 _becomes:_
 
 ```
-((sol > 10 AND sol < 20) OR sol = 25) AND drive = 0
+(sol > 10 OR sol < 20 OR sol = 25) AND (site = 3 && drive = 1) AND NOT (pose = 0)
 ```
 
 ### Spatial Queries

--- a/src/essence/Basics/Layers_/Filtering/Filtering.css
+++ b/src/essence/Basics/Layers_/Filtering/Filtering.css
@@ -25,15 +25,18 @@
     padding: 0px 4px;
     color: #d6d6d6;
 }
-#layersTool_filtering_add_value {
+#layersTool_filtering_add_value,
+#layersTool_filtering_add_group {
     padding: 0px 6px;
     color: var(--color-a6);
 }
-#layersTool_filtering_add_value:hover {
+#layersTool_filtering_add_value:hover,
+#layersTool_filtering_add_group:hover {
     background: var(--color-c);
     color: var(--color-a7);
 }
-#layersTool_filtering_add_value > div {
+#layersTool_filtering_add_value > div,
+#layersTool_filtering_add_group > div  {
     font-size: 11px;
     margin-right: 2px;
     line-height: 32px;
@@ -147,6 +150,29 @@
     padding-left: 2px;
 }
 
+.layersTool_filtering_group {
+    display: flex;
+    justify-content: space-between;
+    height: 31px;
+    border-bottom: 1px solid var(--color-a2);
+    background: var(--color-a1);
+}
+.layersTool_filtering_group > div:first-child {
+    display: flex;
+}
+.layersTool_filtering_group_key {
+    line-height: 31px;
+    padding: 0px 5px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    font-family: 'lato-light';
+    font-size: 13px;
+}
+.layersTool_filtering_group_operator {
+    width: 40px;
+    text-align: center;
+}
+
 .layersTool_filtering_value {
     display: flex;
     height: 31px;
@@ -221,8 +247,35 @@
     height: 30px;
     transition: background 0.2s cubic-bezier(0.785, 0.135, 0.15, 0.86);
 }
+.layersTool_filtering_group_operator_select {
+    color: var(--color-f);
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+    height: 22px;
+    margin: 4px 0px;
+    transition: background 0.2s cubic-bezier(0.785, 0.135, 0.15, 0.86);
+}
+.layersTool_filtering_group_operator_select.op_and {
+    background: var(--color-query);
+}
+.layersTool_filtering_group_operator_select.op_or {
+    background: var(--color-c2);
+}
+.layersTool_filtering_group_operator_select .dropy__title span {
+    padding: 3px 0px !important;
+    width: 100%;
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 1px;
+    text-align: center !important;
+}
+
 .layersTool_filtering_value_operator_select:hover {
     background: var(--color-a2);
+}
+.layersTool_filtering_group_operator_select:hover {
+    background: var(--color-c);
 }
 
 .layersTool_filtering_value_remove .mmgisButton5 {
@@ -286,4 +339,28 @@
     to {
         transform: rotate(360deg);
     }
+}
+
+
+.filterDragHandle {
+    width: 12px;
+    height: 100%;
+    padding-top: 8px;
+    cursor: ns-resize;
+    color: rgba(255, 255, 255, 0.6);
+    box-sizing: border-box;
+    transition: all 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
+}
+.filterDragHandle > i.mdi:before {
+    font-size: 14px;
+    margin-left: -1px;
+}
+.filterDragHandle:hover {
+    color: white;
+}
+.layersTool_filtering_group .filterDragHandle {
+    background: var(--color-a1);
+}
+.layersTool_filtering_value .filterDragHandle {
+    background: var(--color-a2);
 }

--- a/src/essence/Basics/Layers_/Filtering/Filtering.css
+++ b/src/essence/Basics/Layers_/Filtering/Filtering.css
@@ -95,7 +95,7 @@
 }
 .layerTool_filtering_filters_clear {
     width: 30px;
-    background: var(--color-a1-5);
+    background: var(--color-a1);
     padding: 0px 6px;
     color: #888;
 }
@@ -109,7 +109,6 @@
     color: #ccc;
     width: 131px;
     box-sizing: border-box;
-    border-right: 1px solid var(--color-a2);
 }
 #layersTool_filtering
     #layerTool_filtering_filters_spatial_radius_wrapper
@@ -169,7 +168,7 @@
     font-size: 13px;
 }
 .layersTool_filtering_group_operator {
-    width: 40px;
+    width: 190px;
     text-align: center;
 }
 
@@ -183,8 +182,6 @@
 }
 .layersTool_filtering_value_operator {
     box-sizing: border-box;
-    border-left: 1px solid var(--color-a2);
-    border-right: 1px solid var(--color-a2);
 }
 .layersTool_filtering_value .layersTool_filtering_value_value {
     flex: 1;
@@ -221,7 +218,6 @@
     color: #ccc;
     width: 100%;
     box-sizing: border-box;
-    border-left: 6px solid var(--color-a);
     height: 30px;
     padding-left: 8px;
     border: none;
@@ -229,10 +225,9 @@
     transition: background 0.2s cubic-bezier(0.785, 0.135, 0.15, 0.86);
 }
 #layersTool_filtering input:hover {
-    background: var(--color-a1);
+    background: var(--color-a);
 }
 .layersTool_filtering_value_value_input {
-    border-right: 1px solid var(--color-a2) !important;
 }
 #layersTool_filtering select {
     background: #111;
@@ -262,10 +257,13 @@
 .layersTool_filtering_group_operator_select.op_or {
     background: var(--color-c2);
 }
+.layersTool_filtering_group_operator_select.op_not {
+    background: var(--color-p4);
+}
 .layersTool_filtering_group_operator_select .dropy__title span {
-    padding: 3px 0px !important;
+    padding: 4px 0px !important;
     width: 100%;
-    font-size: 13px;
+    font-size: 12px;
     font-weight: bold;
     letter-spacing: 1px;
     text-align: center !important;
@@ -285,7 +283,7 @@
     padding: 0px 14px;
 }
 #layersTool_filtering_clear:hover {
-    background: var(--color-red2);
+    background: var(--color-p4);
 }
 #layersTool_filtering_submit {
     padding: 0px 8px;

--- a/src/essence/Basics/Layers_/Filtering/Filtering.js
+++ b/src/essence/Basics/Layers_/Filtering/Filtering.js
@@ -115,10 +115,23 @@ const Filtering = {
 
         container.append(markup)
 
-        Filtering.filters[layerName].values.forEach((v) => {
-            if (v) Filtering.addValue(layerName, v)
+        // In case of reopening the tool, recreate state
+        let values = JSON.parse(
+            JSON.stringify(Filtering.filters[layerName])
+        ).values.filter(Boolean)
+        const valuesOrder = Filtering.filters[layerName].valuesOrder
+
+        if (valuesOrder && valuesOrder.length > 0) {
+            values.sort((a, b) => {
+                return valuesOrder.indexOf(a.id) - valuesOrder.indexOf(b.id)
+            })
+        }
+        values.forEach((v) => {
+            if (v && v.isGroup === true) Filtering.addGroup(layerName, v)
+            else if (v) Filtering.addValue(layerName, v)
         })
 
+        // events
         Filtering.attachEvents(layerName)
 
         Filtering.drawSpatialLayer(
@@ -165,7 +178,7 @@ const Filtering = {
                     "<div class='layersTool_filtering_group_operator'>",
                         `<div id='layersTool_filtering_group_operator_${F_.getSafeName(
                             layerName
-                        )}_${id}' class='layersTool_filtering_group_operator_select ${op == 'OR' ? 'op_or' : 'op_and'}'></div>`,
+                        )}_${id}' class='layersTool_filtering_group_operator_select op_${(op || 'AND').toLowerCase()}'></div>`,
                     '</div>',
                 `</div>`,
                 `<div id='layersTool_filtering_group_clear_${F_.getSafeName(
@@ -174,7 +187,7 @@ const Filtering = {
             '</li>',
         ].join('\n')
 
-        $('#layerTool_filtering_filters_list').prepend(groupMarkup)
+        $('#layerTool_filtering_filters_list').append(groupMarkup)
 
         if (group == null) {
             Filtering.filters[layerName].values.push({
@@ -423,12 +436,20 @@ const Filtering = {
             Filtering.filters[layerName].values = Filtering.filters[
                 layerName
             ].values.filter((v) => {
-                if (v)
-                    $(
-                        `#layersTool_filtering_value_${F_.getSafeName(
-                            layerName
-                        )}_${v.id}`
-                    ).remove()
+                if (v) {
+                    if (v.isGroup === true)
+                        $(
+                            `#layersTool_filtering_group_${F_.getSafeName(
+                                layerName
+                            )}_${v.id}`
+                        ).remove()
+                    else
+                        $(
+                            `#layersTool_filtering_value_${F_.getSafeName(
+                                layerName
+                            )}_${v.id}`
+                        ).remove()
+                }
                 return false
             })
 
@@ -501,13 +522,14 @@ const Filtering = {
             layerName
         )}_${id}`
 
-        const ops = ['AND', 'OR']
+        const ops = ['AND', 'OR', 'NOT']
         const opId = Math.max(ops.indexOf(options.op), 0)
         $(elmId).html(
             Dropy.construct(
                 [
-                    `<div style='font-family: monospace;'>AND</div>`,
-                    `<div style='font-family: monospace;'>OR</div>`,
+                    `<div style='font-family: monospace;'>Match All (AND)</div>`,
+                    `<div style='font-family: monospace;'>Match Any (OR)</div>`,
+                    `<div style='font-family: monospace;'>Match Inverse (NOT AND)</div>`,
                 ],
                 'op',
                 opId,
@@ -520,11 +542,18 @@ const Filtering = {
             switch (newOp) {
                 case 'AND':
                     $(elmId).removeClass('op_or')
+                    $(elmId).removeClass('op_not')
                     $(elmId).addClass('op_and')
                     break
                 case 'OR':
                     $(elmId).removeClass('op_and')
+                    $(elmId).removeClass('op_not')
                     $(elmId).addClass('op_or')
+                    break
+                case 'NOT':
+                    $(elmId).removeClass('op_and')
+                    $(elmId).removeClass('op_or')
+                    $(elmId).addClass('op_not')
                     break
                 default:
                     break
@@ -651,7 +680,7 @@ const Filtering = {
                     'border-left',
                     `3px solid ${F_.stringToColor($(this).val())}`
                 )
-            } else $(this).css('border', '1px solid red')
+            } else $(this).css('border', '1px solid var(--color-p4)')
         })
 
         // Operator Dropdown

--- a/src/essence/Basics/Layers_/Filtering/Filtering.js
+++ b/src/essence/Basics/Layers_/Filtering/Filtering.js
@@ -13,6 +13,8 @@ import Help from '../../../Ancillary/Help'
 import Dropy from '../../../../external/Dropy/dropy'
 import { circle } from '@turf/turf'
 
+import Sortable from 'sortablejs'
+
 import './Filtering.css'
 
 const helpKey = 'LayersTool-Filtering'
@@ -32,6 +34,7 @@ const Filtering = {
                 radius: 0,
             },
             values: [],
+            groups: [],
             geojson: null,
         }
         Filtering.current = {
@@ -87,6 +90,7 @@ const Filtering = {
                         "<div id='layersTool_filtering_count'></div>",
                     "</div>",
                     "<div id='layersTool_filtering_adds'>",
+                        "<div id='layersTool_filtering_add_group' class='mmgisButton5' title='Add New Grouping'><div>Group</div><i class='mdi mdi-plus mdi-18px'></i></div>",
                         "<div id='layersTool_filtering_add_value' class='mmgisButton5' title='Add New Key-Value Filter'><div>Add</div><i class='mdi mdi-plus mdi-18px'></i></div>",
                     "</div>",
                 "</div>",
@@ -138,6 +142,52 @@ const Filtering = {
 
         $('#layersTool_filtering').remove()
     },
+    addGroup: function (layerName, group) {
+        let id, op
+        if (group) {
+            id = group.id
+            op = group.op
+        } else {
+            id = Filtering.filters[layerName].values.length
+            op = 'OR' // Default to OR since AND is already the higher level op
+        }
+
+        // prettier-ignore
+        const groupMarkup = [
+            `<li class='layersTool_filtering_group' id='layersTool_filtering_group_${F_.getSafeName(
+                layerName
+            )}_${id}' idx='${id}'>`,
+                `<div>`,
+                    `<div class='filterDragHandle'><i class="mdi mdi-drag-vertical mdi-12px"></i></div>`,
+                    "<div class='layersTool_filtering_group_key'>",
+                        `Group`,
+                    '</div>',
+                    "<div class='layersTool_filtering_group_operator'>",
+                        `<div id='layersTool_filtering_group_operator_${F_.getSafeName(
+                            layerName
+                        )}_${id}' class='layersTool_filtering_group_operator_select ${op == 'OR' ? 'op_or' : 'op_and'}'></div>`,
+                    '</div>',
+                `</div>`,
+                `<div id='layersTool_filtering_group_clear_${F_.getSafeName(
+                    layerName
+                )}_${id}' class='mmgisButton5 layerTool_filtering_filters_clear'><i class='mdi mdi-close mdi-18px'></i></div>`,
+            '</li>',
+        ].join('\n')
+
+        $('#layerTool_filtering_filters_list').prepend(groupMarkup)
+
+        if (group == null) {
+            Filtering.filters[layerName].values.push({
+                isGroup: true,
+                id: id,
+                op: op,
+            })
+        }
+
+        Filtering.attachGroupEvents(id, layerName, { op: op })
+
+        Filtering.makeFilterListSortable()
+    },
     addValue: function (layerName, value) {
         let id, key, op, val
         if (value) {
@@ -149,7 +199,8 @@ const Filtering = {
 
         // prettier-ignore
         const valueMarkup = [
-            `<div class='layersTool_filtering_value' id='layersTool_filtering_value_${F_.getSafeName(layerName)}_${id}'>`,
+            `<li class='layersTool_filtering_value' id='layersTool_filtering_value_${F_.getSafeName(layerName)}_${id}' idx='${id}'>`,
+                `<div class='filterDragHandle'><i class="mdi mdi-drag-vertical mdi-12px"></i></div>`,
                 "<div class='layersTool_filtering_value_key'>",
                     `<input id='layersTool_filtering_value_key_input_${F_.getSafeName(layerName)}_${id}' class='layersTool_filtering_value_key_input' spellcheck='false' type='text'${key} placeholder='Property...'></input>`,
                 "</div>",
@@ -164,7 +215,7 @@ const Filtering = {
                     `</div>`,
                 "</div>",
                 `<div id='layersTool_filtering_value_clear_${F_.getSafeName(layerName)}_${id}' class='mmgisButton5 layerTool_filtering_filters_clear'><i class='mdi mdi-close mdi-18px'></i></div>`,
-            "</div>",
+            "</li>",
         ].join('\n')
 
         $('#layerTool_filtering_filters_list').append(valueMarkup)
@@ -180,6 +231,8 @@ const Filtering = {
         }
 
         Filtering.attachValueEvents(id, layerName, { op: op })
+
+        Filtering.makeFilterListSortable()
 
         // Show footer iff value rows exist
         $('#layersTool_filtering_footer').css(
@@ -247,6 +300,10 @@ const Filtering = {
         }
     },
     attachEvents: function (layerName) {
+        // Add Value
+        $('#layersTool_filtering_add_group').on('click', function () {
+            Filtering.addGroup(layerName)
+        })
         // Add Value
         $('#layersTool_filtering_add_value').on('click', function () {
             Filtering.addValue(layerName)
@@ -317,6 +374,16 @@ const Filtering = {
 
         // Submit
         $(`#layersTool_filtering_submit`).on('click', async () => {
+            // Update the desired order of values
+            const valuesOrder = []
+            $('#layerTool_filtering_filters_list > li').each(function () {
+                const idx = $(this).attr('idx')
+                if (idx !== undefined) {
+                    valuesOrder.push(parseInt(idx))
+                }
+            })
+            Filtering.filters[layerName].valuesOrder = valuesOrder
+
             Filtering.setSubmitButtonState(true)
             $(`#layersTool_filtering_submit_loading`).addClass('active')
             if (Filtering.current.type === 'vector') {
@@ -397,6 +464,74 @@ const Filtering = {
                 Filtering.mapSpatialLayer.bringToFront()
         })
     },
+    attachGroupEvents: function (id, layerName, options) {
+        options = options || {}
+
+        let elmId
+
+        // Clear
+        elmId = `#layersTool_filtering_group_clear_${F_.getSafeName(
+            layerName
+        )}_${id}`
+
+        $(elmId).on('click', () => {
+            // Clear value filter element
+            for (
+                let i = 0;
+                i < Filtering.filters[layerName].values.length;
+                i++
+            ) {
+                if (Filtering.filters[layerName].values[i]?.isGroup) {
+                    const vId = Filtering.filters[layerName].values[i]?.id
+                    if (vId != null && vId === id) {
+                        $(
+                            `#layersTool_filtering_group_${F_.getSafeName(
+                                layerName
+                            )}_${vId}`
+                        ).remove()
+                        Filtering.filters[layerName].values[i] = null
+                    }
+                }
+            }
+            Filtering.setSubmitButtonState(true)
+        })
+
+        // Operator Dropdown
+        elmId = `#layersTool_filtering_group_operator_${F_.getSafeName(
+            layerName
+        )}_${id}`
+
+        const ops = ['AND', 'OR']
+        const opId = Math.max(ops.indexOf(options.op), 0)
+        $(elmId).html(
+            Dropy.construct(
+                [
+                    `<div style='font-family: monospace;'>AND</div>`,
+                    `<div style='font-family: monospace;'>OR</div>`,
+                ],
+                'op',
+                opId,
+                { openUp: true, hideChevron: true }
+            )
+        )
+        Dropy.init($(elmId), function (idx) {
+            const newOp = ops[idx]
+            Filtering.filters[layerName].values[id].op = newOp
+            switch (newOp) {
+                case 'AND':
+                    $(elmId).removeClass('op_or')
+                    $(elmId).addClass('op_and')
+                    break
+                case 'OR':
+                    $(elmId).removeClass('op_and')
+                    $(elmId).addClass('op_or')
+                    break
+                default:
+                    break
+            }
+            Filtering.setSubmitButtonState(true)
+        })
+    },
     attachValueEvents: function (id, layerName, options) {
         options = options || {}
 
@@ -434,14 +569,16 @@ const Filtering = {
                 i < Filtering.filters[layerName].values.length;
                 i++
             ) {
-                const vId = Filtering.filters[layerName].values[i]?.id
-                if (vId != null && vId === id) {
-                    $(
-                        `#layersTool_filtering_value_${F_.getSafeName(
-                            layerName
-                        )}_${vId}`
-                    ).remove()
-                    Filtering.filters[layerName].values[i] = null
+                if (Filtering.filters[layerName].values[i]?.isGroup !== true) {
+                    const vId = Filtering.filters[layerName].values[i]?.id
+                    if (vId != null && vId === id) {
+                        $(
+                            `#layersTool_filtering_value_${F_.getSafeName(
+                                layerName
+                            )}_${vId}`
+                        ).remove()
+                        Filtering.filters[layerName].values[i] = null
+                    }
                 }
             }
             Filtering.setSubmitButtonState(true)
@@ -491,7 +628,7 @@ const Filtering = {
                 $(this).css('border', 'none')
                 $(this).css(
                     'border-left',
-                    `6px solid ${F_.stringToColor(event.value)}`
+                    `3px solid ${F_.stringToColor(event.value)}`
                 )
             },
         })
@@ -512,7 +649,7 @@ const Filtering = {
                 $(this).css('border', 'none')
                 $(this).css(
                     'border-left',
-                    `6px solid ${F_.stringToColor($(this).val())}`
+                    `3px solid ${F_.stringToColor($(this).val())}`
                 )
             } else $(this).css('border', '1px solid red')
         })
@@ -522,7 +659,7 @@ const Filtering = {
             layerName
         )}_${id}`
 
-        const ops = ['=', ',', '<', '>']
+        const ops = ['=', ',', '<', '>', 'contains', 'beginswith', 'endswith']
         const opId = Math.max(ops.indexOf(options.op), 0)
         $(elmId).html(
             Dropy.construct(
@@ -531,6 +668,9 @@ const Filtering = {
                     `<div title='Comma-separated list' style='font-family: monospace;'>in</div>`,
                     `<i class='mdi mdi-less-than mdi-18px' title='Less than'></i>`,
                     `<i class='mdi mdi-greater-than mdi-18px' title='Greater than'></i>`,
+                    `<i class='mdi mdi-contain mdi-18px' title='Contains'></i>`,
+                    `<i class='mdi mdi-contain-start mdi-18px' title='Begins With'></i>`,
+                    `<i class='mdi mdi-contain-end mdi-18px' title='Ends With'></i>`,
                 ],
                 'op',
                 opId,
@@ -544,6 +684,19 @@ const Filtering = {
 
         // Value AutoComplete
         Filtering.updateValuesAutoComplete(id, layerName)
+    },
+    makeFilterListSortable: function () {
+        const listToSort = document.getElementById(
+            'layerTool_filtering_filters_list'
+        )
+        Sortable.create(listToSort, {
+            animation: 150,
+            easing: 'cubic-bezier(0.39, 0.575, 0.565, 1)',
+            handle: '.filterDragHandle',
+            onStart: () => {},
+            onChange: () => {},
+            onEnd: () => {},
+        })
     },
     updateValuesAutoComplete: function (id, layerName) {
         let elmId = `#layersTool_filtering_value_value_input_${F_.getSafeName(

--- a/src/essence/Basics/Layers_/Filtering/GeodatasetFilterer.js
+++ b/src/essence/Basics/Layers_/Filtering/GeodatasetFilterer.js
@@ -170,6 +170,33 @@ const GeodatasetFilterer = {
                                 v.matches = true
                             else v.matches = false
                             break
+                        case 'contains':
+                            if (
+                                String(featureValue).indexOf(
+                                    String(filterValue)
+                                ) != -1
+                            )
+                                v.matches = true
+                            else v.matches = false
+                            break
+                        case 'beginswith':
+                            if (
+                                String(featureValue).startsWith(
+                                    String(filterValue)
+                                )
+                            )
+                                v.matches = true
+                            else v.matches = false
+                            break
+                        case 'endswith':
+                            if (
+                                String(featureValue).endsWith(
+                                    String(filterValue)
+                                )
+                            )
+                                v.matches = true
+                            else v.matches = false
+                            break
                         default:
                             break
                     }

--- a/src/essence/Basics/Layers_/Filtering/GeodatasetFilterer.js
+++ b/src/essence/Basics/Layers_/Filtering/GeodatasetFilterer.js
@@ -70,6 +70,7 @@ const GeodatasetFilterer = {
         if (L_.layers.data[layerName]._filter) {
             let fspatial = L_.layers.data[layerName]._filter.spatial
             let fvalues = L_.layers.data[layerName]._filter.values
+            let fvaluesOrder = L_.layers.data[layerName]._filter.valuesOrder
             if (
                 fspatial != null &&
                 fspatial.radius > 0 &&
@@ -83,6 +84,15 @@ const GeodatasetFilterer = {
             if (fvalues != null && fvalues.length > 0) {
                 fvalues = fvalues.filter(Boolean)
 
+                if (fvaluesOrder) {
+                    fvalues.sort((a, b) => {
+                        return (
+                            fvaluesOrder.indexOf(a.id) -
+                            fvaluesOrder.indexOf(b.id)
+                        )
+                    })
+                }
+
                 if (fvalues.length > 0) {
                     let encoded = []
                     fvalues.forEach((v) => {
@@ -92,6 +102,8 @@ const GeodatasetFilterer = {
                                     v.type
                                 }+${v.value.replaceAll(',', '$')}`
                             )
+                        else if (v.isGroup === true && v.op != null)
+                            encoded.push(`${v.op}`)
                     })
                     L_.layers.data[layerName]._filterEncoded.filters =
                         encoded.join(',')


### PR DESCRIPTION
Closes #694 

### Adds
- Logical filter groups: AND, OR, NOT AND
   - Works over geodatasets and local geojson
- Ability to drag and rearrange filter rows
- New filter operators: contains, begins-with, ends-with
   - Works over geodatasets and local geojson

### Updates
- Filtering help updated (yellow rhombus with question-mark icon)

![43645738](https://github.com/user-attachments/assets/deb1ca58-6e3d-4540-b56d-6f59e027bad2)
