### PR TITLE
Fix bug with noDataValue for single banded COGs

### DIFF
--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -1528,6 +1528,11 @@ function makeImageLayer(layerObj) {
                 'variables.image'
             )
 
+            const hideNoDataValue = F_.getIn(
+                L_.layers.data[layerObj.name],
+                'variables.hideNoDataValue'
+            )
+
             let min = null
             let max = null
             if (georaster.numberOfRasters === 1) {
@@ -1608,10 +1613,15 @@ function makeImageLayer(layerObj) {
                     var pixelValue = values[0] // single band
                     // don't return a color
                     if (
-                        georaster.noDataValue &&
+                        georaster.noDataValue != null &&
                         georaster.noDataValue === pixelValue
                     ) {
-                        return null
+                        if (hideNoDataValue) {
+                            return null
+                        }
+
+                        // Handle the case where we do not want to hide noDataValue
+                        return [0, 0, 0]
                     }
 
                     // scale from 0 - 1

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -2292,14 +2292,28 @@ function interfaceWithMMGIS(fromInit) {
             layerData.cogColormap
         )
 
+        const hideNoDataValue = F_.getIn(
+            L_.layers.data[layerName],
+            'variables.hideNoDataValue'
+        )
+
         let pixelValuesToColorFn = (values) => {
             let georaster = layer.options.georaster
             var pixelValue = values[0] // single band
 
             // don't return a color
-            if (georaster.noDataValue && georaster.noDataValue === pixelValue) {
-                return null
+            if (
+                georaster.noDataValue != null &&
+                georaster.noDataValue === pixelValue
+            ) {
+                if (hideNoDataValue) {
+                    return null
+                }
+
+                // Handle the case where we do not want to hide noDataValue
+                return [0, 0, 0]
             }
+
             // scale from 0 - 1
             var scaledPixelValue = (pixelValue - vMin) / range
             if (!(scaledPixelValue >= 0 && scaledPixelValue <= 1)) {


### PR DESCRIPTION
## Purpose
- This fixes a bug where the noDataValue was not being respected when the noDataValue is in between the min/max data range on an image layer.


## Testing
Tested on a single banded COG image where the noDataValue is in between the min/max data range with the following:
- "Transform COG" checked and "Hide No Data Value" checked
- "Transform COG" checked and "Hide No Data Value" unchecked
- "Transform COG" unchecked and "Hide No Data Value" checked
- "Transform COG" unchecked and "Hide No Data Value" unchecked