### PR TITLE
#693 Support default/preset filters for vector layers

### DIFF
--- a/API/Backend/Geodatasets/routes/geodatasets.js
+++ b/API/Backend/Geodatasets/routes/geodatasets.js
@@ -71,7 +71,7 @@ function get(reqtype, req, res, next) {
       const filterSplit = req.query.filters.split(",");
       filters = [];
       filterSplit.forEach((f) => {
-        if (f === "OR" || f === "AND" || f === "NOT") {
+        if (f === "OR" || f === "AND" || f === "NOT_AND" || f === "NOT_OR") {
           filters.push({
             isGroup: true,
             op: f,
@@ -257,9 +257,17 @@ function get(reqtype, req, res, next) {
                 ) {
                   filterSQL.push(
                     `${
-                      currentGroupOp == "NOT" ? "NOT " : ""
+                      currentGroupOp == "NOT_AND" || currentGroupOp == "NOT_OR"
+                        ? "NOT "
+                        : ""
                     }(${currentGroup.join(
-                      ` ${currentGroupOp == "NOT" ? "AND" : f.op} `
+                      ` ${
+                        currentGroupOp == "NOT_AND"
+                          ? "AND"
+                          : currentGroupOp == "NOT_OR"
+                          ? "OR"
+                          : currentGroupOp
+                      } `
                     )})`
                   );
                   currentGroup = [];
@@ -286,6 +294,12 @@ function get(reqtype, req, res, next) {
                   case "<":
                     op = "<";
                     break;
+                  case ">=":
+                    op = ">=";
+                    break;
+                  case "<=":
+                    op = "<=";
+                    break;
                   case "in":
                     op = "IN";
                     break;
@@ -293,6 +307,9 @@ function get(reqtype, req, res, next) {
                   case "beginswith":
                   case "endswith":
                     op = "LIKE";
+                    break;
+                  case "!=":
+                    op = "!=";
                     break;
                   case "=":
                   default:
@@ -342,9 +359,17 @@ function get(reqtype, req, res, next) {
             // Final group
             if (currentGroup.length > 0) {
               filterSQL.push(
-                `${currentGroupOp == "NOT" ? "NOT " : ""}(${currentGroup.join(
+                `${
+                  currentGroupOp == "NOT_AND" || currentGroupOp == "NOT_OR"
+                    ? "NOT "
+                    : ""
+                }(${currentGroup.join(
                   ` ${
-                    currentGroupOp === "NOT" ? "AND" : currentGroupOp || "AND"
+                    currentGroupOp === "NOT_AND"
+                      ? "AND"
+                      : currentGroupOp === "NOT_OR"
+                      ? "OR"
+                      : currentGroupOp || "AND"
                   } `
                 )})`
               );

--- a/configure/src/metaconfigs/layer-vector-config.json
+++ b/configure/src/metaconfigs/layer-vector-config.json
@@ -556,6 +556,82 @@
       ]
     },
     {
+      "name": "Filter",
+      "rows": [
+        {
+          "name": "Filters",
+          "components": [
+            {
+              "field": "variables.initialFilters",
+              "name": "Initial Filters",
+              "description": "Configures the layer's filters for displaying an initial custom subset of the data.",
+              "type": "objectarray",
+              "width": 12,
+              "object": [
+                {
+                  "field": "type",
+                  "name": "Type of Property",
+                  "description": "If not a Group, whether the property's value should be treated as a string or as a number.",
+                  "type": "dropdown",
+                  "width": 2,
+                  "options": ["string", "number"]
+                },
+                {
+                  "field": "key",
+                  "name": "Property",
+                  "description": "If not a Group, a field name from the properties object of each feature of this layer to be to construct a filter. Supports dot.notation for nested properties.",
+                  "type": "text",
+                  "width": 4
+                },
+                {
+                  "field": "op",
+                  "name": "Operator",
+                  "description": "If not a Group, the operator to use between the 'Property' and 'Value'.",
+                  "type": "dropdown",
+                  "width": 2,
+                  "options": [
+                    "=",
+                    "!=",
+                    ",",
+                    "<",
+                    ">",
+                    "<=",
+                    ">=",
+                    "contains",
+                    "beginswith",
+                    "endswith"
+                  ]
+                },
+                {
+                  "field": "value",
+                  "name": "Value",
+                  "description": "If not a Group, a value for the equation to operate on.",
+                  "type": "text",
+                  "width": 4
+                },
+                {
+                  "field": "isGroup",
+                  "name": "Is A Group",
+                  "description": "A group contains all property-value rows beneath this row and up until the next Group row or up until the end. Groups themselves are always ANDed together but enables member rows within them to abide by a different operator. If this entry 'Is A Group', then the type, property, operator and values fields are ignored.",
+                  "type": "switch",
+                  "width": 6,
+                  "defaultChecked": false
+                },
+                {
+                  "field": "groupOp",
+                  "name": "Group Operator",
+                  "description": "If 'Is A Group', the operator to use for members within the group. 'AND' ands all the group members together. 'OR' ors all the group members together. 'NOT_AND' ands all the group members together and then negates the evaluation. 'NOT_OR' ors all the group members together and then negates the evaluation.",
+                  "type": "dropdown",
+                  "width": 6,
+                  "options": ["AND", "OR", "NOT_AND", "NOT_OR"]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "Interface",
       "rows": [
         {

--- a/src/essence/Ancillary/LocalFilterer.js
+++ b/src/essence/Ancillary/LocalFilterer.js
@@ -318,8 +318,10 @@ const LocalFilterer = {
             let result
             if (group.op === 'OR') {
                 result = group.matches.some(Boolean)
-            } else if (group.op === 'NOT') {
+            } else if (group.op === 'NOT_AND') {
                 result = !group.matches.every(Boolean)
+            } else if (group.op === 'NOT_OR') {
+                result = !group.matches.some(Boolean)
             } else {
                 // default to AND
                 result = group.matches.every(Boolean)

--- a/src/essence/Basics/Layers_/Filtering/Filtering.css
+++ b/src/essence/Basics/Layers_/Filtering/Filtering.css
@@ -168,7 +168,7 @@
     font-size: 13px;
 }
 .layersTool_filtering_group_operator {
-    width: 190px;
+    width: 231px;
     text-align: center;
 }
 
@@ -257,7 +257,10 @@
 .layersTool_filtering_group_operator_select.op_or {
     background: var(--color-c2);
 }
-.layersTool_filtering_group_operator_select.op_not {
+.layersTool_filtering_group_operator_select.op_not_and {
+    background: var(--color-orange2);
+}
+.layersTool_filtering_group_operator_select.op_not_or {
     background: var(--color-p4);
 }
 .layersTool_filtering_group_operator_select .dropy__title span {

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -118,6 +118,8 @@ var LayersTool = {
             LayersTool.make(null, true)
             LayersTool.destroy()
         }
+
+        Filtering.initialize()
     },
     make: function (t, fromInit) {
         this.MMGISInterface = new interfaceWithMMGIS(fromInit)


### PR DESCRIPTION
Closes #693 

### Adds
- A new filter tab to vector layers in the configure page to configure the preset filter for the layer
- `!=`, `>=`, and `<=` filter operators
- NOT_OR filter group

### Fixes
- A bug where hand typing a field name (not using autocomplete) didn't properly update the query.

![783465](https://github.com/user-attachments/assets/ccb7a9c7-b52e-438c-b391-1f756724daca)
