### PR TITLE
#704 Upgrade All Adjacent Servers

### DIFF
--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -29,7 +29,7 @@ services:
       - ./ssl:/usr/src/app/ssl
 
   stac-fastapi:
-    image: ghcr.io/stac-utils/stac-fastapi-pgstac:4.0.3
+    image: ghcr.io/stac-utils/stac-fastapi-pgstac:5.0.2
     ports:
       - 8881
     environment:
@@ -57,7 +57,7 @@ services:
       - ./Missions:/Missions
 
   tipg:
-    image: ghcr.io/developmentseed/tipg:0.7.2
+    image: ghcr.io/developmentseed/tipg:1.1.0
     ports:
       - 8882
     environment:
@@ -81,7 +81,7 @@ services:
       - POSTGRES_PORT=5432
       - DB_MIN_CONN_SIZE=1
       - DB_MAX_CONN_SIZE=10
-    command: bash -c "/start.sh"
+    command: bash -c "uvicorn tipg.main:app --host 0.0.0.0 --port 8882"
     depends_on:
       mmgis:
         condition: service_healthy
@@ -96,7 +96,7 @@ services:
     # TODO: remove once https://github.com/rasterio/rasterio-wheels/issues/69 is resolved
     # See https://github.com/developmentseed/titiler/discussions/387
     platform: linux/amd64
-    image: ghcr.io/developmentseed/titiler-uvicorn:0.18.6
+    image: ghcr.io/developmentseed/titiler:0.22.2
     ports:
       - 8883
     environment:
@@ -140,7 +140,7 @@ services:
     # At the time of writing, rasterio and psycopg wheels are not available for arm64 arch
     # so we force the image to be built with linux/amd64
     platform: linux/amd64
-    image: ghcr.io/stac-utils/titiler-pgstac:1.4.0
+    image: ghcr.io/stac-utils/titiler-pgstac:1.8.0
     ports:
       - 8884
     environment:
@@ -191,7 +191,7 @@ services:
       db:
         condition: service_healthy
         restart: true
-    command: bash -c "/start.sh"
+    command: bash -c "uvicorn titiler.pgstac.main:app --host 0.0.0.0 --port 8884"
     volumes:
       - ./Missions:/Missions
 

--- a/python-environment.yml
+++ b/python-environment.yml
@@ -11,11 +11,11 @@ dependencies:
       - rio_stac==0.8.1
       - spiceypy==5.1.2
       - pymap3d==3.0.1
-      - pypgstac==0.8.6
+      - pypgstac==0.9.6
       - python-dotenv[cli]==1.0.1
       - uvicorn==0.30.6
       - psycopg[binary,pool]==3.2.1
-      - stac-fastapi-pgstac==4.0.3
-      - tipg==0.7.2
-      - titiler.application==0.18.6
-      - titiler-pgstac==1.4.0
+      - stac-fastapi-pgstac==5.0.2
+      - tipg==1.1.0
+      - titiler.application==0.22.2
+      - titiler-pgstac==1.8.0

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -1,11 +1,11 @@
 numpy==2.1.0
 spiceypy==5.1.2
 pymap3d==3.0.1
-pypgstac==0.8.6
+pypgstac==0.9.6
 python-dotenv[cli]==1.0.1
 uvicorn==0.30.6
 psycopg[binary,pool]==3.2.1
-stac-fastapi-pgstac==3.0.0
-tipg==0.7.2
-titiler.application==0.18.6
-titiler-pgstac==1.4.0
+stac-fastapi-pgstac==5.0.2
+tipg==1.1.0
+titiler.application==0.22.2
+titiler-pgstac==1.8.0


### PR DESCRIPTION
Closes #704 

- [stac-fastapi](https://github.com/stac-utils/stac-fastapi-pgstac) 4.0.3 -> **5.0.2**
  - Major version upgrade. No migration guide but seems to mainly be a refactor and bugfixes, updates dependencies
- [tipg](https://github.com/developmentseed/tipg) 0.7.2 -> **1.1.0**
  - Major version upgrade. Many breaking changes: renamed/removed/changed endpoints. Okay since it's the first major version and MMGIS doesn't directly interface with tipg yet
- [titiler](https://github.com/developmentseed/titiler) 0.18.6 -> **0.22.2**
  - Includes bugfixes, adds "slope, min, max, mean, median, std, and vars" algorithms, fixes hillshading, returns multipolygons if antimeridian is crossed, removes some generic endpoints in favor of their more specific ones, updates dependencies
  - sample docker-compose.yml used the `ghcr.io/developmentseed/titiler-uvicorn` image; that's been deprecated in favor of just `ghcr.io/developmentseed/titiler`
- [titiler-pgstac](https://github.com/stac-utils/titiler-pgstac) 1.4.0 -> **1.8.0**
  - removes some generic endpoints in favor of their more specific ones, adds a few more options to some endpoints, updates dependencies  
 
Most end python 3.8 support, add python 3.13 and add postgres 17 support