### PR TITLE
Add feature to set Layer header expanded state individually

### DIFF
--- a/configure/src/metaconfigs/layer-header-config.json
+++ b/configure/src/metaconfigs/layer-header-config.json
@@ -30,6 +30,14 @@
               "description": "",
               "type": "textnotrim",
               "width": 8
+            },
+            {
+              "field": "expanded",
+              "name": "Expanded",
+              "description": "Whether all child layers under the header default to being expanded (as opposed to being collapsed).",
+              "type": "checkbox",
+              "width": 2,
+              "defaultChecked": false
             }
           ]
         }

--- a/src/essence/Tools/Layers/LayersTool.css
+++ b/src/essence/Tools/Layers/LayersTool.css
@@ -138,6 +138,13 @@
 #layersTool #searchLayers > div#clear.shown {
     opacity: 1;
 }
+#layersTool #searchLayers > div#restore{
+    position: absolute;
+    right: 60px;
+    background: var(--color-a1);
+    padding-top: 1px;
+    height: 34px;
+}
 #layersTool #searchLayers > div#expand {
     position: absolute;
     right: 30px;

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -52,6 +52,7 @@ var markup = [
                 '<i class="mdi mdi-magnify mdi-18px"></i>',
                 "<input type='text' placeholder='Search Layers (# for tags)' />",
                 '<div id="clear"><i class="mdi mdi-close mdi-18px"></i></div>',
+                '<div id="restore"><i class="mdi mdi-restore mdi-18px"></i></div>',
                 '<div id="expand"><i class="mdi mdi-arrow-expand-vertical mdi-18px"></i></div>',
                 '<div id="collapse"><i class="mdi mdi-arrow-collapse-vertical mdi-18px"></i></div>',
             "</div>",
@@ -1061,7 +1062,7 @@ function interfaceWithMMGIS(fromInit) {
                     // prettier-ignore
                     $('#layersToolList').append(
                         [
-                            `<li class="layersToolHeader" id="header_${headerI}" name="${node[i].name}" type="${node[i].type}" depth="${depth}" childrenon="true" style="margin-bottom: 1px;">`,
+                            `<li class="layersToolHeader" id="header_${node[i].name}" name="${node[i].name}" type="${node[i].type}" depth="${depth}" childrenon="true" style="margin-bottom: 1px;">`,
                                 `<div class="title" id="headerstart" style="border-left: ${depth * DEPTH_SIZE}px solid ${INDENT_COLOR};">`,
                                     '<div class="layersToolColor ' + node[i].type + '">',
                                         '<i class="mdi mdi-drag-vertical mdi-12px"></i>',
@@ -1271,6 +1272,15 @@ function interfaceWithMMGIS(fromInit) {
     // Collapse header
     $('.layersToolHeader').on('click', function () {
         LayersTool.toggleHeader($(this).attr('id'))
+
+        if ($(this).attr('childrenon') === 'true') {
+            // Expand sub layer headers
+            traverseHeaderLayersExpandedState(L_.layers.data[$(this).attr('name')].sublayers, L_.layers.data[$(this).attr('name')], 0)
+        } else {
+            console.log("this", $(this))
+            // Make sure we set the childrenon attribute to false for the sub layer headers
+            traverseHeaderLayersResetChildrenon(L_.layers.data[$(this).attr('name')].sublayers, L_.layers.data[$(this).attr('name')], 0)
+        }
     })
     // Toggle between all-off and previous-on states
     // Power state switches back to on if any inner layer is toggled (done elsewhere)
@@ -1988,6 +1998,14 @@ function interfaceWithMMGIS(fromInit) {
         }
     })
 
+    $('#searchLayers > #restore').on('click', function () {
+        // Collapse all layers
+        $('#searchLayers > #collapse').click()
+
+        // Expand individual headers based on its configuration settings
+        traverseHeaderLayersExpandedState(L_.configData.layers, {}, 0)
+    })
+
     $('#filterLayers .right > div').on('click', function () {
         $(this).toggleClass('on')
         var isOn = $(this).hasClass('on')
@@ -2230,6 +2248,24 @@ function interfaceWithMMGIS(fromInit) {
     //Start collapsed
     if (LayersTool.vars.expanded !== true)
         $('#searchLayers > #collapse').click()
+
+    // Expand individual headers based on its configuration settings
+    traverseHeaderLayersExpandedState(L_.configData.layers, {}, 0)
+
+    function traverseHeaderLayersExpandedState(node, parent, depth) {
+        for (var i = 0; i < node.length; i++) {
+            if (node[i].type == 'header') {
+                if (node[i].expanded) {
+                    //if ($(`#layersToolList > li#header_${parent.name}`).attr('childrenon') === 'true') { // (parent.expanded) {
+                        LayersTool.toggleHeader(`header_${node[i].name}`)
+                    //}
+                }
+            }
+
+            if (node[i].sublayers)
+                traverseHeaderLayersExpandedState(node[i].sublayers, node[i], depth + 1)
+        }
+    }
 
     // Sublayer things
 

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -2237,11 +2237,11 @@ function interfaceWithMMGIS(fromInit) {
     })
 
     //Start collapsed
-    if (LayersTool.vars.expanded !== true)
+    if (LayersTool.vars.expanded !== true) {
         $('#searchLayers > #collapse').click()
-
-    // Expand individual headers based on its configuration settings
-    traverseHeaderLayersExpandedState(L_.configData.layers, {}, 0)
+        // Expand individual headers based on its configuration settings
+        traverseHeaderLayersExpandedState(L_.configData.layers, {}, 0)
+    }
 
     function traverseHeaderLayersExpandedState(node, parent, depth) {
         for (var i = 0; i < node.length; i++) {

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -1272,15 +1272,6 @@ function interfaceWithMMGIS(fromInit) {
     // Collapse header
     $('.layersToolHeader').on('click', function () {
         LayersTool.toggleHeader($(this).attr('id'))
-
-        if ($(this).attr('childrenon') === 'true') {
-            // Expand sub layer headers
-            traverseHeaderLayersExpandedState(L_.layers.data[$(this).attr('name')].sublayers, L_.layers.data[$(this).attr('name')], 0)
-        } else {
-            console.log("this", $(this))
-            // Make sure we set the childrenon attribute to false for the sub layer headers
-            traverseHeaderLayersResetChildrenon(L_.layers.data[$(this).attr('name')].sublayers, L_.layers.data[$(this).attr('name')], 0)
-        }
     })
     // Toggle between all-off and previous-on states
     // Power state switches back to on if any inner layer is toggled (done elsewhere)
@@ -2255,10 +2246,10 @@ function interfaceWithMMGIS(fromInit) {
     function traverseHeaderLayersExpandedState(node, parent, depth) {
         for (var i = 0; i < node.length; i++) {
             if (node[i].type == 'header') {
-                if (node[i].expanded) {
-                    //if ($(`#layersToolList > li#header_${parent.name}`).attr('childrenon') === 'true') { // (parent.expanded) {
-                        LayersTool.toggleHeader(`header_${node[i].name}`)
-                    //}
+                if ((node[i].expanded && node[i].expanded === true)
+                        || (node[i].expanded === undefined
+                            && $(`#layersToolList > li#header_${parent.name}`).attr('childrenon') === true)) {
+                    LayersTool.toggleHeader(`header_${node[i].name}`)
                 }
             }
 


### PR DESCRIPTION
This adds a feature to set the expanded/unexpanded state of each header in the Layers individually by default when opening the layers tool.
<img width="2038" height="1374" alt="Screenshot 2025-08-07 at 11 17 05 AM_" src="https://github.com/user-attachments/assets/29206374-c532-48e9-a569-d80df67a7116" />

The reset button sets all headers to its default expanded/unexpanded state from the MMGIS configuration accordingly. 
<img width="698" height="224" alt="Screenshot 2025-08-07 at 11 09 03 AM" src="https://github.com/user-attachments/assets/05dcf91d-146c-45d6-a84b-ae40585b0432" />

If the "Expanded" option for Layers is set the "Tools" configuration, opening the Layers tool has the original behavior, where all the headers start in the expanded state.
<img width="1958" height="1386" alt="Screenshot 2025-08-07 at 11 19 01 AM_" src="https://github.com/user-attachments/assets/f04af3d8-e8b9-48da-b1a7-a010a36b6f5a" />

