### PR TITLE
#729 Default configuration for live mode

### DIFF
--- a/configure/src/core/Maker.js
+++ b/configure/src/core/Maker.js
@@ -406,9 +406,10 @@ const getComponent = (
           {inlineHelp ? (
             <>
               {inner}
-              <Typography className={c.subtitle2}>
-                {com.description || ""}
-              </Typography>
+              <div
+                className={c.subtitle2}
+                dangerouslySetInnerHTML={{ __html: com.description || "" }}
+              ></div>
             </>
           ) : (
             <Tooltip title={com.description || ""} placement="top" arrow>
@@ -708,9 +709,10 @@ const getComponent = (
           {inlineHelp ? (
             <>
               {inner}
-              <Typography className={c.subtitle2}>
-                {com.description || ""}
-              </Typography>
+              <div
+                className={c.subtitle2}
+                dangerouslySetInnerHTML={{ __html: com.description || "" }}
+              ></div>
             </>
           ) : (
             <Tooltip title={com.description || ""} placement="top" arrow>

--- a/configure/src/metaconfigs/tab-coordinates-config.json
+++ b/configure/src/metaconfigs/tab-coordinates-config.json
@@ -116,9 +116,9 @@
         {
           "field": "coordinates.coordmain",
           "name": "Main Coordinate Type",
-          "description": "",
+          "description": "Sets which coordinates are shown by default in the bottom-right of the map.\n\t<strong>• LL</strong>: Longitude, Latitude\n\t<strong>• EN</strong>: Easting, Northing\n\t<strong>• CPROJ</strong>: Custom Projected (uses Projection tab)\n\t<strong>• SPROJ</strong>: Secondary Projected\n\t<strong>• RXY</strong>: Relative X, Y, (Z) in meters\n\t<strong>• SITE</strong>: Local Level Y, X, -Z",
           "type": "dropdown",
-          "width": 2,
+          "width": 4,
           "options": ["ll", "en", "cproj", "sproj", "rxy", "site"]
         }
       ]

--- a/configure/src/metaconfigs/tab-time-config.json
+++ b/configure/src/metaconfigs/tab-time-config.json
@@ -31,14 +31,6 @@
           "type": "checkbox",
           "width": 3,
           "defaultChecked": false
-        },
-        {
-          "field": "time.startInPointMode",
-          "name": "Start In Point Mode",
-          "description": "The Time UI begins in the Range Mode and allows users to bound by start and end times. Point Mode has users only control the end time and has start time implied by negative infinity.",
-          "type": "checkbox",
-          "width": 3,
-          "defaultChecked": false
         }
       ]
     },
@@ -50,7 +42,23 @@
           "name": "Time Format",
           "description": "The time format to be displayed on the Time UI. Uses D3 time format specifiers: <a target='_blank' href='https://github.com/d3/d3-time-format'>https://github.com/d3/d3-time-format</a>. Default: %Y-%m-%dT%H:%M:%SZ",
           "type": "text",
-          "width": 12
+          "width": 6
+        },
+        {
+          "field": "time.liveByDefault",
+          "name": "Live Mode On By Default",
+          "description": "If enabled, the Time UI will start in Live (Present) mode.",
+          "type": "checkbox",
+          "width": 3,
+          "defaultChecked": false
+        },
+        {
+          "field": "time.startInPointMode",
+          "name": "Start In Point Mode",
+          "description": "The Time UI begins in the Range Mode and allows users to bound by start and end times. Point Mode has users only control the end time and has start time implied by negative infinity.",
+          "type": "checkbox",
+          "width": 3,
+          "defaultChecked": false
         }
       ]
     },

--- a/src/essence/Ancillary/Coordinates.js
+++ b/src/essence/Ancillary/Coordinates.js
@@ -124,7 +124,11 @@ const Coordinates = {
             !(
                 L_.configData.time &&
                 L_.configData.time.enabled === true &&
-                L_.configData.time.visible === true
+                (
+                    L_.configData.time.visible === true ||
+                    L_.configData.time.liveByDefault === true ||
+                    L_.FUTURES.live === true
+                )
             )
         ) {
             $('#toggleTimeUI').css({ display: 'none' })
@@ -275,8 +279,13 @@ const Coordinates = {
         if (
             L_.configData.time &&
             L_.configData.time.enabled === true &&
-            L_.configData.time.visible === true &&
-            L_.configData.time.initiallyOpen === true
+            (
+                L_.FUTURES.live === true ||
+                (L_.FUTURES.live == null && (
+                    L_.configData.time.initiallyOpen === true ||
+                    L_.configData.time.liveByDefault === true
+                ))
+            )
         ) {
             toggleTimeUI()
         }

--- a/src/essence/Ancillary/QueryURL.js
+++ b/src/essence/Ancillary/QueryURL.js
@@ -37,6 +37,7 @@ var QueryURL = {
 
         var startTime = this.getSingleQueryVariable('startTime')
         var endTime = this.getSingleQueryVariable('endTime')
+        var live = this.getSingleQueryVariable('live')
 
         if (urlSite !== false) {
             L_.FUTURES.site = urlSite
@@ -174,6 +175,11 @@ var QueryURL = {
             } else {
                 console.warn('Invalid endTime from deep link in the url')
             }
+        }
+
+        if (live !== false) {
+            const liveStr = (live + '').toLowerCase()
+            L_.FUTURES.live = liveStr === 'true' || liveStr === '1'
         }
 
         if (layersOn !== false || selected !== false) {
@@ -400,6 +406,8 @@ var QueryURL = {
                     urlAppendage += '&startTime=' + TimeControl.startTime
             if (TimeControl.endTime)
                 urlAppendage += '&endTime=' + TimeControl.endTime
+            if (TimeControl.timeUI && typeof TimeControl.timeUI.now === 'boolean')
+                urlAppendage += '&live=' + (TimeControl.timeUI.now ? '1' : '0')
         }
 
         var url = encodeURI(urlAppendage)

--- a/src/essence/Ancillary/TimeUI.css
+++ b/src/essence/Ancillary/TimeUI.css
@@ -179,10 +179,7 @@
     text-transform: capitalize;
     color: var(--color-a5);
 }
-#mmgisTimeUIStartWrapper {
-}
-#mmgisTimeUIEndWrapper {
-}
+/* Start/End wrappers intentionally left for future styling hooks */
 #mmgisTimeUIActionsLeft,
 #mmgisTimeUIActionsRight {
     background: var(--color-a);
@@ -296,6 +293,28 @@
     transition: color 0.2s ease-out;
 }
 
+/* Live (Present) progress indicator */
+#mmgisTimeUIPresent {
+    position: relative;
+    overflow: hidden;
+    margin: 3px;
+    width: 34px;
+    height: 34px;
+}
+#mmgisTimeUIPresentProgress {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    height: 3px;
+    width: 0;
+    background: #dcc565;
+    opacity: 0;
+    transition: width var(--live-duration, 1000ms) linear;
+}
+#mmgisTimeUIPresent.live #mmgisTimeUIPresentProgress {
+    opacity: 0.9;
+}
+
 #mmgisTimeUIFitTime:hover,
 #mmgisTimeUIFitWindow:hover,
 #mmgisTimeUIPresent:hover {
@@ -385,4 +404,13 @@
     background: rgb(96, 78, 26, 0.7);
     transition: opacity 0.2s ease-out;
     z-index: -1;
+}
+
+/* Subtle tick flash on Live update (title text) */
+#mmgisTimeUIEndWrapper > span.flash {
+    animation: mmgis-time-text-flash 0.35s ease-out;
+}
+@keyframes mmgis-time-text-flash {
+    0% { color: var(--color-p4); }
+    100% { color: var(--color-h); }
 }

--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -3200,7 +3200,7 @@ const L_ = {
             layerConfig.type === 'vector' &&
             layerConfig.time.type === 'local' &&
             layerConfig.time.endProp != null &&
-            layer != false &&
+            layer != false && layer != null &&
             layer._sourceGeoJSON != null
         ) {
             const filteredGeoJSON = JSON.parse(


### PR DESCRIPTION
Closes #729 

_With GPT-5_

### PR Summary: Time UI Live Mode defaults, deep-linking, and UX improvements

- Implemented admin-configurable default for Live mode
  - Added `time.liveByDefault` checkbox in `configure/src/metaconfigs/tab-time-config.json` under “Settings.”
  - When `time.enabled` and Live is defaulted or deeplinked, the Time UI is forced Visible and opens Initially on load.

- Deep link support for Live mode
  - Link creation now appends `&live=1|0` to capture Present/Live state.
  - URL parsing reads `live` into `L_.FUTURES.live`, which overrides configuration on navigation.

- Time UI UX improvements for Live mode
  - Present button now includes a progress indicator aligned precisely to the live tick:
    - Removed looping keyframe animation; replaced with a duration-based width transition driven by the actual update callback, ensuring 100% completion coincides with the live reload.
    - Changing the “Every” rate (mmgisTimeUIRateDropdown) updates and restarts the progress animation immediately.
  - When Live is enabled, “Active Time” label changes to “Live Time.”
  - On each live update, the “Live Time” label briefly flashes to indicate a successful tick.
  - Live vs Playback interlocks maintained (Present turns off playback as before).

- Visibility/Initial Open rules when Live is defaulted
  - `#toggleTimeUI` is shown even if `time.visible` is false when `liveByDefault` or deeplink `live=true` is set.
  - Time UI auto-opens when `live=true` (deeplink), else falls back to `initiallyOpen` or `liveByDefault`.

- Configure UI rendering improvement
  - Dropdown descriptions now support HTML in inline-help mode (matches text fields), enabling structured/bulleted guidance where necessary.

- Coordinates tab minor copy improvement
  - Clarified the “Main Coordinate Type” description with a capitalized, bulleted list and increased width for readability.

### Files touched (high-level)
- Time config and behavior: `configure/src/metaconfigs/tab-time-config.json`, `src/essence/Ancillary/TimeUI.js`, `src/essence/Ancillary/TimeUI.css`, `src/essence/Ancillary/TimeControl.js` (indirect), `src/essence/Ancillary/Coordinates.js`
- Deep linking: `src/essence/Ancillary/QueryURL.js`
- Configure UI (Maker): `configure/src/core/Maker.js`
- Coordinates description: `configure/src/metaconfigs/tab-coordinates-config.json`

### Notes on compatibility and defaults
- Default behavior remains unchanged unless admins enable `time.liveByDefault` or a deeplink provides `live=...`.
- Deeplinks now preserve and reproduce Live state; existing links without `live` continue to work.

### Testing
- Verified:
  - `liveByDefault=true` forces UI visible/open and enables Present mode on load.
  - `Copy Link` includes `live` and navigating to that link sets Present mode accordingly.
  - Progress bar timing completes exactly as the label flashes and the end time updates.
  - Rate changes re-time the animation and tick.
  - Dropdown descriptions correctly render HTML in inline-help mode.