### PR TITLE
Use a prerendered image for the layer legend

### DIFF
--- a/configure/src/metaconfigs/layer-image-config.json
+++ b/configure/src/metaconfigs/layer-image-config.json
@@ -190,7 +190,7 @@
               "new": true,
               "field": "legend",
               "name": "Legend From URL",
-              "description": "A URL to a .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
+              "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
               "width": 12
             }

--- a/configure/src/metaconfigs/layer-model-config.json
+++ b/configure/src/metaconfigs/layer-model-config.json
@@ -423,7 +423,7 @@
               "new": true,
               "field": "legend",
               "name": "Legend From URL",
-              "description": "A URL to a .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
+              "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
               "width": 12
             }

--- a/configure/src/metaconfigs/layer-query-config.json
+++ b/configure/src/metaconfigs/layer-query-config.json
@@ -546,7 +546,7 @@
               "new": true,
               "field": "legend",
               "name": "Legend From URL",
-              "description": "A URL to a .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
+              "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
               "width": 12
             }

--- a/configure/src/metaconfigs/layer-tile-config.json
+++ b/configure/src/metaconfigs/layer-tile-config.json
@@ -396,7 +396,7 @@
               "new": true,
               "field": "legend",
               "name": "Legend From URL",
-              "description": "A URL to a .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
+              "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
               "width": 12
             }

--- a/configure/src/metaconfigs/layer-vector-config.json
+++ b/configure/src/metaconfigs/layer-vector-config.json
@@ -484,7 +484,7 @@
               "new": true,
               "field": "legend",
               "name": "Legend From URL",
-              "description": "A URL to a .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
+              "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
               "width": 12
             }

--- a/configure/src/metaconfigs/layer-vectortile-config.json
+++ b/configure/src/metaconfigs/layer-vectortile-config.json
@@ -440,7 +440,7 @@
               "new": true,
               "field": "legend",
               "name": "Legend From URL",
-              "description": "A URL to a .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
+              "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
               "width": 12
             }

--- a/configure/src/metaconfigs/layer-velocity-config.json
+++ b/configure/src/metaconfigs/layer-velocity-config.json
@@ -370,7 +370,7 @@
               "new": true,
               "field": "legend",
               "name": "Legend From URL",
-              "description": "A URL to a .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
+              "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
               "width": 12
             }

--- a/src/essence/Basics/Formulae_/Formulae_.js
+++ b/src/essence/Basics/Formulae_/Formulae_.js
@@ -810,6 +810,11 @@ var Formulae_ = {
     },
     csvToJSON: function (csv) {
         if (csv == null) return {}
+        
+        // Ensure csv is a string
+        if (typeof csv !== 'string') {
+            return {}
+        }
 
         var lines = csv.split('\n')
         var result = []

--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -275,20 +275,27 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity) {
             .attr('class', 'legend-image-container')
             .style('display', 'flex')
             .style('justify-content', 'center')
-            .style('margin', '8px')
-            .style('padding', '8px')
-        
+            .style('margin', '4px')
+            .style('padding', '4px')
+            .style('overflow-x', 'hidden')
         imageContainer
             .append('img')
             .attr('src', _legend.startsWith('http') ? _legend : L_.missionPath + _legend)
             .attr('alt', `Legend for ${display_name}`)
-            .style('max-width', '100%')
+            .style('max-width', '300px')
             .style('max-height', '220px')
             .style('height', 'auto')
             .style('background-color', 'white')
             .style('border', '1px solid var(--color-i)')
             .style('border-radius', '3px')
             .style('opacity', opacity)
+            .on('load', function() {
+                // Set container max-width to image width (capped at 300px)
+                const maxImageWidth = Math.min(this.naturalWidth, 300)
+                imageContainer
+                    .style('max-width', maxImageWidth + 'px')
+                    .style('width', 'fit-content')
+            })
             .on('error', function() {
                 // Handle image load error
                 d3.select(this.parentNode)


### PR DESCRIPTION
## Purpose
- Use a prerendered image for the layer legend
## Proposed Changes
- Allow a URL to an image in the existing "Legend From URL" configuration field for all valid layer types
- Check if legend URL is a valid image
- Display the image from the legend URL as the layer's legend graphic
## Issues
- https://github.com/NASA-AMMOS/MMGIS/issues/658
## Testing
- Tested with legend URL pointing to a static image file: https://gibs.earthdata.nasa.gov/legends/GEDI_MU_Color_Index_V.svg 
- Tested with legend URL pointing to a GetLegendGraphic request: https://gibs.earthdata.nasa.gov/wms/epsg4326/best/?version=1.3.0&service=WMS&request=GetLegendGraphic&sld_version=1.1.0&layer=GRanD_Dams&format=image/png&STYLE=default
- Tested with existing CSV files
- Tested with using legend configuration custom entries