### PR TITLE
#708 User Account Management

### DIFF
--- a/API/Backend/Accounts/routes/accounts.js
+++ b/API/Backend/Accounts/routes/accounts.js
@@ -1,0 +1,239 @@
+/***********************************************************
+ * JavaScript syntax format: ES5/ES6 - ECMAScript 2015
+ * Loading all required dependencies, libraries and packages
+ **********************************************************/
+const express = require("express");
+const router = express.Router();
+const crypto = require("crypto");
+
+const logger = require("../../../logger");
+const userModel = require("../../Users/models/user");
+const User = userModel.User;
+
+router.get("/entries", function (req, res) {
+  User.findAll({
+    attributes: [
+      "id",
+      "username",
+      "email",
+      "permission",
+      "createdAt",
+      "updatedAt",
+    ],
+    order: [["id", "ASC"]],
+  })
+    .then((users) => {
+      res.send({
+        status: "success",
+        body: {
+          entries: users,
+        },
+      });
+    })
+    .catch((err) => {
+      logger("error", "Failed to get user entries.", req.originalUrl, req, err);
+      res.send({
+        status: "failure",
+        message: `Failed to get user entries.`,
+      });
+    });
+});
+
+router.delete("/remove/:id", function (req, res, next) {
+  const id = parseInt(req.params.id);
+
+  if (isNaN(id)) {
+    logger(
+      "error",
+      `Failed to delete user. User Id is null.`,
+      "accounts",
+      null
+    );
+    res.send({
+      status: "failure",
+      message: `Failed to delete user. User Id is null.`,
+    });
+    return null;
+  }
+  if (id === 1) {
+    logger(
+      "error",
+      `Cannot delete the original Administrator account.`,
+      "accounts",
+      null
+    );
+    res.send({
+      status: "failure",
+      message: `Cannot delete the original Administrator account.`,
+    });
+    return null;
+  }
+
+  User.destroy({ where: { id: id } })
+    .then(() => {
+      logger("info", `Successfully deleted user with id: '${id}'.`);
+      res.send({
+        status: "success",
+        message: `Successfully deleted user with id: '${id}'.`,
+        body: {
+          deleted_id: id,
+        },
+      });
+    })
+    .catch((err) => {
+      logger(
+        "error",
+        `Failed to delete user with id: '${id}'.`,
+        "accounts",
+        null,
+        err
+      );
+      res.send({
+        status: "failure",
+        message: `Failed to delete user with id: '${id}'.`,
+      });
+      return null;
+    });
+  return null;
+});
+
+router.post("/update", function (req, res, next) {
+  let id = null;
+  if (req.body.hasOwnProperty("id") && req.body.id != null) {
+    id = parseInt(req.body.id);
+  }
+
+  if (isNaN(id) || id == null) {
+    logger(
+      "error",
+      `Failed to update user. User Id is null.`,
+      "accounts",
+      null
+    );
+    res.send({
+      status: "failure",
+      message: `Failed to update user. User Id is null.`,
+    });
+    return null;
+  }
+
+  //Form update object
+  let toUpdateTo = {};
+  if (req.body.hasOwnProperty("email") && req.body.email != null) {
+    toUpdateTo.email = req.body.email;
+  }
+  if (
+    req.body.hasOwnProperty("permission") &&
+    req.body.permission != null &&
+    (req.body.permission === "111" || req.body.permission === "001")
+  ) {
+    toUpdateTo.permission = req.body.permission;
+  }
+  // Don't allow changing the main admin account's permissions
+  if (id === 1) {
+    delete toUpdateTo.permission;
+  }
+
+  let updateObj = {
+    where: {
+      id: id,
+    },
+  };
+
+  User.update(toUpdateTo, updateObj)
+    .then(() => {
+      res.send({
+        status: "success",
+        message: `Successfully updated user with id: '${id}'.`,
+        body: {
+          updated_id: id,
+        },
+      });
+      return null;
+    })
+    .catch((err) => {
+      logger(
+        "error",
+        `Failed to update user with id: '${id}'.`,
+        req.originalUrl,
+        req,
+        err
+      );
+      res.send({
+        status: "failure",
+        message: `Failed updated user with id: '${id}'.`,
+        body: {},
+      });
+    });
+});
+
+router.post("/generateResetPasswordLink", function (req, res, next) {
+  let id = null;
+  if (req.body.hasOwnProperty("id") && req.body.id != null) {
+    id = parseInt(req.body.id);
+  }
+
+  if (isNaN(id) || id == null) {
+    logger(
+      "error",
+      `Failed to generate a password reset link for user. User Id is null.`,
+      "accounts",
+      null
+    );
+    res.send({
+      status: "failure",
+      message: `Failed to generate a password reset link for user. User Id is null.`,
+    });
+    return null;
+  }
+
+  let expires = 3600000;
+  if (req.body.hasOwnProperty("expires") && req.body.expires != null) {
+    expires = parseInt(req.body.expires);
+  }
+
+  if (isNaN(expires) || expires == null) {
+    expires = 3600000;
+  }
+
+  //Form update object
+  let toUpdateTo = {
+    reset_token: crypto.randomBytes(64).toString("hex"),
+    reset_token_expiration: Date.now() + expires,
+  };
+
+  let updateObj = {
+    where: {
+      id: id,
+    },
+  };
+
+  User.update(toUpdateTo, updateObj)
+    .then(() => {
+      res.send({
+        status: "success",
+        message: `Successfully generated a password reset token for user with id: '${id}'.`,
+        body: {
+          resetToken: toUpdateTo.reset_token,
+          resetTokenExpiration: toUpdateTo.reset_token_expiration,
+        },
+      });
+      return null;
+    })
+    .catch((err) => {
+      logger(
+        "error",
+        `Failed to generate a password reset token for user with id: '${id}'.`,
+        req.originalUrl,
+        req,
+        err
+      );
+      res.send({
+        status: "failure",
+        message: `Failed to generate a password reset token for user with id: '${id}'.`,
+        body: {},
+      });
+    });
+});
+
+module.exports = router;

--- a/API/Backend/Accounts/routes/accounts.js
+++ b/API/Backend/Accounts/routes/accounts.js
@@ -198,7 +198,7 @@ router.post("/generateResetPasswordLink", function (req, res, next) {
 
   //Form update object
   let toUpdateTo = {
-    reset_token: crypto.randomBytes(64).toString("hex"),
+    reset_token: crypto.randomBytes(32).toString("hex"),
     reset_token_expiration: Date.now() + expires,
   };
 

--- a/API/Backend/Accounts/setup.js
+++ b/API/Backend/Accounts/setup.js
@@ -1,0 +1,21 @@
+const router = require("./routes/accounts");
+
+let setup = {
+  //Once the app initializes
+  onceInit: (s) => {
+    s.app.use(
+      s.ROOT_PATH + "/api/accounts",
+      s.checkHeadersCodeInjection,
+      s.ensureAdmin(),
+      s.checkHeadersCodeInjection,
+      s.setContentType,
+      router
+    );
+  },
+  //Once the server starts
+  onceStarted: (s) => {},
+  //Once all tables sync
+  onceSynced: (s) => {},
+};
+
+module.exports = setup;

--- a/API/Backend/Config/setup.js
+++ b/API/Backend/Config/setup.js
@@ -39,7 +39,7 @@ let setup = {
         s.ensureGroup(s.permissions.users),
         s.ensureAdmin(true),
         (req, res) => {
-          const user = process.env.AUTH === "csso" ? req.user : null;
+          const user = process.env.AUTH === "csso" ? req.user : req.user || "";
           res.render("../configure/build/index.pug", {
             user: user,
             AUTH: process.env.AUTH,

--- a/API/Backend/Users/models/user.js
+++ b/API/Backend/Users/models/user.js
@@ -66,10 +66,8 @@ var User = sequelize.define(
         user.password = bcrypt.hashSync(user.password, salt);
       },
       beforeUpdate: (user) => {
-        if (user.changed("password")) {
-          const salt = bcrypt.genSaltSync();
-          user.password = bcrypt.hashSync(user.password, salt);
-        }
+        const salt = bcrypt.genSaltSync();
+        user.password = bcrypt.hashSync(user.password, salt);
       },
     },
   },

--- a/API/Backend/Users/models/user.js
+++ b/API/Backend/Users/models/user.js
@@ -65,6 +65,12 @@ var User = sequelize.define(
         const salt = bcrypt.genSaltSync();
         user.password = bcrypt.hashSync(user.password, salt);
       },
+      beforeUpdate: (user) => {
+        if (user.changed("password")) {
+          const salt = bcrypt.genSaltSync();
+          user.password = bcrypt.hashSync(user.password, salt);
+        }
+      },
     },
   },
   {

--- a/API/Backend/Users/models/user.js
+++ b/API/Backend/Users/models/user.js
@@ -50,6 +50,14 @@ var User = sequelize.define(
       type: Sequelize.DataTypes.STRING(2048),
       allowNull: true,
     },
+    reset_token: {
+      type: Sequelize.DataTypes.STRING(2048),
+      allowNull: true,
+    },
+    reset_token_expiration: {
+      type: Sequelize.DataTypes.BIGINT,
+      allowNull: true,
+    },
   },
   {
     hooks: {
@@ -69,5 +77,51 @@ User.prototype.validPassword = function (password, user) {
   return bcrypt.compareSync(password, user.password);
 };
 
+// Adds to the table, never removes
+const up = async () => {
+  // resetToken column
+  await sequelize
+    .query(
+      `ALTER TABLE users ADD COLUMN IF NOT EXISTS reset_token varchar(2048) NULL;`
+    )
+    .then(() => {
+      return null;
+    })
+    .catch((err) => {
+      logger(
+        "error",
+        `Failed to add users.reset_token column. DB tables may be out of sync!`,
+        "user",
+        null,
+        err
+      );
+      return null;
+    });
+
+  // resetTokenExpiration column
+  await sequelize
+    .query(
+      `ALTER TABLE users ADD COLUMN IF NOT EXISTS reset_token_expiration BIGINT NULL;`
+    )
+    .then(() => {
+      return null;
+    })
+    .catch((err) => {
+      logger(
+        "error",
+        `Failed to add users.reset_token_expiration column. DB tables may be out of sync!`,
+        "user",
+        null,
+        err
+      );
+      return null;
+    });
+};
+
 // export User model for use in other files.
 module.exports = User;
+
+module.exports = {
+  User: User,
+  up,
+};

--- a/API/Backend/Users/models/user.js
+++ b/API/Backend/Users/models/user.js
@@ -25,8 +25,8 @@ var User = sequelize.define(
           User.findOne({ where: { email: value } })
             .then(function (user) {
               // reject if a different user wants to use the same email
-              if (user && self.id !== user.id) {
-                return next("User exists!");
+              if (value != null && value != "" && user && self.id !== user.id) {
+                return next("User email already exists!");
               }
               return next();
             })

--- a/API/Backend/Users/routes/users.js
+++ b/API/Backend/Users/routes/users.js
@@ -74,12 +74,17 @@ router.post("/first_signup", function (req, res, next) {
 
 router.post("/signup", function (req, res, next) {
   if (
-    (process.env.AUTH === "local" && req.session.permission !== "111") ||
+    (process.env.AUTH === "local" &&
+      req.session.permission !== "111" &&
+      !(
+        process.env.AUTH_LOCAL_ALLOW_SIGNUP === true ||
+        process.env.AUTH_LOCAL_ALLOW_SIGNUP === "true"
+      )) ||
     (process.env.AUTH === "off" && req.session.permission !== "111")
   ) {
     res.send({
       status: "failure",
-      message: "Currently set so only administrators may create accounts.",
+      message: "Currently only administrators may create accounts.",
     });
     return;
   }
@@ -106,7 +111,7 @@ router.post("/signup", function (req, res, next) {
   // Define a new user
   let newUser = {
     username: req.body.username,
-    email: req.body.email,
+    email: req.body.email == "" ? null : req.body.email,
     password: req.body.password,
     permission: "001",
     token: null,
@@ -119,7 +124,7 @@ router.post("/signup", function (req, res, next) {
     },
   })
     .then((user) => {
-      if (!user) {
+      if (user == null) {
         User.create(newUser)
           .then((created) => {
             // Just make the account -- don't also login
@@ -193,12 +198,22 @@ router.post("/signup", function (req, res, next) {
             return null;
           })
           .catch((err) => {
-            logger("error", "Failed to sign up.", req.originalUrl, req, err);
-            res.send({ status: "failure", message: "Failed to sign up." });
+            logger(
+              "error",
+              "Failed to sign up. Email might be invalid or already in use.",
+              req.originalUrl,
+              req,
+              err
+            );
+            res.send({
+              status: "failure",
+              message:
+                "Failed to sign up. Email might be invalid or already in use.",
+            });
             return null;
           });
       } else {
-        res.send({ status: "failure", message: "User already exists." });
+        res.send({ status: "failure", message: "Username already exists." });
       }
       return null;
     })

--- a/API/Backend/Users/routes/users.js
+++ b/API/Backend/Users/routes/users.js
@@ -12,6 +12,22 @@ const logger = require("../../../logger");
 const userModel = require("../models/user");
 const User = userModel.User;
 
+function isStrongPassword(password) {
+  const minLength = 8;
+  const hasUpper = /[A-Z]/.test(password);
+  const hasLower = /[a-z]/.test(password);
+  const hasNumber = /[0-9]/.test(password);
+  const hasSymbol = /[^A-Za-z0-9]/.test(password);
+
+  return (
+    password.length >= minLength &&
+    hasUpper &&
+    hasLower &&
+    hasNumber &&
+    hasSymbol
+  );
+}
+
 router.post("/has", function (req, res, next) {
   User.count()
     .then((count) => {
@@ -67,6 +83,26 @@ router.post("/signup", function (req, res, next) {
     });
     return;
   }
+
+  const skipLogin = req.body.skipLogin === true;
+
+  if (req.body.username == null || req.body.username == "") {
+    res.send({
+      status: "failure",
+      message: "Username must be set.",
+    });
+    return;
+  }
+
+  if (!isStrongPassword(req.body.password)) {
+    res.send({
+      status: "failure",
+      message:
+        "Password is not strong enough. Must be at least 8 characters long and contain at least: 1 uppercase letter, 1 lowercase letter, 1 number and 1 symbol.",
+    });
+    return;
+  }
+
   // Define a new user
   let newUser = {
     username: req.body.username,
@@ -86,6 +122,24 @@ router.post("/signup", function (req, res, next) {
       if (!user) {
         User.create(newUser)
           .then((created) => {
+            // Just make the account -- don't also login
+            if (skipLogin === true) {
+              logger(
+                "info",
+                req.body.username + " signed up.",
+                req.originalUrl,
+                req
+              );
+              res.send({
+                status: "success",
+                username: req.body.username,
+                token: null,
+                groups: [],
+              });
+              return null;
+            }
+
+            // Otherwise login too
             clearLoginSession(req);
             req.session.regenerate((err) => {
               // Save the user's info in the session
@@ -381,19 +435,13 @@ router.post("/resetPassword", function (req, res) {
               message: `Password reset time expired.`,
             });
           } else {
-            User.update(
-              {
-                password: password,
-                reset_token: null,
-                reset_token_expiration: null,
-              },
-              {
-                where: {
-                  username: username,
-                  reset_token: resetToken,
-                },
-              }
-            )
+            user.password = password;
+            user.reset_token = null;
+            user.reset_token_expiration = null;
+
+            // using user.save() so that the beforeUpdate hook gets triggered (User.update() doesn't trigger it)
+            user
+              .save()
               .then(() => {
                 res.send({
                   status: "success",

--- a/API/Backend/Users/routes/users.js
+++ b/API/Backend/Users/routes/users.js
@@ -343,6 +343,93 @@ router.get("/logged_in", function (req, res) {
     });
 });
 
+router.post("/resetPassword", function (req, res) {
+  let username = req.body.username;
+  let password = req.body.password;
+  let resetToken = req.body.resetToken;
+
+  if (username == null || username == "") {
+    res.send({ status: "failure", message: "Missing username." });
+  } else if (password == null || password == "") {
+    res.send({ status: "failure", message: "Missing password." });
+  } else if (resetToken == null || resetToken == "") {
+    res.send({ status: "failure", message: "Missing resetToken." });
+  } else {
+    User.findOne({
+      where: {
+        username: username,
+        reset_token: resetToken,
+      },
+      attributes: [
+        "id",
+        "username",
+        "email",
+        "password",
+        "permission",
+        "reset_token",
+        "reset_token_expiration",
+      ],
+    })
+      .then((user) => {
+        if (user) {
+          if (
+            user.reset_token_expiration == null ||
+            Date.now() >= user.reset_token_expiration
+          ) {
+            res.send({
+              status: "failure",
+              message: `Password reset time expired.`,
+            });
+          } else {
+            User.update(
+              {
+                password: password,
+                reset_token: null,
+                reset_token_expiration: null,
+              },
+              {
+                where: {
+                  username: username,
+                  reset_token: resetToken,
+                },
+              }
+            )
+              .then(() => {
+                res.send({
+                  status: "success",
+                  message: `Successfully reset password for user: ${username}`,
+                });
+              })
+              .catch((err) => {
+                logger(
+                  "error",
+                  `Failed to reset password for user: ${username}`,
+                  req.originalUrl,
+                  req,
+                  err
+                );
+                res.send({
+                  status: "failure",
+                  message: `Failed to reset password for user: ${username}`,
+                });
+              });
+          }
+        } else {
+          res.send({
+            status: "failure",
+            message: `Invalid username or reset token.`,
+          });
+        }
+        return null;
+      })
+      .catch((err) => {
+        logger("error", "Password reset failed.", req.originalUrl, req, err);
+        res.send({ status: "failure", message: "Password reset failed." });
+        return null;
+      });
+  }
+});
+
 function getUserGroups(user, leadGroupName) {
   let leads = process.env.LEADS ? JSON.parse(process.env.LEADS) : [];
   let groups = {};

--- a/API/Backend/Users/routes/users.js
+++ b/API/Backend/Users/routes/users.js
@@ -9,7 +9,8 @@ const bcrypt = require("bcryptjs");
 const buf = crypto.randomBytes(128);
 
 const logger = require("../../../logger");
-const User = require("../models/user");
+const userModel = require("../models/user");
+const User = userModel.User;
 
 router.post("/has", function (req, res, next) {
   User.count()

--- a/API/Backend/Users/setup.js
+++ b/API/Backend/Users/setup.js
@@ -1,5 +1,7 @@
 const router = require("./routes/users");
 
+const userModel = require("./models/user");
+
 let setup = {
   //Once the app initializes
   onceInit: (s) => {
@@ -8,7 +10,11 @@ let setup = {
   //Once the server starts
   onceStarted: (s) => {},
   //Once all tables sync
-  onceSynced: (s) => {},
+  onceSynced: (s) => {
+    if (typeof userModel.up === "function") {
+      userModel.up();
+    }
+  },
 };
 
 module.exports = setup;

--- a/configuration/env.js
+++ b/configuration/env.js
@@ -96,8 +96,10 @@ function getClientEnvironment(publicUrl) {
         WDS_SOCKET_PORT: process.env.WDS_SOCKET_PORT,
         // MMGIS
         AUTH: process.env.AUTH,
+        AUTH_LOCAL_ALLOW_SIGNUP: process.env.AUTH_LOCAL_ALLOW_SIGNUP,
         VERSION: packagejson.version,
         CLEARANCE_NUMBER: process.env.CLEARANCE_NUMBER,
+        CONTACT_INFO: process.env.CONTACT_INFO,
         LINK_PREVIEW_TITLE: process.env.LINK_PREVIEW_TITLE,
         LINK_PREVIEW_DESCRIPTION: process.env.LINK_PREVIEW_DESCRIPTION,
         HOSTS: JSON.stringify({

--- a/configure/src/components/Main/Main.js
+++ b/configure/src/components/Main/Main.js
@@ -1,3 +1,5 @@
+/* global mmgisglobal */
+
 import React, { useEffect, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import {} from "./MainSlice";
@@ -41,6 +43,7 @@ import WebHooks from "../../pages/WebHooks/WebHooks";
 import APIs from "../../pages/APIs/APIs";
 import STAC from "../../pages/STAC/STAC";
 import GeneralOptions from "../../pages/GeneralOptions/GeneralOptions";
+import Users from "../../pages/Users/Users";
 
 const useStyles = makeStyles((theme) => ({
   Main: {
@@ -64,6 +67,18 @@ const useStyles = makeStyles((theme) => ({
     background: theme.palette.swatches.grey[1000],
     boxShadow: `inset 10px 0px 10px -5px rgba(0,0,0,0.3)`,
     borderBottom: `2px solid ${theme.palette.swatches.grey[800]} !important`,
+  },
+  topbarPage: {
+    width: "100%",
+    height: "48px",
+    minHeight: "48px",
+    display: "flex",
+    justifyContent: "space-between",
+    boxSizing: "border-box",
+    background: theme.palette.swatches.grey[1000],
+    boxShadow: `inset 10px 0px 10px -5px rgba(0,0,0,0.3)`,
+    borderBottom: `2px solid ${theme.palette.swatches.grey[800]} !important`,
+    position: "absolute",
   },
   left: {
     display: "flex",
@@ -127,6 +142,12 @@ const useStyles = makeStyles((theme) => ({
     opacity: 0.6,
   },
   page: { height: "100%" },
+  username: {
+    lineHeight: "40px",
+    padding: "0px 4px",
+    letterSpacing: "1px",
+    color: "#1a1a1a",
+  },
 }));
 
 export default function Main() {
@@ -195,6 +216,9 @@ export default function Main() {
     case "general_options":
       Page = <GeneralOptions />;
       break;
+    case "users":
+      Page = <Users />;
+      break;
     default:
   }
 
@@ -252,7 +276,22 @@ export default function Main() {
   return (
     <div className={c.Main}>
       {Page != null ? (
-        <div className={c.page}>{Page}</div>
+        <>
+          <div className={c.topbarPage}>
+            <div className={c.left}></div>
+            <div className={c.right}>
+              <Tooltip title="Signed in as" placement="bottom" arrow>
+                <div className={c.username}>{mmgisglobal?.user}</div>
+              </Tooltip>
+              <Tooltip title="Sign-out" placement="bottom" arrow>
+                <IconButton onClick={signout}>
+                  <LogoutIcon fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
+            </div>
+          </div>
+          <div className={c.page}>{Page}</div>
+        </>
       ) : mission == null ? (
         <div className={c.introWrapper}>
           <div className={c.topbar}>
@@ -270,6 +309,9 @@ export default function Main() {
               </Tooltip>
             </div>
             <div className={c.right}>
+              <Tooltip title="Signed in as" placement="bottom" arrow>
+                <div className={c.username}>{mmgisglobal?.user}</div>
+              </Tooltip>
               <Tooltip title="Sign-out" placement="bottom" arrow>
                 <IconButton onClick={signout}>
                   <LogoutIcon fontSize="inherit" />
@@ -337,6 +379,9 @@ export default function Main() {
               </Tabs>
             </div>
             <div className={c.right}>
+              <Tooltip title="Signed in as" placement="bottom" arrow>
+                <div className={c.username}>{mmgisglobal?.user}</div>
+              </Tooltip>
               <Tooltip title="Sign-out" placement="bottom" arrow>
                 <IconButton onClick={signout}>
                   <LogoutIcon fontSize="inherit" />

--- a/configure/src/components/Panel/Panel.js
+++ b/configure/src/components/Panel/Panel.js
@@ -20,6 +20,7 @@ import PhishingIcon from "@mui/icons-material/Phishing";
 import ApiIcon from "@mui/icons-material/Api";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import HorizontalSplitIcon from "@mui/icons-material/HorizontalSplit";
+import AccountBoxIcon from "@mui/icons-material/AccountBox";
 
 const useStyles = makeStyles((theme) => ({
   Panel: {
@@ -265,6 +266,19 @@ export default function Panel() {
             }}
           >
             General Options
+          </Button>
+
+          <Button
+            className={c.pageButton}
+            variant="contained"
+            disableElevation
+            startIcon={<AccountBoxIcon size="small" />}
+            onClick={() => {
+              dispatch(setMission(null));
+              dispatch(setPage({ page: "users" }));
+            }}
+          >
+            Users
           </Button>
         </div>
       </div>

--- a/configure/src/core/ConfigureStore.js
+++ b/configure/src/core/ConfigureStore.js
@@ -15,6 +15,7 @@ export const ConfigureStore = createSlice({
     geodatasets: [],
     datasets: [],
     stacCollections: [],
+    userEntries: [],
     page: null,
     modal: {
       newMission: false,
@@ -37,6 +38,10 @@ export const ConfigureStore = createSlice({
       uploadConfig: false,
       cloneConfig: false,
       deleteConfig: false,
+      updateUser: false,
+      deleteUser: false,
+      newUser: false,
+      resetPassword: false,
     },
     snackBarText: false,
     lockConfig: false,
@@ -69,6 +74,9 @@ export const ConfigureStore = createSlice({
     },
     setStacCollections: (state, action) => {
       state.stacCollections = action.payload;
+    },
+    setUserEntries: (state, action) => {
+      state.userEntries = action.payload;
     },
     setPage: (state, action) => {
       state.page = action.payload.page;
@@ -196,6 +204,7 @@ export const {
   setGeodatasets,
   setDatasets,
   setStacCollections,
+  setUserEntries,
   setPage,
   setModal,
   setSnackBarText,

--- a/configure/src/core/calls.js
+++ b/configure/src/core/calls.js
@@ -102,6 +102,22 @@ const c = {
     type: "DELETE",
     url: "stac/collections/:collection",
   },
+  account_entries: {
+    type: "GET",
+    url: "api/accounts/entries",
+  },
+  account_delete_user: {
+    type: "DELETE",
+    url: "api/accounts/remove/:id",
+  },
+  account_update_user: {
+    type: "POST",
+    url: "api/accounts/update",
+  },
+  account_reset_password_link: {
+    type: "POST",
+    url: "api/accounts/generateResetPasswordLink",
+  },
   longtermtoken_get: {
     type: "GET",
     url: "api/longtermtoken/get",

--- a/configure/src/core/calls.js
+++ b/configure/src/core/calls.js
@@ -118,6 +118,10 @@ const c = {
     type: "POST",
     url: "api/accounts/generateResetPasswordLink",
   },
+  user_signup: {
+    type: "POST",
+    url: "api/users/signup",
+  },
   longtermtoken_get: {
     type: "GET",
     url: "api/longtermtoken/get",

--- a/configure/src/core/constants.js
+++ b/configure/src/core/constants.js
@@ -2,6 +2,10 @@ export const publicUrl = `${window.location.pathname
   .replace(`configure`, "")
   .replace(/^\//g, "")}configure`;
 
+export const publicUrlMainSite = `${
+  window.location.origin
+}${window.location.pathname.replace(`configure`, "").replace(/^\//g, "")}`;
+
 export const endpoints = {};
 
 export const HASH_PATHS = {

--- a/configure/src/pages/APITokens/APITokens.js
+++ b/configure/src/pages/APITokens/APITokens.js
@@ -12,6 +12,7 @@ import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Tooltip from "@mui/material/Tooltip";
 
+import Toolbar from "@mui/material/Toolbar";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import InputLabel from "@mui/material/InputLabel";
@@ -32,7 +33,6 @@ const useStyles = makeStyles((theme) => ({
     flexFlow: "column",
     background: theme.palette.swatches.grey[1000],
     backgroundImage: "url(configure/build/gridlines.png)",
-    paddingBottom: "64px",
     overflowY: "auto",
     height: "100vh",
     boxSizing: "border-box",
@@ -41,6 +41,23 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     paddingBottom: "10px",
     height: "48px",
+  },
+  topbar: {
+    width: "calc(100% - 100px)",
+    height: "44px",
+    minHeight: "44px !important",
+    display: "flex",
+    justifyContent: "space-between",
+    padding: `0px 20px`,
+    boxSizing: `border-box !important`,
+  },
+  topbarTitle: {
+    display: "flex",
+    color: theme.palette.swatches.grey[150],
+    "& > svg": {
+      color: theme.palette.swatches.grey[150],
+      margin: "3px 10px 0px 2px",
+    },
   },
   title: {
     margin: "18px 0px 0px 60px",
@@ -54,7 +71,7 @@ const useStyles = makeStyles((theme) => ({
     margin: "20px 60px",
   },
   subtitle: {
-    margin: "0px 60px 0px 60px !important",
+    margin: "30px 60px 0px 60px !important",
     fontSize: "13px !important",
     paddingBottom: "5px",
     fontStyle: "italic",
@@ -164,6 +181,10 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: "4px",
     background: theme.palette.swatches.grey[900],
     wordBreak: "break-all",
+  },
+  content: {
+    width: "100%",
+    overflowY: "auto",
   },
 }));
 
@@ -278,10 +299,19 @@ export default function APITokens() {
 
   return (
     <div className={c.APITokens}>
-      <div className={c.top}>
-        <div className={c.title}>API Tokens</div>
-      </div>
-      <div>
+      <Toolbar className={c.topbar}>
+        <div className={c.topbarTitle}>
+          <KeyIcon />
+          <Typography
+            style={{ fontWeight: "bold", fontSize: "16px", lineHeight: "29px" }}
+            variant="h6"
+            component="div"
+          >
+            API Tokens
+          </Typography>
+        </div>
+      </Toolbar>
+      <div className={c.content}>
         <Typography className={c.subtitle}>
           {
             "Generate an authentication token for programmatic control over the configuration and data endpoints. The generated token may be used it requests via the header: 'Authorization:Bearer <token>' and more information can be found at https://nasa-ammos.github.io/MMGIS/apis/configure#api-tokens"

--- a/configure/src/pages/APIs/APIs.js
+++ b/configure/src/pages/APIs/APIs.js
@@ -81,9 +81,9 @@ const useStyles = makeStyles((theme) => ({
     backgroundImage: "url(configure/build/gridlines.png)",
   },
   topbar: {
-    width: "100%",
-    height: "48px",
-    minHeight: "48px !important",
+    width: "calc(100% - 100px)",
+    height: "44px",
+    minHeight: "44px !important",
     display: "flex",
     justifyContent: "space-between",
     padding: `0px 20px`,

--- a/configure/src/pages/GeneralOptions/GeneralOptions.js
+++ b/configure/src/pages/GeneralOptions/GeneralOptions.js
@@ -81,9 +81,9 @@ const useStyles = makeStyles((theme) => ({
     boxSizing: "border-box",
   },
   topbar: {
-    width: "100%",
-    height: "48px",
-    minHeight: "48px !important",
+    width: "calc(100% - 100px)",
+    height: "44px",
+    minHeight: "44px !important",
     display: "flex",
     justifyContent: "space-between",
     padding: `0px 20px`,

--- a/configure/src/pages/GeoDatasets/GeoDatasets.js
+++ b/configure/src/pages/GeoDatasets/GeoDatasets.js
@@ -161,9 +161,9 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   topbar: {
-    width: "100%",
-    height: "48px",
-    minHeight: "48px !important",
+    width: "calc(100% - 100px)",
+    height: "44px",
+    minHeight: "44px !important",
     display: "flex",
     justifyContent: "space-between",
     padding: `0px 20px`,

--- a/configure/src/pages/STAC/STAC.js
+++ b/configure/src/pages/STAC/STAC.js
@@ -162,9 +162,9 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   topbar: {
-    width: "100%",
-    height: "48px",
-    minHeight: "48px !important",
+    width: "calc(100% - 100px)",
+    height: "44px",
+    minHeight: "44px !important",
     display: "flex",
     justifyContent: "space-between",
     padding: `0px 20px`,

--- a/configure/src/pages/Users/Modals/DeleteUserModal/DeleteUserModal.js
+++ b/configure/src/pages/Users/Modals/DeleteUserModal/DeleteUserModal.js
@@ -272,6 +272,9 @@ const DeleteUserModal = (props) => {
           label="Confirm Username"
           variant="filled"
           value={userName}
+          inputProps={{
+            autoComplete: "off",
+          }}
           onChange={(e) => {
             setUserName(e.target.value);
           }}

--- a/configure/src/pages/Users/Modals/DeleteUserModal/DeleteUserModal.js
+++ b/configure/src/pages/Users/Modals/DeleteUserModal/DeleteUserModal.js
@@ -1,0 +1,300 @@
+import React, { useState } from "react";
+import { useSelector, useDispatch } from "react-redux";
+
+import { calls } from "../../../../core/calls";
+
+import { setModal, setSnackBarText } from "../../../../core/ConfigureStore";
+
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import IconButton from "@mui/material/IconButton";
+
+import CloseSharpIcon from "@mui/icons-material/CloseSharp";
+import AccountBoxIcon from "@mui/icons-material/AccountBox";
+import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
+
+import TextField from "@mui/material/TextField";
+
+import { makeStyles, useTheme } from "@mui/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
+
+const useStyles = makeStyles((theme) => ({
+  Modal: {
+    margin: theme.headHeights[1],
+    [theme.breakpoints.down("xs")]: {
+      margin: "6px",
+    },
+    "& .MuiDialog-container": {
+      height: "unset !important",
+      transform: "translateX(-50%) translateY(-50%)",
+      left: "50%",
+      top: "50%",
+      position: "absolute",
+    },
+  },
+  contents: {
+    background: theme.palette.primary.main,
+    height: "100%",
+    width: "500px",
+  },
+  heading: {
+    height: theme.headHeights[2],
+    boxSizing: "border-box",
+    background: theme.palette.swatches.p[4],
+    borderBottom: `1px solid ${theme.palette.swatches.grey[800]}`,
+    padding: `4px ${theme.spacing(2)} 4px ${theme.spacing(4)} !important`,
+  },
+  title: {
+    padding: `8px 0px`,
+    fontSize: theme.typography.pxToRem(16),
+    fontWeight: "bold",
+    color: theme.palette.swatches.grey[0],
+    textTransform: "uppercase",
+  },
+  content: {
+    padding: "8px 16px 16px 16px !important",
+    height: `calc(100% - ${theme.headHeights[2]}px)`,
+  },
+  closeIcon: {
+    padding: theme.spacing(1.5),
+    height: "100%",
+    margin: "4px 0px",
+  },
+  flexBetween: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
+  subtitle: {
+    fontSize: "14px !important",
+    width: "100%",
+    marginBottom: "8px !important",
+    color: theme.palette.swatches.grey[300],
+    letterSpacing: "0.2px",
+  },
+  subtitle2: {
+    fontSize: "12px !important",
+    fontStyle: "italic",
+    width: "100%",
+    marginBottom: "8px !important",
+    color: theme.palette.swatches.grey[400],
+  },
+  confirmInput: {
+    width: "100%",
+    margin: "10px 0px 4px 0px !important",
+    borderTop: `1px solid ${theme.palette.swatches.grey[500]}`,
+  },
+  backgroundIcon: {
+    margin: "7px 8px 0px 0px",
+  },
+
+  fileName: {
+    textAlign: "center",
+    fontWeight: "bold",
+    letterSpacing: "1px",
+    marginBottom: "10px",
+    borderBottom: `1px solid ${theme.palette.swatches.grey[500]}`,
+    paddingBottom: "10px",
+  },
+
+  layerName: {
+    textAlign: "center",
+    fontSize: "24px !important",
+    letterSpacing: "1px !important",
+    color: theme.palette.swatches.p[4],
+    fontWeight: "bold !important",
+    margin: "10px !important",
+    borderBottom: `1px solid ${theme.palette.swatches.grey[100]}`,
+    paddingBottom: "10px",
+  },
+  hasOccurrencesTitle: {
+    margin: "10px",
+    display: "flex",
+  },
+  hasOccurrences: {
+    fontStyle: "italic",
+  },
+  mission: {
+    background: theme.palette.swatches.p[11],
+    color: theme.palette.swatches.grey[900],
+    height: "24px",
+    lineHeight: "24px",
+    padding: "0px 5px",
+    borderRadius: "3px",
+    display: "inline-block",
+    letterSpacing: "1px",
+    marginLeft: "20px",
+  },
+  pathName: {
+    display: "flex",
+    marginLeft: "40px",
+    marginTop: "4px",
+    height: "24px",
+    lineHeight: "24px",
+  },
+  path: {
+    color: theme.palette.swatches.grey[500],
+  },
+  name: {
+    color: theme.palette.swatches.grey[100],
+    fontWeight: "bold",
+  },
+  confirmMessage: {
+    fontStyle: "italic",
+    fontSize: "15px !important",
+  },
+  dialogActions: {
+    display: "flex !important",
+    justifyContent: "space-between !important",
+  },
+  delete: {
+    background: `${theme.palette.swatches.p[4]} !important`,
+    color: `${theme.palette.swatches.grey[1000]} !important`,
+    "&:hover": {
+      background: `${theme.palette.swatches.grey[0]} !important`,
+    },
+  },
+  cancel: {},
+}));
+
+const MODAL_NAME = "deleteUser";
+const DeleteUserModal = (props) => {
+  const { queryUsers } = props;
+  const c = useStyles();
+
+  const modal = useSelector((state) => state.core.modal[MODAL_NAME]);
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  const dispatch = useDispatch();
+
+  const [userName, setUserName] = useState(null);
+
+  const handleClose = () => {
+    // close modal
+    dispatch(setModal({ name: MODAL_NAME, on: false }));
+  };
+  const handleSubmit = () => {
+    if (!modal?.row?.id) {
+      dispatch(
+        setSnackBarText({
+          text: "Cannot delete undefined User.",
+          severity: "error",
+        })
+      );
+      return;
+    }
+
+    if (userName !== modal.row.username) {
+      dispatch(
+        setSnackBarText({
+          text: "Confirmation Username does not match.",
+          severity: "error",
+        })
+      );
+      return;
+    }
+
+    calls.api(
+      "account_delete_user",
+      {
+        urlReplacements: {
+          id: modal.row.id,
+        },
+      },
+      (res) => {
+        if (res.body?.deleted_id === modal.row.id) {
+          dispatch(
+            setSnackBarText({
+              text: `Successfully deleted '${modal.row.username}'.`,
+              severity: "success",
+            })
+          );
+          queryUsers();
+          handleClose();
+        } else {
+          dispatch(
+            setSnackBarText({
+              text: `Failed to delete '${modal.row.username}'.`,
+              severity: "error",
+            })
+          );
+        }
+      },
+      (res) => {
+        dispatch(
+          setSnackBarText({
+            text: `Failed to delete '${modal.row.username}'.`,
+            severity: "error",
+          })
+        );
+      }
+    );
+  };
+
+  return (
+    <Dialog
+      className={c.Modal}
+      fullScreen={isMobile}
+      open={modal !== false}
+      onClose={handleClose}
+      aria-labelledby="responsive-dialog-title"
+      PaperProps={{
+        className: c.contents,
+      }}
+    >
+      <DialogTitle className={c.heading}>
+        <div className={c.flexBetween}>
+          <div className={c.flexBetween}>
+            <AccountBoxIcon className={c.backgroundIcon} />
+            <div className={c.title}>Delete a User's Account</div>
+          </div>
+          <IconButton
+            className={c.closeIcon}
+            title="Close"
+            aria-label="close"
+            onClick={handleClose}
+          >
+            <CloseSharpIcon fontSize="inherit" />
+          </IconButton>
+        </div>
+      </DialogTitle>
+      <DialogContent className={c.content}>
+        <Typography
+          className={c.layerName}
+        >{`Deleting: ${modal?.row?.username}`}</Typography>
+        <TextField
+          className={c.confirmInput}
+          label="Confirm Username"
+          variant="filled"
+          value={userName}
+          onChange={(e) => {
+            setUserName(e.target.value);
+          }}
+        />
+        <Typography
+          className={c.subtitle2}
+        >{`Enter '${modal?.row?.username}' above and click 'Delete' to confirm the permanent deletion of this user's account.`}</Typography>
+      </DialogContent>
+      <DialogActions className={c.dialogActions}>
+        <Button
+          className={c.delete}
+          variant="contained"
+          startIcon={<DeleteForeverIcon size="small" />}
+          onClick={handleSubmit}
+        >
+          Delete
+        </Button>
+        <Button className={c.cancel} variant="outlined" onClick={handleClose}>
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeleteUserModal;

--- a/configure/src/pages/Users/Modals/NewUserModal/NewUserModal.js
+++ b/configure/src/pages/Users/Modals/NewUserModal/NewUserModal.js
@@ -1,0 +1,336 @@
+import React, { useState } from "react";
+import { useSelector, useDispatch } from "react-redux";
+
+import { calls } from "../../../../core/calls";
+
+import { setModal, setSnackBarText } from "../../../../core/ConfigureStore";
+
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import IconButton from "@mui/material/IconButton";
+
+import CloseSharpIcon from "@mui/icons-material/CloseSharp";
+import ShapeLineIcon from "@mui/icons-material/ShapeLine";
+import WarningIcon from "@mui/icons-material/Warning";
+import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
+
+import TextField from "@mui/material/TextField";
+
+import { makeStyles, useTheme } from "@mui/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
+
+const useStyles = makeStyles((theme) => ({
+  Modal: {
+    margin: theme.headHeights[1],
+    [theme.breakpoints.down("xs")]: {
+      margin: "6px",
+    },
+    "& .MuiDialog-container": {
+      height: "unset !important",
+      transform: "translateX(-50%) translateY(-50%)",
+      left: "50%",
+      top: "50%",
+      position: "absolute",
+    },
+  },
+  contents: {
+    background: theme.palette.primary.main,
+    height: "100%",
+    width: "500px",
+  },
+  heading: {
+    height: theme.headHeights[2],
+    boxSizing: "border-box",
+    background: theme.palette.swatches.p[4],
+    borderBottom: `1px solid ${theme.palette.swatches.grey[800]}`,
+    padding: `4px ${theme.spacing(2)} 4px ${theme.spacing(4)} !important`,
+  },
+  title: {
+    padding: `8px 0px`,
+    fontSize: theme.typography.pxToRem(16),
+    fontWeight: "bold",
+    color: theme.palette.swatches.grey[0],
+    textTransform: "uppercase",
+  },
+  content: {
+    padding: "8px 16px 16px 16px !important",
+    height: `calc(100% - ${theme.headHeights[2]}px)`,
+  },
+  closeIcon: {
+    padding: theme.spacing(1.5),
+    height: "100%",
+    margin: "4px 0px",
+  },
+  flexBetween: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
+  subtitle: {
+    fontSize: "14px !important",
+    width: "100%",
+    marginBottom: "8px !important",
+    color: theme.palette.swatches.grey[300],
+    letterSpacing: "0.2px",
+  },
+  subtitle2: {
+    fontSize: "12px !important",
+    fontStyle: "italic",
+    width: "100%",
+    marginBottom: "8px !important",
+    color: theme.palette.swatches.grey[400],
+  },
+  confirmInput: {
+    width: "100%",
+    margin: "10px 0px 4px 0px !important",
+    borderTop: `1px solid ${theme.palette.swatches.grey[500]}`,
+  },
+  backgroundIcon: {
+    margin: "7px 8px 0px 0px",
+  },
+
+  fileName: {
+    textAlign: "center",
+    fontWeight: "bold",
+    letterSpacing: "1px",
+    marginBottom: "10px",
+    borderBottom: `1px solid ${theme.palette.swatches.grey[500]}`,
+    paddingBottom: "10px",
+  },
+
+  layerName: {
+    textAlign: "center",
+    fontSize: "24px !important",
+    letterSpacing: "1px !important",
+    color: theme.palette.swatches.p[4],
+    fontWeight: "bold !important",
+    margin: "10px !important",
+    borderBottom: `1px solid ${theme.palette.swatches.grey[100]}`,
+    paddingBottom: "10px",
+  },
+  hasOccurrencesTitle: {
+    margin: "10px",
+    display: "flex",
+  },
+  hasOccurrences: {
+    fontStyle: "italic",
+  },
+  mission: {
+    background: theme.palette.swatches.p[11],
+    color: theme.palette.swatches.grey[900],
+    height: "24px",
+    lineHeight: "24px",
+    padding: "0px 5px",
+    borderRadius: "3px",
+    display: "inline-block",
+    letterSpacing: "1px",
+    marginLeft: "20px",
+  },
+  pathName: {
+    display: "flex",
+    marginLeft: "40px",
+    marginTop: "4px",
+    height: "24px",
+    lineHeight: "24px",
+  },
+  path: {
+    color: theme.palette.swatches.grey[500],
+  },
+  name: {
+    color: theme.palette.swatches.grey[100],
+    fontWeight: "bold",
+  },
+  confirmMessage: {
+    fontStyle: "italic",
+    fontSize: "15px !important",
+  },
+  dialogActions: {
+    display: "flex !important",
+    justifyContent: "space-between !important",
+  },
+  delete: {
+    background: `${theme.palette.swatches.p[4]} !important`,
+    color: `${theme.palette.swatches.grey[1000]} !important`,
+    "&:hover": {
+      background: `${theme.palette.swatches.grey[0]} !important`,
+    },
+  },
+  cancel: {},
+}));
+
+const MODAL_NAME = "deleteStacCollection";
+const DeleteStacCollectionModal = (props) => {
+  const { querySTAC } = props;
+  const c = useStyles();
+
+  const modal = useSelector((state) => state.core.modal[MODAL_NAME]);
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  const dispatch = useDispatch();
+
+  const [stacCollectionName, setStacCollectionName] = useState(null);
+
+  const handleClose = () => {
+    // close modal
+    dispatch(setModal({ name: MODAL_NAME, on: false }));
+  };
+  const handleSubmit = () => {
+    if (!modal?.stacCollection?.id) {
+      dispatch(
+        setSnackBarText({
+          text: "Cannot delete undefined STAC Collection.",
+          severity: "error",
+        })
+      );
+      return;
+    }
+
+    if (stacCollectionName !== modal.stacCollection.id) {
+      dispatch(
+        setSnackBarText({
+          text: "Confirmation STAC Collection name does not match.",
+          severity: "error",
+        })
+      );
+      return;
+    }
+
+    calls.api(
+      "stac_delete_collection",
+      {
+        urlReplacements: {
+          collection: modal.stacCollection.id,
+        },
+      },
+      (res) => {
+        if (res["deleted collection"] === modal.stacCollection.id) {
+          dispatch(
+            setSnackBarText({
+              text: `Successfully deleted the '${modal.stacCollection.id}' STAC Collection.`,
+              severity: "success",
+            })
+          );
+          querySTAC();
+          handleClose();
+        } else {
+          dispatch(
+            setSnackBarText({
+              text: `Failed to delete the '${modal.stacCollection.id}' STAC Collection.`,
+              severity: "error",
+            })
+          );
+        }
+      },
+      (res) => {
+        dispatch(
+          setSnackBarText({
+            text: `Failed to delete the '${modal.stacCollection.id}' STAC Collection.`,
+            severity: "error",
+          })
+        );
+      }
+    );
+  };
+
+  let occurrences = [];
+
+  if (modal?.stacCollection?.occurrences)
+    occurrences = Object.keys(modal?.stacCollection?.occurrences)
+      .map((mission) => {
+        const m = modal?.stacCollection?.occurrences[mission];
+        if (m.length == 0) return null;
+        else {
+          const items = [<div className={c.mission}>{mission}</div>];
+          m.forEach((n) => {
+            items.push(
+              <div className={c.pathName}>
+                <div className={c.path}>
+                  {`${n.path}.`.replaceAll(".", " ➔ ")}
+                </div>
+                <div className={c.name}>{n.name}</div>
+              </div>
+            );
+          });
+          return items;
+        }
+      })
+      .filter(Boolean);
+
+  return (
+    <Dialog
+      className={c.Modal}
+      fullScreen={isMobile}
+      open={modal !== false}
+      onClose={handleClose}
+      aria-labelledby="responsive-dialog-title"
+      PaperProps={{
+        className: c.contents,
+      }}
+    >
+      <DialogTitle className={c.heading}>
+        <div className={c.flexBetween}>
+          <div className={c.flexBetween}>
+            <ShapeLineIcon className={c.backgroundIcon} />
+            <div className={c.title}>Delete a STAC Collection</div>
+          </div>
+          <IconButton
+            className={c.closeIcon}
+            title="Close"
+            aria-label="close"
+            onClick={handleClose}
+          >
+            <CloseSharpIcon fontSize="inherit" />
+          </IconButton>
+        </div>
+      </DialogTitle>
+      <DialogContent className={c.content}>
+        <Typography
+          className={c.layerName}
+        >{`Deleting: ${modal?.stacCollection?.id}`}</Typography>
+        {occurrences.length > 0 && (
+          <>
+            <div className={c.hasOccurrencesTitle}>
+              <WarningIcon />
+              <Typography className={c.hasOccurrences}>
+                {`This STAC Collection is currently in use in the following layers:`}
+              </Typography>
+            </div>
+            <div className={c.occurrences}>{occurrences}</div>
+          </>
+        )}
+        <TextField
+          className={c.confirmInput}
+          label="Confirm STAC Collection Name"
+          variant="filled"
+          value={stacCollectionName}
+          onChange={(e) => {
+            setStacCollectionName(e.target.value);
+          }}
+        />
+        <Typography
+          className={c.confirmMessage}
+        >{`Enter '${modal?.stacCollection?.id}' above and click 'Delete' to confirm the permanent deletion of this STAC Collection.`}</Typography>
+      </DialogContent>
+      <DialogActions className={c.dialogActions}>
+        <Button
+          className={c.delete}
+          variant="contained"
+          startIcon={<DeleteForeverIcon size="small" />}
+          onClick={handleSubmit}
+        >
+          Delete
+        </Button>
+        <Button className={c.cancel} variant="outlined" onClick={handleClose}>
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeleteStacCollectionModal;

--- a/configure/src/pages/Users/Modals/NewUserModal/NewUserModal.js
+++ b/configure/src/pages/Users/Modals/NewUserModal/NewUserModal.js
@@ -206,6 +206,7 @@ const NewUserModal = (props) => {
         username: userName,
         email: email,
         password: password,
+        skipLogin: true,
       },
       (res) => {
         if (res.status === "success") {
@@ -277,7 +278,9 @@ const NewUserModal = (props) => {
             setUserName(e.target.value);
           }}
         />
-        <Typography className={c.subtitle2}>{`Username`}</Typography>
+        <Typography
+          className={c.subtitle2}
+        >{`Username. Must be unique.`}</Typography>
 
         <TextField
           className={c.confirmInput}
@@ -291,7 +294,9 @@ const NewUserModal = (props) => {
             setEmail(e.target.value);
           }}
         />
-        <Typography className={c.subtitle2}>{`The user's email.`}</Typography>
+        <Typography
+          className={c.subtitle2}
+        >{`The user's email. Optional but if set, must be unique.`}</Typography>
 
         <TextField
           className={c.confirmInput}
@@ -318,7 +323,7 @@ const NewUserModal = (props) => {
           inputProps={{
             autoComplete: "off",
           }}
-          tyep="password"
+          type="password"
           onChange={(e) => {
             setPasswordRetype(e.target.value);
           }}

--- a/configure/src/pages/Users/Modals/NewUserModal/NewUserModal.js
+++ b/configure/src/pages/Users/Modals/NewUserModal/NewUserModal.js
@@ -12,11 +12,14 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import IconButton from "@mui/material/IconButton";
+import FormControl from "@mui/material/FormControl";
+import Select from "@mui/material/Select";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
 
 import CloseSharpIcon from "@mui/icons-material/CloseSharp";
-import ShapeLineIcon from "@mui/icons-material/ShapeLine";
-import WarningIcon from "@mui/icons-material/Warning";
-import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
+import AccountBoxIcon from "@mui/icons-material/AccountBox";
+import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
 
 import TextField from "@mui/material/TextField";
 
@@ -45,7 +48,7 @@ const useStyles = makeStyles((theme) => ({
   heading: {
     height: theme.headHeights[2],
     boxSizing: "border-box",
-    background: theme.palette.swatches.p[4],
+    background: theme.palette.swatches.p[0],
     borderBottom: `1px solid ${theme.palette.swatches.grey[800]}`,
     padding: `4px ${theme.spacing(2)} 4px ${theme.spacing(4)} !important`,
   },
@@ -53,7 +56,6 @@ const useStyles = makeStyles((theme) => ({
     padding: `8px 0px`,
     fontSize: theme.typography.pxToRem(16),
     fontWeight: "bold",
-    color: theme.palette.swatches.grey[0],
     textTransform: "uppercase",
   },
   content: {
@@ -100,24 +102,6 @@ const useStyles = makeStyles((theme) => ({
     borderBottom: `1px solid ${theme.palette.swatches.grey[500]}`,
     paddingBottom: "10px",
   },
-
-  layerName: {
-    textAlign: "center",
-    fontSize: "24px !important",
-    letterSpacing: "1px !important",
-    color: theme.palette.swatches.p[4],
-    fontWeight: "bold !important",
-    margin: "10px !important",
-    borderBottom: `1px solid ${theme.palette.swatches.grey[100]}`,
-    paddingBottom: "10px",
-  },
-  hasOccurrencesTitle: {
-    margin: "10px",
-    display: "flex",
-  },
-  hasOccurrences: {
-    fontStyle: "italic",
-  },
   mission: {
     background: theme.palette.swatches.p[11],
     color: theme.palette.swatches.grey[900],
@@ -151,19 +135,23 @@ const useStyles = makeStyles((theme) => ({
     display: "flex !important",
     justifyContent: "space-between !important",
   },
-  delete: {
-    background: `${theme.palette.swatches.p[4]} !important`,
+  submit: {
+    background: `${theme.palette.swatches.p[0]} !important`,
     color: `${theme.palette.swatches.grey[1000]} !important`,
     "&:hover": {
       background: `${theme.palette.swatches.grey[0]} !important`,
     },
   },
   cancel: {},
+  dropdown: {
+    width: "100%",
+    marginTop: "20px",
+  },
 }));
 
-const MODAL_NAME = "deleteStacCollection";
-const DeleteStacCollectionModal = (props) => {
-  const { querySTAC } = props;
+const MODAL_NAME = "newUser";
+const NewUserModal = (props) => {
+  const { queryUsers } = props;
   const c = useStyles();
 
   const modal = useSelector((state) => state.core.modal[MODAL_NAME]);
@@ -173,27 +161,39 @@ const DeleteStacCollectionModal = (props) => {
 
   const dispatch = useDispatch();
 
-  const [stacCollectionName, setStacCollectionName] = useState(null);
+  const [userName, setUserName] = useState(null);
+  const [email, setEmail] = useState(null);
+  const [password, setPassword] = useState(null);
+  const [passwordRetype, setPasswordRetype] = useState(null);
 
   const handleClose = () => {
+    setUserName(null);
+    setEmail(null);
+    setPassword(null);
+    setPasswordRetype(null);
     // close modal
     dispatch(setModal({ name: MODAL_NAME, on: false }));
   };
   const handleSubmit = () => {
-    if (!modal?.stacCollection?.id) {
+    if (
+      userName == null ||
+      userName == "" ||
+      password == null ||
+      password == ""
+    ) {
       dispatch(
         setSnackBarText({
-          text: "Cannot delete undefined STAC Collection.",
+          text: "Username and Password must be filled.",
           severity: "error",
         })
       );
       return;
     }
 
-    if (stacCollectionName !== modal.stacCollection.id) {
+    if (password !== passwordRetype) {
       dispatch(
         setSnackBarText({
-          text: "Confirmation STAC Collection name does not match.",
+          text: "Passwords do not match.",
           severity: "error",
         })
       );
@@ -201,26 +201,26 @@ const DeleteStacCollectionModal = (props) => {
     }
 
     calls.api(
-      "stac_delete_collection",
+      "user_signup",
       {
-        urlReplacements: {
-          collection: modal.stacCollection.id,
-        },
+        username: userName,
+        email: email,
+        password: password,
       },
       (res) => {
-        if (res["deleted collection"] === modal.stacCollection.id) {
+        if (res.status === "success") {
           dispatch(
             setSnackBarText({
-              text: `Successfully deleted the '${modal.stacCollection.id}' STAC Collection.`,
+              text: `Successfully created new user: '${userName}'.`,
               severity: "success",
             })
           );
-          querySTAC();
+          queryUsers();
           handleClose();
         } else {
           dispatch(
             setSnackBarText({
-              text: `Failed to delete the '${modal.stacCollection.id}' STAC Collection.`,
+              text: `Failed to create new user: ${res.message}`,
               severity: "error",
             })
           );
@@ -229,37 +229,13 @@ const DeleteStacCollectionModal = (props) => {
       (res) => {
         dispatch(
           setSnackBarText({
-            text: `Failed to delete the '${modal.stacCollection.id}' STAC Collection.`,
+            text: `Failed to create new user: ${res.message}`,
             severity: "error",
           })
         );
       }
     );
   };
-
-  let occurrences = [];
-
-  if (modal?.stacCollection?.occurrences)
-    occurrences = Object.keys(modal?.stacCollection?.occurrences)
-      .map((mission) => {
-        const m = modal?.stacCollection?.occurrences[mission];
-        if (m.length == 0) return null;
-        else {
-          const items = [<div className={c.mission}>{mission}</div>];
-          m.forEach((n) => {
-            items.push(
-              <div className={c.pathName}>
-                <div className={c.path}>
-                  {`${n.path}.`.replaceAll(".", " ➔ ")}
-                </div>
-                <div className={c.name}>{n.name}</div>
-              </div>
-            );
-          });
-          return items;
-        }
-      })
-      .filter(Boolean);
 
   return (
     <Dialog
@@ -275,8 +251,8 @@ const DeleteStacCollectionModal = (props) => {
       <DialogTitle className={c.heading}>
         <div className={c.flexBetween}>
           <div className={c.flexBetween}>
-            <ShapeLineIcon className={c.backgroundIcon} />
-            <div className={c.title}>Delete a STAC Collection</div>
+            <AccountBoxIcon className={c.backgroundIcon} />
+            <div className={c.title}>{`Create a New User`}</div>
           </div>
           <IconButton
             className={c.closeIcon}
@@ -289,41 +265,73 @@ const DeleteStacCollectionModal = (props) => {
         </div>
       </DialogTitle>
       <DialogContent className={c.content}>
-        <Typography
-          className={c.layerName}
-        >{`Deleting: ${modal?.stacCollection?.id}`}</Typography>
-        {occurrences.length > 0 && (
-          <>
-            <div className={c.hasOccurrencesTitle}>
-              <WarningIcon />
-              <Typography className={c.hasOccurrences}>
-                {`This STAC Collection is currently in use in the following layers:`}
-              </Typography>
-            </div>
-            <div className={c.occurrences}>{occurrences}</div>
-          </>
-        )}
         <TextField
           className={c.confirmInput}
-          label="Confirm STAC Collection Name"
+          label="Username"
           variant="filled"
-          value={stacCollectionName}
+          value={userName}
+          inputProps={{
+            autoComplete: "off",
+          }}
           onChange={(e) => {
-            setStacCollectionName(e.target.value);
+            setUserName(e.target.value);
+          }}
+        />
+        <Typography className={c.subtitle2}>{`Username`}</Typography>
+
+        <TextField
+          className={c.confirmInput}
+          label="Email Address"
+          variant="filled"
+          value={email}
+          inputProps={{
+            autoComplete: "off",
+          }}
+          onChange={(e) => {
+            setEmail(e.target.value);
+          }}
+        />
+        <Typography className={c.subtitle2}>{`The user's email.`}</Typography>
+
+        <TextField
+          className={c.confirmInput}
+          label="Password"
+          variant="filled"
+          value={password}
+          inputProps={{
+            autoComplete: "off",
+          }}
+          type="password"
+          onChange={(e) => {
+            setPassword(e.target.value);
           }}
         />
         <Typography
-          className={c.confirmMessage}
-        >{`Enter '${modal?.stacCollection?.id}' above and click 'Delete' to confirm the permanent deletion of this STAC Collection.`}</Typography>
+          className={c.subtitle2}
+        >{`Passwords must be at least 8 characters long and contain at least: 1 uppercase letter, 1 lowercase letter, 1 number and 1 symbol.`}</Typography>
+
+        <TextField
+          className={c.confirmInput}
+          label="Retype Password"
+          variant="filled"
+          value={passwordRetype}
+          inputProps={{
+            autoComplete: "off",
+          }}
+          tyep="password"
+          onChange={(e) => {
+            setPasswordRetype(e.target.value);
+          }}
+        />
+        <Typography className={c.subtitle2}>{`Retype Password`}</Typography>
       </DialogContent>
       <DialogActions className={c.dialogActions}>
         <Button
-          className={c.delete}
           variant="contained"
-          startIcon={<DeleteForeverIcon size="small" />}
+          startIcon={<AdminPanelSettingsIcon size="small" />}
           onClick={handleSubmit}
         >
-          Delete
+          Create
         </Button>
         <Button className={c.cancel} variant="outlined" onClick={handleClose}>
           Cancel
@@ -333,4 +341,4 @@ const DeleteStacCollectionModal = (props) => {
   );
 };
 
-export default DeleteStacCollectionModal;
+export default NewUserModal;

--- a/configure/src/pages/Users/Modals/ResetPasswordModal/ResetPasswordModal.js
+++ b/configure/src/pages/Users/Modals/ResetPasswordModal/ResetPasswordModal.js
@@ -383,7 +383,7 @@ const ResetPasswordModal = (props) => {
           <DialogContent className={c.content}>
             <Typography
               className={c.message}
-            >{`Send this password reset link to the user:`}</Typography>
+            >{`Securely send this password reset link to the user:`}</Typography>
             <div className={c.generated}>
               <div className={c.resetLinkTitle}>Reset Link:</div>
               <textarea

--- a/configure/src/pages/Users/Modals/ResetPasswordModal/ResetPasswordModal.js
+++ b/configure/src/pages/Users/Modals/ResetPasswordModal/ResetPasswordModal.js
@@ -2,7 +2,9 @@ import React, { useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 
 import { calls } from "../../../../core/calls";
+import { publicUrlMainSite } from "../../../../core/constants";
 
+import { copyToClipboard } from "../../../../core/utils";
 import { setModal, setSnackBarText } from "../../../../core/ConfigureStore";
 
 import Typography from "@mui/material/Typography";
@@ -16,10 +18,12 @@ import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
+import Tooltip from "@mui/material/Tooltip";
 
 import CloseSharpIcon from "@mui/icons-material/CloseSharp";
 import AccountBoxIcon from "@mui/icons-material/AccountBox";
 import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
+import ContentPasteIcon from "@mui/icons-material/ContentPaste";
 
 import TextField from "@mui/material/TextField";
 
@@ -43,7 +47,13 @@ const useStyles = makeStyles((theme) => ({
   contents: {
     background: theme.palette.primary.main,
     height: "100%",
-    width: "500px",
+    width: "700px",
+  },
+  contentsLink: {
+    background: theme.palette.primary.main,
+    height: "100%",
+    width: "1000px",
+    maxWidth: "1000px !important",
   },
   heading: {
     height: theme.headHeights[2],
@@ -93,7 +103,6 @@ const useStyles = makeStyles((theme) => ({
   backgroundIcon: {
     margin: "7px 8px 0px 0px",
   },
-
   fileName: {
     textAlign: "center",
     fontWeight: "bold",
@@ -146,6 +155,58 @@ const useStyles = makeStyles((theme) => ({
   dropdown: {
     width: "100%",
     marginTop: "20px",
+  },
+  generated: {
+    height: "42px",
+    lineHeight: "42px",
+    display: "flex",
+    marginBottom: "20px",
+    border: `2px solid ${theme.palette.swatches.p[0]}`,
+    borderRadius: "4px",
+    boxShadow: `0px 2px 2px 0px rgba(0,0,0,0.2)`,
+    "& > div:nth-child(1)": {
+      padding: "0px 16px",
+      background: theme.palette.swatches.p[0],
+      textTransform: "uppercase",
+      fontSize: "13px",
+    },
+    "& > div:nth-child(2)": {
+      padding: "0px 16px",
+    },
+    "& > div:nth-child(3)": {
+      height: "42px",
+    },
+  },
+  resetLink: {
+    whiteSpace: "nowrap",
+    lineHeight: "42px !important",
+    padding: "0px 12px",
+    flex: "1",
+    overflowX: "auto",
+    overflowY: "hidden",
+    border: "none",
+  },
+  message: {
+    fontSize: "18px !important",
+    textAlign: "center !important",
+    letterSpacing: "1px !important",
+    color: `${theme.palette.swatches.r[4]} !important`,
+    margin: "6px 0pc !important",
+    fontWeight: "bold !important",
+    textTransform: "uppercase",
+  },
+  message2: {
+    display: "flex",
+    justifyContent: "space-between",
+    margin: "6px 0px",
+    "& > div:first-child": {
+      color: theme.palette.swatches.grey[200],
+      fontStyle: "italic",
+    },
+    "& > div:last-child": {
+      color: theme.palette.swatches.grey[100],
+      fontWeight: "bold",
+    },
   },
 }));
 
@@ -212,8 +273,6 @@ const ResetPasswordModal = (props) => {
               severity: "success",
             })
           );
-          queryUsers();
-          handleClose();
         } else {
           dispatch(
             setSnackBarText({
@@ -242,7 +301,7 @@ const ResetPasswordModal = (props) => {
       onClose={handleClose}
       aria-labelledby="responsive-dialog-title"
       PaperProps={{
-        className: c.contents,
+        className: passwordResetLink == null ? c.contents : c.contentsLink,
       }}
     >
       <DialogTitle className={c.heading}>
@@ -319,13 +378,52 @@ const ResetPasswordModal = (props) => {
       ) : (
         <>
           <DialogContent className={c.content}>
-            <Typography className={c.resetLink}>{passwordResetLink}</Typography>
-            <Typography className={c.resetLinkExpiration}>
-              {passwordResetLinkExpiration}
-            </Typography>
             <Typography
-              className={c.subtitle2}
-            >{`Pass this link to the user.`}</Typography>
+              className={c.message}
+            >{`Send this password reset link to the user:`}</Typography>
+            <div className={c.generated}>
+              <div className={c.resetLinkTitle}>Reset Link:</div>
+              <textarea
+                readonly={true}
+                className={c.resetLink}
+                id="resetPasswordLink"
+              >{`${publicUrlMainSite}/resetPassword?t=${passwordResetLink}`}</textarea>
+              <Tooltip
+                title={"Copy Reset Link to Clipboard"}
+                placement="top"
+                arrow
+              >
+                <IconButton
+                  className={c.copy2clipboard}
+                  onClick={() => {
+                    if (passwordResetLink) {
+                      document.getElementById("resetPasswordLink").select(); // Select the <textarea> content
+                      document.execCommand("copy");
+                      dispatch(
+                        setSnackBarText({
+                          text: "Copied Password Reset Link to Clipboard!",
+                          severity: "success",
+                        })
+                      );
+                    }
+                  }}
+                >
+                  <ContentPasteIcon fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
+            </div>
+            <div className={c.message2}>
+              <div>{"Username:"}</div>
+              <div>{modal.row.username}</div>
+            </div>
+            <div className={c.message2}>
+              <div>{"Email:"}</div>
+              <div>{modal.row.email}</div>
+            </div>
+            <div className={c.message2}>
+              <div>{"Link Expires At:"}</div>
+              <div>{new Date(passwordResetLinkExpiration).toString()}</div>
+            </div>
           </DialogContent>
           <DialogActions className={c.dialogActions}>
             <Button
@@ -333,7 +431,7 @@ const ResetPasswordModal = (props) => {
               variant="outlined"
               onClick={handleClose}
             >
-              Close
+              Done
             </Button>
           </DialogActions>
         </>

--- a/configure/src/pages/Users/Modals/ResetPasswordModal/ResetPasswordModal.js
+++ b/configure/src/pages/Users/Modals/ResetPasswordModal/ResetPasswordModal.js
@@ -1,0 +1,345 @@
+import React, { useState } from "react";
+import { useSelector, useDispatch } from "react-redux";
+
+import { calls } from "../../../../core/calls";
+
+import { setModal, setSnackBarText } from "../../../../core/ConfigureStore";
+
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import IconButton from "@mui/material/IconButton";
+import FormControl from "@mui/material/FormControl";
+import Select from "@mui/material/Select";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+
+import CloseSharpIcon from "@mui/icons-material/CloseSharp";
+import AccountBoxIcon from "@mui/icons-material/AccountBox";
+import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
+
+import TextField from "@mui/material/TextField";
+
+import { makeStyles, useTheme } from "@mui/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
+
+const useStyles = makeStyles((theme) => ({
+  Modal: {
+    margin: theme.headHeights[1],
+    [theme.breakpoints.down("xs")]: {
+      margin: "6px",
+    },
+    "& .MuiDialog-container": {
+      height: "unset !important",
+      transform: "translateX(-50%) translateY(-50%)",
+      left: "50%",
+      top: "50%",
+      position: "absolute",
+    },
+  },
+  contents: {
+    background: theme.palette.primary.main,
+    height: "100%",
+    width: "500px",
+  },
+  heading: {
+    height: theme.headHeights[2],
+    boxSizing: "border-box",
+    background: theme.palette.swatches.p[0],
+    borderBottom: `1px solid ${theme.palette.swatches.grey[800]}`,
+    padding: `4px ${theme.spacing(2)} 4px ${theme.spacing(4)} !important`,
+  },
+  title: {
+    padding: `8px 0px`,
+    fontSize: theme.typography.pxToRem(16),
+    fontWeight: "bold",
+    textTransform: "uppercase",
+  },
+  content: {
+    padding: "8px 16px 16px 16px !important",
+    height: `calc(100% - ${theme.headHeights[2]}px)`,
+  },
+  closeIcon: {
+    padding: theme.spacing(1.5),
+    height: "100%",
+    margin: "4px 0px",
+  },
+  flexBetween: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
+  subtitle: {
+    fontSize: "14px !important",
+    width: "100%",
+    marginBottom: "8px !important",
+    color: theme.palette.swatches.grey[300],
+    letterSpacing: "0.2px",
+  },
+  subtitle2: {
+    fontSize: "12px !important",
+    fontStyle: "italic",
+    width: "100%",
+    marginBottom: "8px !important",
+    color: theme.palette.swatches.grey[400],
+  },
+  confirmInput: {
+    width: "100%",
+    margin: "10px 0px 4px 0px !important",
+    borderTop: `1px solid ${theme.palette.swatches.grey[500]}`,
+  },
+  backgroundIcon: {
+    margin: "7px 8px 0px 0px",
+  },
+
+  fileName: {
+    textAlign: "center",
+    fontWeight: "bold",
+    letterSpacing: "1px",
+    marginBottom: "10px",
+    borderBottom: `1px solid ${theme.palette.swatches.grey[500]}`,
+    paddingBottom: "10px",
+  },
+  mission: {
+    background: theme.palette.swatches.p[11],
+    color: theme.palette.swatches.grey[900],
+    height: "24px",
+    lineHeight: "24px",
+    padding: "0px 5px",
+    borderRadius: "3px",
+    display: "inline-block",
+    letterSpacing: "1px",
+    marginLeft: "20px",
+  },
+  pathName: {
+    display: "flex",
+    marginLeft: "40px",
+    marginTop: "4px",
+    height: "24px",
+    lineHeight: "24px",
+  },
+  path: {
+    color: theme.palette.swatches.grey[500],
+  },
+  name: {
+    color: theme.palette.swatches.grey[100],
+    fontWeight: "bold",
+  },
+  confirmMessage: {
+    fontStyle: "italic",
+    fontSize: "15px !important",
+  },
+  dialogActions: {
+    display: "flex !important",
+    justifyContent: "space-between !important",
+  },
+  submit: {
+    background: `${theme.palette.swatches.p[0]} !important`,
+    color: `${theme.palette.swatches.grey[1000]} !important`,
+    "&:hover": {
+      background: `${theme.palette.swatches.grey[0]} !important`,
+    },
+  },
+  cancel: {},
+  dropdown: {
+    width: "100%",
+    marginTop: "20px",
+  },
+}));
+
+const MODAL_NAME = "resetPassword";
+const ResetPasswordModal = (props) => {
+  const { queryUsers } = props;
+  const c = useStyles();
+
+  const modal = useSelector((state) => state.core.modal[MODAL_NAME]);
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  const dispatch = useDispatch();
+
+  const [expires, setExpires] = useState(3600000);
+  const [userName, setUserName] = useState(null);
+  const [passwordResetLink, setPasswordResetLink] = useState(null);
+  const [passwordResetLinkExpiration, setPasswordResetLinkExpiration] =
+    useState(null);
+
+  const handleClose = () => {
+    setExpires(3600000);
+    setPasswordResetLink(null);
+    setPasswordResetLinkExpiration(null);
+    setUserName(null);
+    // close modal
+    dispatch(setModal({ name: MODAL_NAME, on: false }));
+  };
+  const handleSubmit = () => {
+    if (!modal?.row?.id) {
+      dispatch(
+        setSnackBarText({
+          text: "Cannot update undefined User.",
+          severity: "error",
+        })
+      );
+      return;
+    }
+
+    if (userName !== modal.row.username) {
+      dispatch(
+        setSnackBarText({
+          text: "Confirmation Username does not match.",
+          severity: "error",
+        })
+      );
+      return;
+    }
+
+    calls.api(
+      "account_reset_password_link",
+      {
+        id: modal.row.id,
+        expires: expires,
+      },
+      (res) => {
+        if (res.body?.resetToken != null) {
+          setPasswordResetLink(res.body.resetToken);
+          setPasswordResetLinkExpiration(res.body.resetTokenExpiration);
+          dispatch(
+            setSnackBarText({
+              text: `Successfully generated a password reset link for '${modal.row.username}'.`,
+              severity: "success",
+            })
+          );
+          queryUsers();
+          handleClose();
+        } else {
+          dispatch(
+            setSnackBarText({
+              text: `Failed to generate a password reset link for '${modal.row.username}'.`,
+              severity: "error",
+            })
+          );
+        }
+      },
+      (res) => {
+        dispatch(
+          setSnackBarText({
+            text: `Failed to generate a password reset link for '${modal.row.username}'.`,
+            severity: "error",
+          })
+        );
+      }
+    );
+  };
+
+  return (
+    <Dialog
+      className={c.Modal}
+      fullScreen={isMobile}
+      open={modal !== false}
+      onClose={handleClose}
+      aria-labelledby="responsive-dialog-title"
+      PaperProps={{
+        className: c.contents,
+      }}
+    >
+      <DialogTitle className={c.heading}>
+        <div className={c.flexBetween}>
+          <div className={c.flexBetween}>
+            <AccountBoxIcon className={c.backgroundIcon} />
+            <div
+              className={c.title}
+            >{`Generate a Password Reset Link for: ${modal?.row?.username}`}</div>
+          </div>
+          <IconButton
+            className={c.closeIcon}
+            title="Close"
+            aria-label="close"
+            onClick={handleClose}
+          >
+            <CloseSharpIcon fontSize="inherit" />
+          </IconButton>
+        </div>
+      </DialogTitle>
+      {passwordResetLink == null ? (
+        <>
+          <DialogContent className={c.content}>
+            <Typography
+              className={c.subtitle2}
+            >{`Generates a single-use password reset link for the user. Generating this link does not disable a user from logging in with their current password.`}</Typography>
+
+            <FormControl className={c.dropdown} variant="filled" size="small">
+              <InputLabel>Expires</InputLabel>
+              <Select
+                value={expires || 3600000}
+                onChange={(e) => {
+                  setExpires(e.target.value);
+                }}
+              >
+                <MenuItem value={3600000}>1 hour</MenuItem>
+                <MenuItem value={28800000}>8 hours</MenuItem>
+                <MenuItem value={86400000}>1 day</MenuItem>
+                <MenuItem value={259200000}>3 days</MenuItem>
+                <MenuItem value={604800000}>1 week</MenuItem>
+              </Select>
+            </FormControl>
+            <Typography className={c.subtitle2}>{``}</Typography>
+            <TextField
+              className={c.confirmInput}
+              label="Confirm Username"
+              variant="filled"
+              value={userName}
+              onChange={(e) => {
+                setUserName(e.target.value);
+              }}
+            />
+            <Typography
+              className={c.subtitle2}
+            >{`Confirm their username before generating a password reset link.`}</Typography>
+          </DialogContent>
+          <DialogActions className={c.dialogActions}>
+            <Button
+              variant="contained"
+              startIcon={<AdminPanelSettingsIcon size="small" />}
+              onClick={handleSubmit}
+            >
+              Generate
+            </Button>
+            <Button
+              className={c.cancel}
+              variant="outlined"
+              onClick={handleClose}
+            >
+              Cancel
+            </Button>
+          </DialogActions>
+        </>
+      ) : (
+        <>
+          <DialogContent className={c.content}>
+            <Typography className={c.resetLink}>{passwordResetLink}</Typography>
+            <Typography className={c.resetLinkExpiration}>
+              {passwordResetLinkExpiration}
+            </Typography>
+            <Typography
+              className={c.subtitle2}
+            >{`Pass this link to the user.`}</Typography>
+          </DialogContent>
+          <DialogActions className={c.dialogActions}>
+            <Button
+              className={c.cancel}
+              variant="outlined"
+              onClick={handleClose}
+            >
+              Close
+            </Button>
+          </DialogActions>
+        </>
+      )}
+    </Dialog>
+  );
+};
+
+export default ResetPasswordModal;

--- a/configure/src/pages/Users/Modals/ResetPasswordModal/ResetPasswordModal.js
+++ b/configure/src/pages/Users/Modals/ResetPasswordModal/ResetPasswordModal.js
@@ -350,6 +350,9 @@ const ResetPasswordModal = (props) => {
               label="Confirm Username"
               variant="filled"
               value={userName}
+              inputProps={{
+                autoComplete: "off",
+              }}
               onChange={(e) => {
                 setUserName(e.target.value);
               }}

--- a/configure/src/pages/Users/Modals/UpdateUserModal/UpdateUserModal.js
+++ b/configure/src/pages/Users/Modals/UpdateUserModal/UpdateUserModal.js
@@ -1,0 +1,318 @@
+import React, { useState } from "react";
+import { useSelector, useDispatch } from "react-redux";
+
+import { calls } from "../../../../core/calls";
+
+import { setModal, setSnackBarText } from "../../../../core/ConfigureStore";
+
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import IconButton from "@mui/material/IconButton";
+import FormControl from "@mui/material/FormControl";
+import Select from "@mui/material/Select";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+
+import CloseSharpIcon from "@mui/icons-material/CloseSharp";
+import AccountBoxIcon from "@mui/icons-material/AccountBox";
+import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
+
+import TextField from "@mui/material/TextField";
+
+import { makeStyles, useTheme } from "@mui/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
+
+const useStyles = makeStyles((theme) => ({
+  Modal: {
+    margin: theme.headHeights[1],
+    [theme.breakpoints.down("xs")]: {
+      margin: "6px",
+    },
+    "& .MuiDialog-container": {
+      height: "unset !important",
+      transform: "translateX(-50%) translateY(-50%)",
+      left: "50%",
+      top: "50%",
+      position: "absolute",
+    },
+  },
+  contents: {
+    background: theme.palette.primary.main,
+    height: "100%",
+    width: "500px",
+  },
+  heading: {
+    height: theme.headHeights[2],
+    boxSizing: "border-box",
+    background: theme.palette.swatches.p[0],
+    borderBottom: `1px solid ${theme.palette.swatches.grey[800]}`,
+    padding: `4px ${theme.spacing(2)} 4px ${theme.spacing(4)} !important`,
+  },
+  title: {
+    padding: `8px 0px`,
+    fontSize: theme.typography.pxToRem(16),
+    fontWeight: "bold",
+    textTransform: "uppercase",
+  },
+  content: {
+    padding: "8px 16px 16px 16px !important",
+    height: `calc(100% - ${theme.headHeights[2]}px)`,
+  },
+  closeIcon: {
+    padding: theme.spacing(1.5),
+    height: "100%",
+    margin: "4px 0px",
+  },
+  flexBetween: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
+  subtitle: {
+    fontSize: "14px !important",
+    width: "100%",
+    marginBottom: "8px !important",
+    color: theme.palette.swatches.grey[300],
+    letterSpacing: "0.2px",
+  },
+  subtitle2: {
+    fontSize: "12px !important",
+    fontStyle: "italic",
+    width: "100%",
+    marginBottom: "8px !important",
+    color: theme.palette.swatches.grey[400],
+  },
+  confirmInput: {
+    width: "100%",
+    margin: "10px 0px 4px 0px !important",
+    borderTop: `1px solid ${theme.palette.swatches.grey[500]}`,
+  },
+  backgroundIcon: {
+    margin: "7px 8px 0px 0px",
+  },
+
+  fileName: {
+    textAlign: "center",
+    fontWeight: "bold",
+    letterSpacing: "1px",
+    marginBottom: "10px",
+    borderBottom: `1px solid ${theme.palette.swatches.grey[500]}`,
+    paddingBottom: "10px",
+  },
+  mission: {
+    background: theme.palette.swatches.p[11],
+    color: theme.palette.swatches.grey[900],
+    height: "24px",
+    lineHeight: "24px",
+    padding: "0px 5px",
+    borderRadius: "3px",
+    display: "inline-block",
+    letterSpacing: "1px",
+    marginLeft: "20px",
+  },
+  pathName: {
+    display: "flex",
+    marginLeft: "40px",
+    marginTop: "4px",
+    height: "24px",
+    lineHeight: "24px",
+  },
+  path: {
+    color: theme.palette.swatches.grey[500],
+  },
+  name: {
+    color: theme.palette.swatches.grey[100],
+    fontWeight: "bold",
+  },
+  confirmMessage: {
+    fontStyle: "italic",
+    fontSize: "15px !important",
+  },
+  dialogActions: {
+    display: "flex !important",
+    justifyContent: "space-between !important",
+  },
+  submit: {
+    background: `${theme.palette.swatches.p[0]} !important`,
+    color: `${theme.palette.swatches.grey[1000]} !important`,
+    "&:hover": {
+      background: `${theme.palette.swatches.grey[0]} !important`,
+    },
+  },
+  cancel: {},
+  dropdown: {
+    width: "100%",
+    marginTop: "20px",
+  },
+}));
+
+const MODAL_NAME = "updateUser";
+const UpdateUserModal = (props) => {
+  const { queryUsers } = props;
+  const c = useStyles();
+
+  const modal = useSelector((state) => state.core.modal[MODAL_NAME]);
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  const dispatch = useDispatch();
+
+  const [email, setEmail] = useState(null);
+  const [permissions, setPermissions] = useState(null);
+  const [userName, setUserName] = useState(null);
+
+  const handleClose = () => {
+    setEmail(null);
+    setPermissions(null);
+    setUserName(null);
+    // close modal
+    dispatch(setModal({ name: MODAL_NAME, on: false }));
+  };
+  const handleSubmit = () => {
+    if (!modal?.row?.id) {
+      dispatch(
+        setSnackBarText({
+          text: "Cannot update undefined User.",
+          severity: "error",
+        })
+      );
+      return;
+    }
+
+    if (userName !== modal.row.username) {
+      dispatch(
+        setSnackBarText({
+          text: "Confirmation Username does not match.",
+          severity: "error",
+        })
+      );
+      return;
+    }
+
+    calls.api(
+      "account_update_user",
+      {
+        id: modal.row.id,
+        permission: permissions,
+        email: email,
+      },
+      (res) => {
+        if (res.body?.updated_id === modal.row.id) {
+          dispatch(
+            setSnackBarText({
+              text: `Successfully updated '${modal.row.username}'.`,
+              severity: "success",
+            })
+          );
+          queryUsers();
+          handleClose();
+        } else {
+          dispatch(
+            setSnackBarText({
+              text: `Failed to update '${modal.row.username}'.`,
+              severity: "error",
+            })
+          );
+        }
+      },
+      (res) => {
+        dispatch(
+          setSnackBarText({
+            text: `Failed to update '${modal.row.username}'.`,
+            severity: "error",
+          })
+        );
+      }
+    );
+  };
+
+  return (
+    <Dialog
+      className={c.Modal}
+      fullScreen={isMobile}
+      open={modal !== false}
+      onClose={handleClose}
+      aria-labelledby="responsive-dialog-title"
+      PaperProps={{
+        className: c.contents,
+      }}
+    >
+      <DialogTitle className={c.heading}>
+        <div className={c.flexBetween}>
+          <div className={c.flexBetween}>
+            <AccountBoxIcon className={c.backgroundIcon} />
+            <div
+              className={c.title}
+            >{`Update a User's Account: ${modal?.row?.username}`}</div>
+          </div>
+          <IconButton
+            className={c.closeIcon}
+            title="Close"
+            aria-label="close"
+            onClick={handleClose}
+          >
+            <CloseSharpIcon fontSize="inherit" />
+          </IconButton>
+        </div>
+      </DialogTitle>
+      <DialogContent className={c.content}>
+        <TextField
+          className={c.confirmInput}
+          label="Email Address"
+          variant="filled"
+          value={email || modal?.row?.email}
+          onChange={(e) => {
+            setEmail(e.target.value);
+          }}
+        />
+        <Typography className={c.subtitle2}>{`The user's email.`}</Typography>
+
+        <FormControl className={c.dropdown} variant="filled" size="small">
+          <InputLabel>Role</InputLabel>
+          <Select
+            value={permissions || modal?.row?.permission}
+            onChange={(e) => {
+              setPermissions(e.target.value);
+            }}
+          >
+            <MenuItem value={"111"}>Administrator</MenuItem>
+            <MenuItem value={"001"}>User</MenuItem>
+          </Select>
+        </FormControl>
+        <Typography
+          className={c.subtitle2}
+        >{`Admins have full control over mission configurations as well as elevated privileges in the Draw Tool. Users do not and are the most basic role.`}</Typography>
+        <TextField
+          className={c.confirmInput}
+          label="Confirm Username"
+          variant="filled"
+          value={userName}
+          onChange={(e) => {
+            setUserName(e.target.value);
+          }}
+        />
+        <Typography
+          className={c.subtitle2}
+        >{`Because updating may grant privileges, enter '${modal?.row?.username}' above to confirm the update to this user's account.`}</Typography>
+      </DialogContent>
+      <DialogActions className={c.dialogActions}>
+        <Button
+          variant="contained"
+          startIcon={<AdminPanelSettingsIcon size="small" />}
+          onClick={handleSubmit}
+        >
+          Update
+        </Button>
+        <Button className={c.cancel} variant="outlined" onClick={handleClose}>
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default UpdateUserModal;

--- a/configure/src/pages/Users/Modals/UpdateUserModal/UpdateUserModal.js
+++ b/configure/src/pages/Users/Modals/UpdateUserModal/UpdateUserModal.js
@@ -265,6 +265,9 @@ const UpdateUserModal = (props) => {
           label="Email Address"
           variant="filled"
           value={email || modal?.row?.email}
+          inputProps={{
+            autoComplete: "off",
+          }}
           onChange={(e) => {
             setEmail(e.target.value);
           }}
@@ -291,6 +294,9 @@ const UpdateUserModal = (props) => {
           label="Confirm Username"
           variant="filled"
           value={userName}
+          inputProps={{
+            autoComplete: "off",
+          }}
           onChange={(e) => {
             setUserName(e.target.value);
           }}

--- a/configure/src/pages/Users/Users.js
+++ b/configure/src/pages/Users/Users.js
@@ -100,7 +100,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   tableInner: {
-    margin: "16px 32px 32px 32px",
+    margin: "0px 32px 32px 32px",
     width: "calc(100% - 64px) !important",
     boxShadow: "0px 1px 7px 0px rgba(0, 0, 0, 0.2)",
   },
@@ -203,7 +203,7 @@ const useStyles = makeStyles((theme) => ({
     color: "white",
   },
   authIndicator: {
-    margin: "16px 32px -16px 32px",
+    margin: "16px auto -16px 32px",
     display: "flex",
     padding: "8px 16px",
     background: theme.palette.swatches.grey[300],
@@ -211,6 +211,7 @@ const useStyles = makeStyles((theme) => ({
     letterSpacing: "1px",
     fontSize: "14px",
     borderRadius: "4px",
+    height: "32px",
     boxShadow:
       "rgba(0, 0, 0, 0.2) 0px 2px 1px -1px, rgba(0, 0, 0, 0.14) 0px 1px 1px 0px, rgba(0, 0, 0, 0.12) 0px 1px 3px 0px",
     "& > div:first-child": {
@@ -423,7 +424,7 @@ export default function Users() {
       break;
     case "local":
       authDescription =
-        "- Anyone without credentials is blocked. Either the Admin must log in, create accounts and pass out the credentials or set AUTH_LOCAL_ALLOW_SIGNUP=true.";
+        "- Anyone without credentials is blocked. Either the Admin must log in, create accounts and pass out the credentials or set AUTH_LOCAL_ALLOW_SIGNUP=true so that users may sign up on their own.";
       break;
     case "csso":
       authDescription =

--- a/configure/src/pages/Users/Users.js
+++ b/configure/src/pages/Users/Users.js
@@ -40,6 +40,7 @@ import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
 import ResetPasswordModal from "./Modals/ResetPasswordModal/ResetPasswordModal";
 import DeleteUserModal from "./Modals/DeleteUserModal/DeleteUserModal";
 import UpdateUserModal from "./Modals/UpdateUserModal/UpdateUserModal";
+import NewUserModal from "./Modals/NewUserModal/NewUserModal";
 
 function descendingComparator(a, b, orderBy) {
   if (b[orderBy] < a[orderBy]) {
@@ -530,6 +531,7 @@ export default function Users() {
       <ResetPasswordModal queryUsers={queryUsers} />
       <DeleteUserModal queryUsers={queryUsers} />
       <UpdateUserModal queryUsers={queryUsers} />
+      <NewUserModal queryUsers={queryUsers} />
     </>
   );
 }

--- a/configure/src/pages/Users/Users.js
+++ b/configure/src/pages/Users/Users.js
@@ -6,11 +6,12 @@ import { calls } from "../../core/calls";
 import { downloadObject } from "../../core/utils";
 import {
   setSnackBarText,
-  setDatasets,
+  setUserEntries,
   setModal,
 } from "../../core/ConfigureStore";
 
 import PropTypes from "prop-types";
+import { alpha } from "@mui/material/styles";
 import Box from "@mui/material/Box";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -30,17 +31,15 @@ import Divider from "@mui/material/Divider";
 import Badge from "@mui/material/Badge";
 import { visuallyHidden } from "@mui/utils";
 
-import InventoryIcon from "@mui/icons-material/Inventory";
-import DownloadIcon from "@mui/icons-material/Download";
-import UploadIcon from "@mui/icons-material/Upload";
 import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
 import AddIcon from "@mui/icons-material/Add";
-import TextSnippetIcon from "@mui/icons-material/TextSnippet";
+import AccountBoxIcon from "@mui/icons-material/AccountBox";
+import LockResetIcon from "@mui/icons-material/LockReset";
+import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
 
-import NewDatasetModal from "./Modals/NewDatasetModal/NewDatasetModal";
-import LayersUsedByModal from "./Modals/LayersUsedByModal/LayersUsedByModal";
-import UpdateDatasetModal from "./Modals/UpdateDatasetModal/UpdateDatasetModal";
-import DeleteDatasetModal from "./Modals/DeleteDatasetModal/DeleteDatasetModal";
+import ResetPasswordModal from "./Modals/ResetPasswordModal/ResetPasswordModal";
+import DeleteUserModal from "./Modals/DeleteUserModal/DeleteUserModal";
+import UpdateUserModal from "./Modals/UpdateUserModal/UpdateUserModal";
 
 function descendingComparator(a, b, orderBy) {
   if (b[orderBy] < a[orderBy]) {
@@ -75,8 +74,8 @@ function stableSort(array, comparator) {
 }
 
 const useStyles = makeStyles((theme) => ({
-  Datasets: { width: "100%", height: "100%" },
-  DatasetsInner: {
+  Users: { width: "100%", height: "100%" },
+  UsersInner: {
     width: "100%",
     height: "100%",
     display: "flex",
@@ -148,7 +147,7 @@ const useStyles = makeStyles((theme) => ({
   addButton: {
     whiteSpace: "nowrap",
     padding: "5px 20px !important",
-    margin: "0px 10px !important",
+    margin: "0px 10px 0px 10px !important",
   },
   badge: {
     "& > span": {
@@ -183,16 +182,52 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: `${theme.palette.swatches.grey[1000]} !important`,
     borderRight: `1px solid ${theme.palette.swatches.grey[900]}`,
   },
+  roleSuperAdmin: {
+    background: "#db589a",
+    padding: "4px 6px",
+    borderRadius: "4px",
+    display: "inline",
+    color: "white",
+  },
+  roleAdmin: {
+    background: theme.palette.swatches.p[0],
+    padding: "4px 6px",
+    borderRadius: "4px",
+    display: "inline",
+  },
+  roleUser: {
+    background: theme.palette.swatches.grey[300],
+    padding: "4px 6px",
+    borderRadius: "4px",
+    display: "inline",
+    color: "white",
+  },
 }));
 
 const headCells = [
   {
-    id: "name",
-    label: "Name",
+    id: "id",
+    label: "Id",
   },
   {
-    id: "updated",
-    label: "Last Updated",
+    id: "username",
+    label: "Username",
+  },
+  {
+    id: "email",
+    label: "Email",
+  },
+  {
+    id: "permission",
+    label: "Role",
+  },
+  {
+    id: "createdAt",
+    label: "Joined",
+  },
+  {
+    id: "updatedAt",
+    label: "Last Login/Update",
   },
   {
     id: "actions",
@@ -201,7 +236,7 @@ const headCells = [
 ];
 
 function EnhancedTableHead(props) {
-  const { order, orderBy, onRequestSort } = props;
+  const { order, orderBy, rowCount, onRequestSort } = props;
   const createSortHandler = (property) => (event) => {
     onRequestSort(event, property);
   };
@@ -253,26 +288,13 @@ function EnhancedTableToolbar(props) {
   return (
     <Toolbar className={c.topbar}>
       <div className={c.topbarTitle}>
-        <TextSnippetIcon />
+        <AccountBoxIcon />
         <Typography
           style={{ fontWeight: "bold", fontSize: "16px", lineHeight: "29px" }}
           variant="h6"
           component="div"
         >
-          DATASETS
-        </Typography>
-
-        <Typography
-          style={{
-            fontWeight: "bold",
-            fontSize: "14px",
-            lineHeight: "29px",
-            paddingLeft: "20px",
-          }}
-          variant="h6"
-          component="div"
-        >
-          {`1) Create a New Dataset. 2) Connect to it through a Vector Layer's Datasets tab.`}
+          Users
         </Typography>
       </div>
 
@@ -281,10 +303,10 @@ function EnhancedTableToolbar(props) {
         className={c.addButton}
         endIcon={<AddIcon />}
         onClick={() => {
-          dispatch(setModal({ name: "newDataset" }));
+          dispatch(setModal({ name: "newUser" }));
         }}
       >
-        New Dataset
+        New User
       </Button>
     </Toolbar>
   );
@@ -294,35 +316,28 @@ EnhancedTableToolbar.propTypes = {
   numSelected: PropTypes.number.isRequired,
 };
 
-export default function Datasets() {
-  const [order, setOrder] = React.useState("asc");
-  const [orderBy, setOrderBy] = React.useState("name");
+export default function Users() {
+  const [order, setOrder] = React.useState("desc");
+  const [orderBy, setOrderBy] = React.useState("permission");
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(25);
 
   const c = useStyles();
 
   const dispatch = useDispatch();
-  const datasets = useSelector((state) => state.core.datasets);
+  const userEntries = useSelector((state) => state.core.userEntries);
 
-  const queryDatasets = () => {
+  const queryUsers = () => {
     calls.api(
-      "datasets_entries",
+      "account_entries",
       {},
       (res) => {
-        if (res.status === "success")
-          dispatch(
-            setDatasets(
-              res.body.entries.map((en, idx) => {
-                en.id = idx;
-                return en;
-              })
-            )
-          );
+        if (res?.body?.entries != null)
+          dispatch(setUserEntries(res.body.entries));
         else
           dispatch(
             setSnackBarText({
-              text: res?.message || "Failed to get datasets.",
+              text: res?.message || "Failed to get User Entries.",
               severity: "error",
             })
           );
@@ -330,7 +345,7 @@ export default function Datasets() {
       (res) => {
         dispatch(
           setSnackBarText({
-            text: res?.message || "Failed to get datasets.",
+            text: res?.message || "Failed to get Users Entries.",
             severity: "error",
           })
         );
@@ -338,7 +353,7 @@ export default function Datasets() {
     );
   };
   useEffect(() => {
-    queryDatasets();
+    queryUsers();
   }, []);
 
   const handleRequestSort = (event, property) => {
@@ -358,21 +373,21 @@ export default function Datasets() {
 
   // Avoid a layout jump when reaching the last page with empty rows.
   const emptyRows =
-    page > 0 ? Math.max(0, (1 + page) * rowsPerPage - datasets.length) : 0;
+    page > 0 ? Math.max(0, (1 + page) * rowsPerPage - userEntries.length) : 0;
 
   const visibleRows = React.useMemo(
     () =>
-      stableSort(datasets, getComparator(order, orderBy)).slice(
+      stableSort(userEntries, getComparator(order, orderBy)).slice(
         page * rowsPerPage,
         page * rowsPerPage + rowsPerPage
       ),
-    [order, orderBy, page, rowsPerPage, datasets]
+    [order, orderBy, page, rowsPerPage, userEntries]
   );
 
   return (
     <>
-      <Box className={c.Datasets}>
-        <Paper className={c.DatasetsInner}>
+      <Box className={c.Users}>
+        <Paper className={c.UsersInner}>
           <EnhancedTableToolbar />
           <TableContainer className={c.table}>
             <Table
@@ -386,7 +401,7 @@ export default function Datasets() {
                 order={order}
                 orderBy={orderBy}
                 onRequestSort={handleRequestSort}
-                rowCount={datasets.length}
+                rowCount={userEntries.length}
               />
               <TableBody>
                 {visibleRows.map((row, index) => {
@@ -406,111 +421,64 @@ export default function Datasets() {
                       key={row.id}
                       selected={false}
                     >
-                      <TableCell align="left">{row.name}</TableCell>
+                      <TableCell align="left">{row.id}</TableCell>
+                      <TableCell align="left">{row.username}</TableCell>
+                      <TableCell align="right">{row.email}</TableCell>
                       <TableCell align="right">
-                        {row.updated
-                          ? new Date(row.updated).toLocaleString()
-                          : row.updated}
+                        {row.permission === "111" ? (
+                          row.id === 1 ? (
+                            <div className={c.roleSuperAdmin}>SuperAdmin</div>
+                          ) : (
+                            <div className={c.roleAdmin}>Admin</div>
+                          )
+                        ) : (
+                          <div className={c.roleUser}>User</div>
+                        )}
                       </TableCell>
+                      <TableCell align="right">{row.createdAt}</TableCell>
+                      <TableCell align="right">{row.updatedAt}</TableCell>
                       <TableCell align="right">
                         <div className={c.actions}>
-                          <Tooltip title={"Used By"} placement="top" arrow>
+                          <Tooltip title={"Update User"} placement="top" arrow>
                             <IconButton
-                              className={c.inIcon}
-                              title="Used By"
-                              aria-label="used by"
+                              className={c.previewIcon}
+                              title="Update User"
+                              aria-label="update user"
                               onClick={() => {
-                                console.log(row);
                                 dispatch(
                                   setModal({
-                                    name: "layersUsedByDataset",
-                                    dataset: row,
+                                    name: "updateUser",
+                                    row: row,
                                   })
                                 );
                               }}
                             >
-                              <Badge
-                                className={c.badge}
-                                badgeContent={numOccurrences}
-                                color="primary"
-                              >
-                                <InventoryIcon fontSize="small" />
-                              </Badge>
+                              <AdminPanelSettingsIcon fontSize="small" />
                             </IconButton>
                           </Tooltip>
-                          <Tooltip title={"Download"} placement="top" arrow>
+
+                          <Tooltip
+                            title={"Reset Password"}
+                            placement="top"
+                            arrow
+                          >
                             <IconButton
-                              className={c.downloadIcon}
-                              title="Download"
-                              aria-label="download"
-                              onClick={() => {
-                                if (row.name)
-                                  calls.api(
-                                    "datasets_download",
-                                    {
-                                      layer: row.name,
-                                    },
-                                    (res) => {
-                                      downloadObject(
-                                        res,
-                                        `${row.name}-dataset`,
-                                        ".json"
-                                      );
-                                      dispatch(
-                                        setSnackBarText({
-                                          text:
-                                            res?.message ||
-                                            "Successfully downloaded Dataset.",
-                                          severity: "success",
-                                        })
-                                      );
-                                    },
-                                    (res) => {
-                                      dispatch(
-                                        setSnackBarText({
-                                          text:
-                                            res?.message ||
-                                            "Failed to download Dataset.",
-                                          severity: "error",
-                                        })
-                                      );
-                                    }
-                                  );
-                              }}
-                            >
-                              <DownloadIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                          <Divider orientation="vertical" flexItem />
-                          {/*
-                          <Tooltip title={"Rename"} placement="top" arrow>
-                            <IconButton
-                              className={c.renameIcon}
-                              title="Rename"
-                              aria-label="rename"
-                              onClick={() => {}}
-                            >
-                              <DriveFileRenameOutlineIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                            */}
-                          <Tooltip title={"Update"} placement="top" arrow>
-                            <IconButton
-                              className={c.updateIcon}
-                              title="Update"
-                              aria-label="update"
+                              className={c.previewIcon}
+                              title="Reset Password"
+                              aria-label="reset password"
                               onClick={() => {
                                 dispatch(
                                   setModal({
-                                    name: "updateDataset",
-                                    dataset: row,
+                                    name: "resetPassword",
+                                    row: row,
                                   })
                                 );
                               }}
                             >
-                              <UploadIcon fontSize="small" />
+                              <LockResetIcon fontSize="small" />
                             </IconButton>
                           </Tooltip>
+
                           <Divider orientation="vertical" flexItem />
 
                           <Tooltip title={"Delete"} placement="top" arrow>
@@ -521,8 +489,8 @@ export default function Datasets() {
                               onClick={() => {
                                 dispatch(
                                   setModal({
-                                    name: "deleteDataset",
-                                    dataset: row,
+                                    name: "deleteUser",
+                                    row: row,
                                   })
                                 );
                               }}
@@ -551,7 +519,7 @@ export default function Datasets() {
             className={c.bottomBar}
             rowsPerPageOptions={[25, 50, 100]}
             component="div"
-            count={datasets.length}
+            count={userEntries.length}
             rowsPerPage={rowsPerPage}
             page={page}
             onPageChange={handleChangePage}
@@ -559,10 +527,9 @@ export default function Datasets() {
           />
         </Paper>
       </Box>
-      <NewDatasetModal queryDatasets={queryDatasets} />
-      <LayersUsedByModal />
-      <UpdateDatasetModal queryDatasets={queryDatasets} />
-      <DeleteDatasetModal queryDatasets={queryDatasets} />
+      <ResetPasswordModal queryUsers={queryUsers} />
+      <DeleteUserModal queryUsers={queryUsers} />
+      <UpdateUserModal queryUsers={queryUsers} />
     </>
   );
 }

--- a/configure/src/pages/Users/Users.js
+++ b/configure/src/pages/Users/Users.js
@@ -1,9 +1,10 @@
+/* global mmgisglobal */
+
 import React, { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { makeStyles } from "@mui/styles";
 
 import { calls } from "../../core/calls";
-import { downloadObject } from "../../core/utils";
 import {
   setSnackBarText,
   setUserEntries,
@@ -11,7 +12,6 @@ import {
 } from "../../core/ConfigureStore";
 
 import PropTypes from "prop-types";
-import { alpha } from "@mui/material/styles";
 import Box from "@mui/material/Box";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -28,7 +28,6 @@ import IconButton from "@mui/material/IconButton";
 import Button from "@mui/material/Button";
 import Tooltip from "@mui/material/Tooltip";
 import Divider from "@mui/material/Divider";
-import Badge from "@mui/material/Badge";
 import { visuallyHidden } from "@mui/utils";
 
 import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
@@ -101,7 +100,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   tableInner: {
-    margin: "32px",
+    margin: "16px 32px 32px 32px",
     width: "calc(100% - 64px) !important",
     boxShadow: "0px 1px 7px 0px rgba(0, 0, 0, 0.2)",
   },
@@ -202,6 +201,33 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: "4px",
     display: "inline",
     color: "white",
+  },
+  authIndicator: {
+    margin: "16px 32px -16px 32px",
+    display: "flex",
+    padding: "8px 16px",
+    background: theme.palette.swatches.grey[300],
+    color: "white",
+    letterSpacing: "1px",
+    fontSize: "14px",
+    borderRadius: "4px",
+    boxShadow:
+      "rgba(0, 0, 0, 0.2) 0px 2px 1px -1px, rgba(0, 0, 0, 0.14) 0px 1px 1px 0px, rgba(0, 0, 0, 0.12) 0px 1px 3px 0px",
+    "& > div:first-child": {
+      color: theme.palette.accent.main,
+      fontWeight: "bold",
+      paddingRight: "4px",
+    },
+    "& > div:nth-child(2)": {
+      textTransform: "uppercase",
+      paddingRight: "4px",
+    },
+    "& > div:last-child": {
+      color: theme.palette.swatches.grey[850],
+      fontSize: "13px",
+      fontStyle: "italic",
+      lineHeight: "17px",
+    },
   },
 }));
 
@@ -385,11 +411,40 @@ export default function Users() {
     [order, orderBy, page, rowsPerPage, userEntries]
   );
 
+  let authDescription = null;
+  switch (mmgisglobal.AUTH) {
+    case "off":
+      authDescription =
+        "- Guests are allowed access. No authentication. Users cannot sign up or log in. Tools that require log in will not work.";
+      break;
+    case "none":
+      authDescription =
+        "- Guests are allowed access. No authentication. Users can still sign up and log in from within MMGIS.";
+      break;
+    case "local":
+      authDescription =
+        "- Anyone without credentials is blocked. Either the Admin must log in, create accounts and pass out the credentials or set AUTH_LOCAL_ALLOW_SIGNUP=true.";
+      break;
+    case "csso":
+      authDescription =
+        "- Using an external Cloud Single Sign On (CSSO) service that's proxied in front of MMGIS for authentication.";
+      break;
+    default:
+      break;
+  }
+
   return (
     <>
       <Box className={c.Users}>
         <Paper className={c.UsersInner}>
           <EnhancedTableToolbar />
+          {authDescription != null && (
+            <div className={c.authIndicator}>
+              <div>AUTH:</div>
+              <div>{mmgisglobal.AUTH}</div>
+              <div>{authDescription}</div>
+            </div>
+          )}
           <TableContainer className={c.table}>
             <Table
               className={c.tableInner}

--- a/configure/src/pages/WebHooks/WebHooks.js
+++ b/configure/src/pages/WebHooks/WebHooks.js
@@ -8,6 +8,8 @@ import Maker from "../../core/Maker";
 import { setSnackBarText, setConfiguration } from "../../core/ConfigureStore";
 
 import Button from "@mui/material/Button";
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
 
 import SaveIcon from "@mui/icons-material/Save";
 import PhishingIcon from "@mui/icons-material/Phishing";
@@ -15,7 +17,6 @@ import PhishingIcon from "@mui/icons-material/Phishing";
 const config = {
   rows: [
     {
-      name: "Webhooks",
       description:
         "Trigger HTTP requests whenever certain actions are executed in MMGIS.",
       components: [
@@ -81,17 +82,37 @@ const useStyles = makeStyles((theme) => ({
   WebHooks: {
     width: "100%",
     height: "100%",
-    overflowY: "auto",
     display: "flex",
     flexFlow: "column",
     background: theme.palette.swatches.grey[1000],
-    padding: "0px 32px 64px 32px",
+    padding: "0px",
     boxSizing: "border-box",
     backgroundImage: "url(configure/build/gridlines.png)",
+  },
+  topbar: {
+    width: "calc(100% - 100px)",
+    height: "44px",
+    minHeight: "44px !important",
+    display: "flex",
+    justifyContent: "space-between",
+    padding: `0px 20px`,
+    boxSizing: `border-box !important`,
+  },
+  topbarTitle: {
+    display: "flex",
+    color: theme.palette.swatches.grey[150],
+    "& > svg": {
+      color: theme.palette.swatches.grey[150],
+      margin: "3px 10px 0px 2px",
+    },
   },
   gap: {
     height: "64px",
     width: "100%",
+  },
+  content: {
+    width: "100%",
+    overflowY: "auto",
   },
   save: {
     margin: "8px !important",
@@ -190,7 +211,21 @@ export default function WebHooks() {
 
   return (
     <div className={c.WebHooks}>
-      <Maker config={config} inlineHelp={true} />
+      <Toolbar className={c.topbar}>
+        <div className={c.topbarTitle}>
+          <PhishingIcon />
+          <Typography
+            style={{ fontWeight: "bold", fontSize: "16px", lineHeight: "29px" }}
+            variant="h6"
+            component="div"
+          >
+            Webhooks
+          </Typography>
+        </div>
+      </Toolbar>
+      <div className={c.content}>
+        <Maker config={config} inlineHelp={true} />
+      </div>
       <div className={c.gap}></div>
       <Button
         className={c.save}

--- a/docs/mmgis-openapi.json
+++ b/docs/mmgis-openapi.json
@@ -3937,9 +3937,12 @@
                   },
                   "password": {
                     "type": "string"
+                  },
+                  "skipLogin": {
+                    "type": "boolean"
                   }
                 },
-                "required": ["username", "email", "password"]
+                "required": ["username", "password"]
               }
             }
           }
@@ -3963,7 +3966,7 @@
                     "summary": "Permission Denied",
                     "value": {
                       "status": "failure",
-                      "message": "Currently set so only administrators may create accounts."
+                      "message": "Currently only administrators may create accounts."
                     }
                   },
                   "failure_user_exists": {
@@ -4145,6 +4148,322 @@
                         "loggedIn": false,
                         "user": null
                       }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/users/resetPassword": {
+      "post": {
+        "summary": "Reset a Password",
+        "tags": ["Users"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  },
+                  "resetToken": {
+                    "type": "boolean"
+                  }
+                },
+                "required": ["username", "password", "resetToken"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Password Reset response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "success": {
+                    "summary": "Success",
+                    "value": {
+                      "status": "success",
+                      "message": "Successfully reset password for user:"
+                    }
+                  },
+                  "failure": {
+                    "summary": "Failure",
+                    "value": {
+                      "status": "failure",
+                      "message": "Password reset failed."
+                    }
+                  },
+                  "other_failure": {
+                    "summary": "Found user but still failed",
+                    "value": {
+                      "status": "failure",
+                      "message": "Failed to reset password for user:"
+                    }
+                  },
+                  "missing_username": {
+                    "summary": "Missing username input",
+                    "value": {
+                      "status": "failure",
+                      "message": "Missing username."
+                    }
+                  },
+                  "missing_password": {
+                    "summary": "Missing password input",
+                    "value": {
+                      "status": "failure",
+                      "message": "Missing password."
+                    }
+                  },
+                  "missing_resetToken": {
+                    "summary": "Missing resetToken input",
+                    "value": {
+                      "status": "failure",
+                      "message": "Missing resetToken."
+                    }
+                  },
+                  "reset_expired": {
+                    "summary": "Password reset time expired.",
+                    "value": {
+                      "status": "failure",
+                      "message": "Password reset time expired."
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid username or reset token.",
+                    "value": {
+                      "status": "failure",
+                      "message": "Invalid username or reset token."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/entries": {
+      "get": {
+        "summary": "Get a list of current user accounts. Requires administrator permissions.",
+        "tags": ["Accounts"],
+        "responses": {
+          "200": {
+            "description": "Returned user account entries.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "success": {
+                    "summary": "Success",
+                    "value": {
+                      "status": "success",
+                      "body": {
+                        "entries": [
+                          {
+                            "id": 6,
+                            "username": "my_username",
+                            "email": "my@email.com",
+                            "permission": "001",
+                            "createdAt": "2023-02-10T01:48:24.961Z",
+                            "updatedAt": "2025-01-14T07:32:30.857Z"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "failure": {
+                    "summary": "failure",
+                    "value": {
+                      "status": "failure",
+                      "message": "Failed to get user entries"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/remove/{id}": {
+      "delete": {
+        "summary": "Remove a user account. Requires administrator permissions.",
+        "tags": ["Accounts"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Remove response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "success": {
+                    "summary": "Success",
+                    "value": {
+                      "status": "success",
+                      "message": "Successfully deleted user with id: ."
+                    }
+                  },
+                  "missing_id": {
+                    "summary": "Missing user id",
+                    "value": {
+                      "status": "failure",
+                      "message": "Failed to delete user. User Id is null."
+                    }
+                  },
+                  "cannot_delete_superadmin": {
+                    "summary": "Cannot delete SuperAdmin",
+                    "value": {
+                      "status": "failure",
+                      "message": "Cannot delete the original Administrator account."
+                    }
+                  },
+                  "failure": {
+                    "summary": "Failure",
+                    "value": {
+                      "status": "failure",
+                      "message": "Failed to delete user with id: ."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/update": {
+      "post": {
+        "summary": "Update a user account. Requires administrator permissions.",
+        "tags": ["Accounts"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "email": {
+                    "type": "string"
+                  },
+                  "permission": {
+                    "type": "string"
+                  }
+                },
+                "required": ["id"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User account update response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "success": {
+                    "summary": "Success",
+                    "value": {
+                      "status": "success",
+                      "message": "Successfully updated user with id: .",
+                      "body": {
+                        "updated_id": "id"
+                      }
+                    }
+                  },
+                  "missing_id": {
+                    "summary": "Missing user id.",
+                    "value": {
+                      "status": "failure",
+                      "message": "Failed to update user. User Id is null."
+                    }
+                  },
+                  "failure": {
+                    "summary": "Failure to update user.",
+                    "value": {
+                      "status": "failure",
+                      "message": "Failed to update user with id: ."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/accounts/generateResetPasswordLink": {
+      "post": {
+        "summary": "Generate a password reset link for a user. Requires administrator permissions.",
+        "tags": ["Accounts"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "expires": {
+                    "type": "integer"
+                  }
+                },
+                "required": ["id"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generate a password reset link response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "success": {
+                    "summary": "Success",
+                    "value": {
+                      "status": "success",
+                      "message": "Successfully generated a password reset token for user with id: .",
+                      "body": {
+                        "resetToken": "reset_token",
+                        "resetTokenExpiration": "reset_token_expiration_timestamp_ms"
+                      }
+                    }
+                  },
+                  "missing_id": {
+                    "summary": "Missing user id.",
+                    "value": {
+                      "status": "failure",
+                      "message": "Failed to generate a password reset link for user. User Id is null."
+                    }
+                  },
+                  "failure": {
+                    "summary": "Failed to generate a password reset token",
+                    "value": {
+                      "status": "failure",
+                      "message": "Failed to generate a password reset token for user with id: ."
                     }
                   }
                 }

--- a/docs/pages/Setup/ENVs/ENVs.md
+++ b/docs/pages/Setup/ENVs/ENVs.md
@@ -25,7 +25,7 @@ The kind of authentication method used | string enum | default `''`
 
 - _off:_ No authentication. Users cannot sign up or log in. Tools that require log in will not work.
 - _none:_ No authentication. Users can still sign up and log in from within MMGIS.
-- _local:_ Anyone without credentials is blocked. The Admin must log in, create accounts and pass out the credentials.
+- _local:_ Anyone without credentials is blocked. The Admin must log in, create accounts and pass out the credentials or set AUTH_LOCAL_ALLOW_SIGNUP=true.
 - _csso:_ Use a Cloud Single Sign On service that's proxied in front of MMGIS.
 
 #### `NODE_ENV=`
@@ -101,6 +101,10 @@ If `DB_SSL=true` and if needed, the path to a certificate for ssl | string | def
 
 Alternatively, if `DB_SSL=true` and if needed, a base64 encoded certificate for ssl. `DB_SSL_CERT_BASE64` will take priority over `DB_SSL_CERT` | string | default `null`
 
+#### `AUTH_LOCAL_ALLOW_SIGNUP=`
+
+If AUTH=local and set to true, this allows all guests to the site to create user accounts otherwise, they just see a login page with no signup section | boolean | default `false`
+
 #### `CSSO_GROUPS=`
 
 A list of CSSO LDAP groups that have access | string[] | default `[]`
@@ -136,6 +140,10 @@ Overrides ROOT_PATH's use when the client connects via websocket. Websocket url:
 #### `CLEARANCE_NUMBER=`
 
 Sets a clearance for the website | string | default `CL##-####`
+
+#### `CONTACT_INFO=`
+
+A string of text for contact information on the bottom right corner of the login pages | string | default `None Provided`
 
 #### `LINK_PREVIEW_TITLE=`
 

--- a/public/login.css
+++ b/public/login.css
@@ -11,7 +11,7 @@ html {
   margin: 0;
 }
 
-.container {
+#container {
   margin: 0;
   top: 50%;
   left: 50%;
@@ -24,6 +24,7 @@ html {
   width: 400px;
   height: 440px;
   box-shadow: 0px 4px 30px 10px #141414;
+  transition: height 0.2s;
 }
 
 .box h4 {
@@ -88,7 +89,7 @@ a:hover {
   height: 49px;
   font-size: 16px;
   position: absolute;
-  top: 80%;
+  bottom: 47px;
   left: 7.5%;
   transition: 0.3s;
   cursor: pointer;
@@ -100,6 +101,7 @@ a:hover {
 
 .btn1:hover {
   background: #08aeea;
+  color: white;
 }
 
 .error {
@@ -110,16 +112,33 @@ a:hover {
   border: 0;
   margin: 10px auto 10px;
   position: absolute;
-  top: 37%;
+  top: 158px;
+  white-space: nowrap;
+  display: flex;
+  justify-content: center;
   left: 7.2%;
-  color: #d6d7db;
+  color: #ffcfb3;
   border-bottom: 2px solid #ff7426;
   opacity: 0;
   transition: opacity 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
 }
 
+#email_label,
+#email,
+#email_description,
+#pwd_description,
+#pwd_retype_label,
 #pwd_retype {
   display: none;
+}
+
+#email_description,
+#pwd_description {
+  color: #a1a4ad;
+  font-style: italic;
+  font-size: 14px;
+  text-align: left;
+  margin: -17px 39px -8px 39px;
 }
 
 img {
@@ -158,4 +177,29 @@ img {
 }
 #configIcon:hover {
   color: black;
+}
+
+#toggleWrapper {
+  width: 100%;
+  display: none;
+  justify-content: center;
+}
+#toggle {
+  position: absolute;
+  bottom: 15px;
+  padding: 2px 8px;
+  line-height: 16px;
+  text-align: center;
+  background: #36373a;
+  color: #a1a4ad;
+  font-family: "Source Sans Pro", sans-serif;
+  border-radius: 3px;
+  font-size: 13px;
+  text-transform: lowercase;
+  cursor: pointer;
+  transition: all 0.2s ease-out;
+}
+#toggle:hover {
+  background: #08aeea;
+  color: white;
 }

--- a/public/login.js
+++ b/public/login.js
@@ -1,48 +1,132 @@
+let toggleState = "login";
+
 function login() {
   if (
     document.getElementById("username").value === "" ||
     document.getElementById("pwd").value === ""
   ) {
-    document.getElementById("msg").innerHTML = "Missing username or password";
+    document.getElementById("msg").innerHTML = "Missing username or password.";
     document.getElementById("msg").style.opacity = 1;
     return;
   }
 
-  $.ajax({
-    type: "POST",
-    url: "api/users/login",
-    data: {
-      username: document.getElementById("username").value,
-      password: document.getElementById("pwd").value,
-    },
-    success: function (data) {
-      if (
-        !data.hasOwnProperty("status") ||
-        (data.hasOwnProperty("status") && data.status === "success")
-      ) {
-        //success
-        document.cookie = "MMGISUser=;expires=Thu, 01 Jan 1970 00:00:01 GMT;";
-        document.cookie = `MMGISUser=${JSON.stringify({
-          username: data.username,
-          token: data.token,
-        })}${data.additional}`;
-        window.location.reload();
-      } else {
+  if (toggleState === "login") {
+    $.ajax({
+      type: "POST",
+      url: "api/users/login",
+      data: {
+        username: document.getElementById("username").value,
+        password: document.getElementById("pwd").value,
+      },
+      success: function (data) {
+        if (
+          !data.hasOwnProperty("status") ||
+          (data.hasOwnProperty("status") && data.status === "success")
+        ) {
+          //success
+          document.cookie = "MMGISUser=;expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+          document.cookie = `MMGISUser=${JSON.stringify({
+            username: data.username,
+            token: data.token,
+          })}${data.additional}`;
+          window.location.reload();
+        } else {
+          //error
+          document.getElementById("msg").innerHTML =
+            "Invalid username or password";
+          document.getElementById("msg").style.opacity = 1;
+        }
+      },
+      error: function () {
         //error
-        document.getElementById("msg").innerHTML =
-          "Invalid username or password";
+        document.getElementById("msg").innerHTML = "Server error.";
         document.getElementById("msg").style.opacity = 1;
-      }
-    },
-    error: function () {
-      //error
-      document.getElementById("msg").innerHTML = "Server error.";
+      },
+    });
+  } else if (toggleState === "signup") {
+    if (
+      document.getElementById("pwd").value !=
+      document.getElementById("pwd_retype").value
+    ) {
+      document.getElementById("msg").innerHTML = "Passwords don't match.";
       document.getElementById("msg").style.opacity = 1;
-    },
-  });
+      return;
+    }
+
+    $.ajax({
+      type: "POST",
+      url: "api/users/signup",
+      data: {
+        username: document.getElementById("username").value,
+        email: document.getElementById("email").value,
+        password: document.getElementById("pwd").value,
+      },
+      success: function (data) {
+        if (
+          !data.hasOwnProperty("status") ||
+          (data.hasOwnProperty("status") && data.status === "success")
+        ) {
+          //success
+          document.cookie = "MMGISUser=;expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+          document.cookie = `MMGISUser=${JSON.stringify({
+            username: data.username,
+            token: data.token,
+          })}${data.additional}`;
+          window.location.reload();
+        } else {
+          //error
+          document.getElementById("msg").innerHTML =
+            data.message || "Something went wrong.";
+          document.getElementById("msg").style.opacity = 1;
+        }
+      },
+      error: function () {
+        //error
+        document.getElementById("msg").innerHTML = "Server error.";
+        document.getElementById("msg").style.opacity = 1;
+      },
+    });
+  }
+}
+function toggle() {
+  if (toggleState == "login") {
+    document.getElementById("container").style.height = "635px";
+    document.getElementById("login").innerHTML = "Sign Up";
+
+    document.getElementById("email_label").style.display = "block";
+
+    document.getElementById("email").style.display = "block";
+    document.getElementById("email_description").style.display = "block";
+    document.getElementById("pwd_description").style.display = "block";
+    document.getElementById("pwd_retype_label").style.display = "block";
+    document.getElementById("pwd_retype").style.display = "block";
+    document.getElementById("pwd_label").style.top = "348px";
+
+    toggleState = "signup";
+  } else {
+    document.getElementById("container").style.height = "440px";
+    document.getElementById("login").innerHTML = "Sign In";
+
+    document.getElementById("email_label").style.display = "none";
+
+    document.getElementById("email").style.display = "none";
+    document.getElementById("email_description").style.display = "none";
+
+    document.getElementById("pwd_description").style.display = "none";
+
+    document.getElementById("pwd_retype_label").style.display = "none";
+
+    document.getElementById("pwd_retype").style.display = "none";
+
+    document.getElementById("pwd_label").style.top = "270px";
+
+    toggleState = "login";
+  }
 }
 
 $(document).ready(function () {
+  if (allowSignup === true)
+    document.getElementById("toggleWrapper").style.display = "flex";
   $(document).on("keypress", function (e) {
     if (e.which === 13) {
       login();

--- a/public/resetPassword.css
+++ b/public/resetPassword.css
@@ -1,0 +1,161 @@
+@font-face {
+  font-family: "Source Sans Pro";
+  src: url(/public/fonts/sourcesanspro/SourceSansPro-Regular.ttf);
+}
+
+body,
+html {
+  font-family: "Source Sans Pro", sans-serif;
+  background-color: #1a1a1a;
+  padding: 0;
+  margin: 0;
+}
+
+.container {
+  margin: 0;
+  top: 50%;
+  left: 50%;
+  position: absolute;
+  text-align: center;
+  transform: translateX(-50%) translateY(-50%);
+  background-color: #1c1c1c;
+  border-top: 4px solid #08aeea;
+  border-bottom: 4px solid #08aeea;
+  width: 400px;
+  height: 440px;
+  box-shadow: 0px 4px 30px 10px #141414;
+}
+
+.box h4 {
+  font-family: "Source Sans Pro", sans-serif;
+  color: #08aeea;
+  font-size: 18px;
+  margin-top: 94px;
+}
+
+.box h4 span {
+  color: #dfdeee;
+  font-weight: lighter;
+  margin-left: 4px;
+}
+
+.box h5 {
+  font-family: "Source Sans Pro", sans-serif;
+  font-size: 13px;
+  color: #a1a4ad;
+  letter-spacing: 1.5px;
+  margin-top: -15px;
+  margin-bottom: 53px;
+}
+
+.box input[type="text"],
+.box input[type="password"] {
+  display: block;
+  margin: 20px auto;
+  background: #36373a;
+  border: 0;
+  border-radius: 5px;
+  padding: 14px 10px;
+  width: 320px;
+  outline: none;
+  font-size: 14px;
+  color: #ececec;
+  border: 1px solid rgba(0, 0, 0, 0);
+}
+::-webkit-input-placeholder {
+  color: #727580;
+}
+
+.box input[type="text"]:focus,
+.box input[type="password"]:focus {
+  border: 1px solid #75767a;
+}
+
+a {
+  color: #75767a;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.btn1 {
+  background: #36373a;
+  color: #dfdeee;
+  border-radius: 5px;
+  width: 340px;
+  height: 49px;
+  font-size: 16px;
+  position: absolute;
+  top: 80%;
+  left: 7.5%;
+  transition: 0.3s;
+  cursor: pointer;
+  text-align: center;
+  user-select: none;
+  font-family: "Source Sans Pro", sans-serif;
+  line-height: 49px;
+}
+
+.btn1:hover {
+  background: #08aeea;
+}
+
+.error {
+  text-align: center;
+  width: 337px;
+  height: 22px;
+  padding: 2px;
+  border: 0;
+  margin: 10px auto 10px;
+  position: absolute;
+  top: 37%;
+  left: 7.2%;
+  color: #d6d7db;
+  border-bottom: 2px solid #ff7426;
+  opacity: 0;
+  transition: opacity 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
+}
+
+#pwd_retype {
+  display: none;
+}
+
+img {
+  position: absolute;
+  top: 44px;
+  left: 50%;
+  transform: translateX(-50%);
+  cursor: pointer;
+}
+
+.mmgisScrollbar::-webkit-scrollbar-track {
+  -webkit-box-shadow: inset 0px 0px 6px rgba(0, 0, 0, 0.3);
+  background-color: Transparent;
+}
+
+.mmgisScrollbar::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+  background-color: transparent;
+}
+
+.mmgisScrollbar::-webkit-scrollbar-thumb {
+  border-radius: 2px;
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+#configIcon {
+  position: absolute;
+  bottom: 0px;
+  left: 0px;
+  padding: 10px;
+  cursor: pointer;
+  color: #999;
+  transition: color 0.2s ease-in;
+  z-index: 100;
+}
+#configIcon:hover {
+  color: black;
+}

--- a/public/resetPassword.css
+++ b/public/resetPassword.css
@@ -11,7 +11,7 @@ html {
   margin: 0;
 }
 
-.container {
+#container {
   margin: 0;
   top: 50%;
   left: 50%;
@@ -19,10 +19,11 @@ html {
   text-align: center;
   transform: translateX(-50%) translateY(-50%);
   background-color: #1c1c1c;
-  border-top: 4px solid #08aeea;
-  border-bottom: 4px solid #08aeea;
+  border-top: 4px solid #eab708;
+  border-bottom: 4px solid #eab708;
   width: 400px;
-  height: 440px;
+  height: 514px;
+  z-index: 1;
   box-shadow: 0px 4px 30px 10px #141414;
 }
 
@@ -110,7 +111,7 @@ a:hover {
   border: 0;
   margin: 10px auto 10px;
   position: absolute;
-  top: 37%;
+  top: 31%;
   left: 7.2%;
   color: #d6d7db;
   border-bottom: 2px solid #ff7426;
@@ -118,8 +119,33 @@ a:hover {
   transition: opacity 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
 }
 
-#pwd_retype {
-  display: none;
+.success {
+  text-align: center;
+  background: #1c1c1c;
+  width: calc(100% - 4px);
+  height: calc(100% - 4px);
+  top: 0;
+  left: 0;
+  z-index: 10;
+  margin: 0;
+  border: none;
+  position: absolute;
+  color: #d6d7db;
+  opacity: 0;
+  padding: 128px 0px;
+  box-sizing: border-box;
+  pointer-events: none;
+  transition: opacity 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
+}
+.success > div:first-child {
+  font-size: 90px;
+  color: #08ea67;
+}
+#msgSuccessMsg {
+  font-weight: bold;
+  font-size: 18px;
+  letter-spacing: 1px;
+  text-transform: capitalize;
 }
 
 img {

--- a/public/resetPassword.js
+++ b/public/resetPassword.js
@@ -1,0 +1,51 @@
+function resetPassword() {
+  let token = window.location.href.split("?t=")[1];
+  if (
+    document.getElementById("username").value === "" ||
+    document.getElementById("pwd").value === "" ||
+    token === "" ||
+    token == null
+  ) {
+    document.getElementById("msg").innerHTML =
+      "Missing username, password, or reset token";
+    document.getElementById("msg").style.opacity = 1;
+    return;
+  }
+
+  $.ajax({
+    type: "POST",
+    url: "api/users/resetPassword",
+    data: {
+      username: document.getElementById("username").value,
+      password: document.getElementById("pwd").value,
+      resetToken: token,
+    },
+    success: function (data) {
+      if (
+        !data.hasOwnProperty("status") ||
+        (data.hasOwnProperty("status") && data.status === "success")
+      ) {
+        //success
+        document.getElementById("msg").innerHTML = data.message;
+        document.getElementById("msg").style.opacity = 1;
+      } else {
+        //error
+        document.getElementById("msg").innerHTML = data.message;
+        document.getElementById("msg").style.opacity = 1;
+      }
+    },
+    error: function () {
+      //error
+      document.getElementById("msg").innerHTML = "Server error.";
+      document.getElementById("msg").style.opacity = 1;
+    },
+  });
+}
+
+$(document).ready(function () {
+  $(document).on("keypress", function (e) {
+    if (e.which === 13) {
+      login();
+    }
+  });
+});

--- a/public/resetPassword.js
+++ b/public/resetPassword.js
@@ -6,9 +6,18 @@ function resetPassword() {
     token === "" ||
     token == null
   ) {
-    document.getElementById("msg").innerHTML =
-      "Missing username, password, or reset token";
-    document.getElementById("msg").style.opacity = 1;
+    document.getElementById("msgError").innerHTML =
+      "Missing username, password, or reset token.";
+    document.getElementById("msgError").style.opacity = 1;
+    return;
+  }
+
+  if (
+    document.getElementById("pwd").value !=
+    document.getElementById("pwd_retype").value
+  ) {
+    document.getElementById("msgError").innerHTML = "Passwords don't match.";
+    document.getElementById("msgError").style.opacity = 1;
     return;
   }
 
@@ -26,26 +35,42 @@ function resetPassword() {
         (data.hasOwnProperty("status") && data.status === "success")
       ) {
         //success
-        document.getElementById("msg").innerHTML = data.message;
-        document.getElementById("msg").style.opacity = 1;
+        document.getElementById("msgSuccessMsg").innerHTML =
+          "Successfully Reset Password!";
+        document.getElementById("msgSuccess").style.opacity = 1;
+        document.getElementById("msgSuccess").style.pointerEvents = "all";
+        document.getElementById("container").style.borderTop =
+          "4px solid #08ea67";
+        document.getElementById("container").style.borderBottom =
+          "4px solid #08ea67";
       } else {
         //error
-        document.getElementById("msg").innerHTML = data.message;
-        document.getElementById("msg").style.opacity = 1;
+        document.getElementById("msgError").innerHTML = data.message;
+        document.getElementById("msgError").style.opacity = 1;
       }
     },
     error: function () {
       //error
-      document.getElementById("msg").innerHTML = "Server error.";
-      document.getElementById("msg").style.opacity = 1;
+      document.getElementById("msgError").innerHTML = "Server error.";
+      document.getElementById("msgError").style.opacity = 1;
     },
   });
 }
 
-$(document).ready(function () {
-  $(document).on("keypress", function (e) {
-    if (e.which === 13) {
-      login();
-    }
-  });
-});
+function goHome() {
+  const url = new URL(window.location.href);
+
+  // Remove search params and hash
+  url.search = "";
+  url.hash = "";
+
+  // Split path, remove last segment
+  const parts = url.pathname.split("/").filter(Boolean);
+  parts.pop();
+
+  // Join back and set the new pathname
+  const newPath = "/" + parts.join("/");
+  url.pathname = newPath === "/" ? "/" : newPath + "/";
+
+  window.location.href = url.href;
+}

--- a/sample.env
+++ b/sample.env
@@ -10,10 +10,14 @@ PORT=8888
 # AUTH - off || none || local || csso
 # off: No authentication. Users cannot sign up or log in. Tools that require log in will not work.
 # none: No authentication. Users can still sign up and log in from within MMGIS
-# local: Anyone without credentials is blocked. The Admin must log in, create accounts and pass out the credentials
+# local: Anyone without credentials is blocked. The Admin must log in, create accounts and pass out the credentials or set AUTH_LOCAL_ALLOW_SIGNUP=true.
 #   (does not work in dev env/build first and npm run start:prod)
 # csso: Use a Cloud Single Sign On service that's proxied in front of MMGIS   
 AUTH=none
+
+# If AUTH=local and set to true, this allows all guests to the site to create user accounts
+#  otherwise, they just see a login page with no signup section
+AUTH_LOCAL_ALLOW_SIGNUP=false
 
 # NODE_ENV - development || production
 NODE_ENV=development
@@ -72,6 +76,9 @@ WEBSOCKET_ROOT_PATH=
 
 # Sets a clearance number for the website
 CLEARANCE_NUMBER=
+
+# A string of text for contact information on the bottom right corner of the login pages
+CONTACT_INFO=
 
 # Initial HTML page title. When sharing a link to MMGIS in an application that supports link previews, the title to be used | string | default `MMGIS`
 LINK_PREVIEW_TITLE=

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -623,6 +623,20 @@ setups.getBackendSetups(function (setups) {
     middleware.missions(ROOT_PATH),
     express.static(path.join(rootDir, "/Missions"))
   );
+  app.get(s.ROOT_PATH + "/resetPassword", (req, res) => {
+    const user = process.env.AUTH === "csso" ? req.user : req.user || "";
+    res.render("../views/resetpassword.pug", {
+      user: user,
+      AUTH: process.env.AUTH,
+      NODE_ENV: process.env.NODE_ENV,
+      ROOT_PATH:
+        process.env.NODE_ENV === "development"
+          ? ""
+          : /*(process.env.EXTERNAL_ROOT_PATH || "") +*/
+            process.env.ROOT_PATH || "",
+      CLEARANCE_NUMBER: process.env.CLEARANCE_NUMBER || "CL##-####",
+    });
+  });
 
   if (isDevEnv) {
     app.use(

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -423,6 +423,8 @@ function ensureUser() {
         res.render("login", {
           user: req.user,
           CLEARANCE_NUMBER: process.env.CLEARANCE_NUMBER || "CL##-####",
+          CONTACT_INFO: process.env.CONTACT_INFO || "None Provided",
+          AUTH_LOCAL_ALLOW_SIGNUP: process.env.AUTH_LOCAL_ALLOW_SIGNUP || false,
         });
       }
     }
@@ -635,6 +637,7 @@ setups.getBackendSetups(function (setups) {
           : /*(process.env.EXTERNAL_ROOT_PATH || "") +*/
             process.env.ROOT_PATH || "",
       CLEARANCE_NUMBER: process.env.CLEARANCE_NUMBER || "CL##-####",
+      CONTACT_INFO: process.env.CONTACT_INFO || "None Provided",
     });
   });
 

--- a/views/login.pug
+++ b/views/login.pug
@@ -4,29 +4,38 @@ html(lang='en')
     title MMGIS / Login
     link(rel='shortcut icon' href='public/images/logos/logo.png')
     link(type='text/css' rel='stylesheet' href='public/login.css')
+    script.
+      allowSignup = #{AUTH_LOCAL_ALLOW_SIGNUP}
     script(type='text/javascript' src='public/jquery.min.js')
     script(type='text/javascript' src='public/login.js')
   body.mmgisScrollbar
     .header
       img(src='public/images/logos/local_login_brand.png' alt='Branding' style='left: 44px; transform: unset; height: 60px; opacity: 0.5;')
-    .container(style='z-index: 1;')
+    #container(style='z-index: 1;')
       img(src='public/images/logos/mmgis.png' alt='MMGIS')
       span#msg.error
-      form.box(name='form1' title='Log in to MMGIS!')
+      form.box(name='form1')
         h4
           | Sign in
           span to your account.
-        h5 If you do not have an account,<br>request one from your administrator.
-        label(for="username" style="position: absolute; color: #a1a4ad; top: 203px; left: 50%; transform: translateX(-50%); background: #1c1c1c; border-radius: 10px; font-size: 14px; width: 100px; text-align: center;") Username
+        h5 If you do not have an account,<br>sign up or request one from your administrator.
+        label#username_label(for="username" style="position: absolute; color: #a1a4ad; top: 203px; left: 50%; transform: translateX(-50%); background: #1c1c1c; border-radius: 10px; font-size: 14px; width: 100px; text-align: center;") Username
         input#username(type='text' name='username' placeholder='Username' autocomplete='off')
-        label(for="password" style="position: absolute; color: #a1a4ad; top: 270px; left: 50%; transform: translateX(-50%); background: #1c1c1c; border-radius: 10px; font-size: 14px; width: 100px; text-align: center;") Password
+        label#email_label(for="email" style="position: absolute; color: #a1a4ad; top: 270px; left: 50%; transform: translateX(-50%); background: #1c1c1c; border-radius: 10px; font-size: 14px; width: 100px; text-align: center;") Email
+        input#email(type='text' name='email' placeholder='Email' autocomplete='off')
+        div#email_description An email is optional.
+        label#pwd_label(for="pwd" style="position: absolute; color: #a1a4ad; top: 270px; left: 50%; transform: translateX(-50%); background: #1c1c1c; border-radius: 10px; font-size: 14px; width: 100px; text-align: center;") Password
         input#pwd(type='password' name='password' placeholder='Password' autocomplete='off')
+        div#pwd_description Must be at least 8 characters long and contain at least: 1 uppercase letter, 1 lowercase letter, 1 number and 1 symbol.
+        label#pwd_retype_label(for="pwd_retype" style="position: absolute; color: #a1a4ad; top: 464px; left: 50%; transform: translateX(-50%); background: #1c1c1c; border-radius: 10px; font-size: 14px; width: 120px; text-align: center;") Retype Password
         input#pwd_retype(type='password' name='password' placeholder='Retype Password' autocomplete='off')
-        div.btn1(onClick='login()') Sign in
+        div#login.btn1(onClick='login()' title='Log in to MMGIS!') Sign in
+        div#toggleWrapper
+          div#toggle(onClick='toggle()') Or Sign Up
     .footer(style='position: absolute; bottom: 0; padding: 44px; box-sizing: border-box; width: 100%; color: #adadad; font-size: 14px; display: flex; justify-content: flex-end; text-align: end;')
       
       div
-        div Contact: fred.calef@jpl.nasa.gov
+        div Contact: #{CONTACT_INFO}
         div Clearance Number: #{CLEARANCE_NUMBER}
         div(style='display: flex;')
         a(href='http://www.jpl.nasa.gov/copyrights.cfm' style='margin-right: 10px;') PRIVACY

--- a/views/resetpassword.pug
+++ b/views/resetpassword.pug
@@ -31,7 +31,7 @@ html(lang='en')
     .footer(style='position: absolute; bottom: 0; padding: 44px; box-sizing: border-box; width: 100%; color: #adadad; font-size: 14px; display: flex; justify-content: flex-end; text-align: end;')
       
       div
-        div Contact: fred.calef@jpl.nasa.gov
+        div Contact: #{CONTACT_INFO}
         div Clearance Number: #{CLEARANCE_NUMBER}
         div(style='display: flex;')
         a(href='http://www.jpl.nasa.gov/copyrights.cfm' style='margin-right: 10px;') PRIVACY

--- a/views/resetpassword.pug
+++ b/views/resetpassword.pug
@@ -9,9 +9,13 @@ html(lang='en')
   body.mmgisScrollbar
     .header
       img(src='public/images/logos/local_login_brand.png' alt='Branding' style='left: 44px; transform: unset; height: 60px; opacity: 0.5;')
-    .container(style='z-index: 1; border-top: 4px solid #eab708; border-bottom: 4px solid #eab708; height: 514px;')
+    div#container
       img(src='public/images/logos/mmgis.png' alt='MMGIS')
-      span#msg.error
+      span#msgError.error
+      div#msgSuccess.success
+        div 🗸
+        div#msgSuccessMsg 
+        div.btn1(onCLick='goHome()' style='top: 60%;') Return Home
       form.box(name='form1' title='Reset your MMGIS password.')
         h4(style='color: #eab708;')
           | Reset
@@ -22,7 +26,7 @@ html(lang='en')
         label(for="pwd" style="position: absolute; color: #a1a4ad; top: 270px; left: 50%; transform: translateX(-50%); background: #1c1c1c; border-radius: 10px; font-size: 14px; width: 132px; text-align: center;") New Password
         input#pwd(type='password' name='password' placeholder='Password' autocomplete='off')
         label(for="pwd_retype" style="position: absolute; color: #a1a4ad; top: 336px; left: 50%; transform: translateX(-50%); background: #1c1c1c; border-radius: 10px; font-size: 14px; width: 164px; text-align: center;") Retype New Password
-        input#pwd_retype(type='password' name='password' placeholder='Retype Password' autocomplete='off' style='display: block;')
+        input#pwd_retype(type='password' name='password' placeholder='Retype Password' autocomplete='off')
         div.btn1(onClick='resetPassword()') Reset Password
     .footer(style='position: absolute; bottom: 0; padding: 44px; box-sizing: border-box; width: 100%; color: #adadad; font-size: 14px; display: flex; justify-content: flex-end; text-align: end;')
       

--- a/views/resetpassword.pug
+++ b/views/resetpassword.pug
@@ -1,0 +1,36 @@
+doctype html
+html(lang='en')
+  head
+    title MMGIS / Reset Password
+    link(rel='shortcut icon' href='public/images/logos/logo.png')
+    link(type='text/css' rel='stylesheet' href='public/resetPassword.css')
+    script(type='text/javascript' src='public/jquery.min.js')
+    script(type='text/javascript' src='public/resetPassword.js')
+  body.mmgisScrollbar
+    .header
+      img(src='public/images/logos/local_login_brand.png' alt='Branding' style='left: 44px; transform: unset; height: 60px; opacity: 0.5;')
+    .container(style='z-index: 1; border-top: 4px solid #eab708; border-bottom: 4px solid #eab708; height: 514px;')
+      img(src='public/images/logos/mmgis.png' alt='MMGIS')
+      span#msg.error
+      form.box(name='form1' title='Reset your MMGIS password.')
+        h4(style='color: #eab708;')
+          | Reset
+          span your password.
+        h5 If you have forgotten your account credentials,<br>request a password reset from your administrator.
+        label(for="username" style="position: absolute; color: #a1a4ad; top: 203px; left: 50%; transform: translateX(-50%); background: #1c1c1c; border-radius: 10px; font-size: 14px; width: 100px; text-align: center;") Username
+        input#username(type='text' name='username' placeholder='Username' autocomplete='off')
+        label(for="pwd" style="position: absolute; color: #a1a4ad; top: 270px; left: 50%; transform: translateX(-50%); background: #1c1c1c; border-radius: 10px; font-size: 14px; width: 132px; text-align: center;") New Password
+        input#pwd(type='password' name='password' placeholder='Password' autocomplete='off')
+        label(for="pwd_retype" style="position: absolute; color: #a1a4ad; top: 336px; left: 50%; transform: translateX(-50%); background: #1c1c1c; border-radius: 10px; font-size: 14px; width: 164px; text-align: center;") Retype New Password
+        input#pwd_retype(type='password' name='password' placeholder='Retype Password' autocomplete='off' style='display: block;')
+        div.btn1(onClick='resetPassword()') Reset Password
+    .footer(style='position: absolute; bottom: 0; padding: 44px; box-sizing: border-box; width: 100%; color: #adadad; font-size: 14px; display: flex; justify-content: flex-end; text-align: end;')
+      
+      div
+        div Contact: fred.calef@jpl.nasa.gov
+        div Clearance Number: #{CLEARANCE_NUMBER}
+        div(style='display: flex;')
+        a(href='http://www.jpl.nasa.gov/copyrights.cfm' style='margin-right: 10px;') PRIVACY
+        a(href='http://www.jpl.nasa.gov/imagepolicy/') IMAGE POLICY
+  footer
+    script(id="_fed_an_ua_tag" type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=MMGIS&dclink=true&sp=search,s")


### PR DESCRIPTION
Closes #708 

## Adds
### Features
- Admins can delete user accounts
- Admins can one-time-use, expiring, generate password reset links for users
- Admins can create users with the /configure page
- Admins can upgrade User accounts to be Admin accounts thus supporting multiple admin accounts
- Admins can view user's emails
- Admins can change a user's listed email
- Admins can view user join dates and last login dates
- User account emails are now optional.
- If `AUTH=true` and `AUTH_LOCAL_ALLOW_SIGNUP=true`, then new users can sign up from the login page on their own without first directly getting an account by contacting an admin.
- The new `CONTACT_INFO` allows setting a point of contact that's shown in the login page. (Previously this was hardcoded to fred.calef@jpl.nasa.gov) 
### New Endpoints
- POST /api/users/resetPassword
- GET /api/accounts/entries
- DELETE /api/accounts/remove/:id
- POST /api/accounts/update
- POST /api/accounts/generateResetPasswordLink
### New ENVs
- CONTACT_INFO
- AUTH_LOCAL_ALLOW_SIGNUP
### New Pages
- https://{domain}/resetPassword?t={token}
### New /configure pages
- Users

## Changes
- Passwords must now be (from no requirements):
  - Must be 8 of more characters long
  - Contain at least: 1 symbol, 1 uppercase letter, 1 lowercase letter, 1 number
  
  
 ## Showcases
 ### Optional new user sign up:
![9807346834956](https://github.com/user-attachments/assets/56996249-bbee-4276-be21-fb0b3e2911d8)

### New Users page in /configure:
![4357089678904](https://github.com/user-attachments/assets/05ce694a-c6d4-4572-976d-22c6c569eba1)

### Password reset modal:
![326237986](https://github.com/user-attachments/assets/846a6849-4f50-4e85-b2a0-e61bd359520c)

### https://{domain}/resetPassword?t={token} page:
![28735623](https://github.com/user-attachments/assets/59557bd4-90a5-4ba7-8134-d6ac92c1e97e)
