### PR TITLE
#731 Projection Tab Autocomplete, Case Insensitive Mission Sorting, S…

### DIFF
--- a/API/Backend/Config/routes/configs.js
+++ b/API/Backend/Config/routes/configs.js
@@ -596,7 +596,7 @@ router.get("/missions", function (req, res, next) {
         let allMissions = [];
         for (let i = 0; i < missions.length; i++)
           allMissions.push(missions[i].DISTINCT);
-        allMissions.sort();
+        allMissions.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
         res.send({ status: "success", missions: allMissions });
         return null;
       })

--- a/configure/src/core/Configure.js
+++ b/configure/src/core/Configure.js
@@ -36,7 +36,10 @@ export default function Configure() {
       "missions",
       null,
       (res) => {
-        dispatch(setMissions(res.missions));
+        const missions = (res?.missions || [])
+          .slice()
+          .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
+        dispatch(setMissions(missions));
       },
       (res) => {
         dispatch(

--- a/configure/src/metaconfigs/tab-coordinates-config.json
+++ b/configure/src/metaconfigs/tab-coordinates-config.json
@@ -21,6 +21,7 @@
           "name": "EPSG Code",
           "description": "An EPSG (or similar) code representing the spatial reference system. See <a target='_blank' href='https://spatialreference.org/ref/epsg/'>https://spatialreference.org/ref/epsg/</a> for examples. For instance: 'IAU2000:30120'",
           "type": "text",
+          "disableSwitch": "projection.custom",
           "width": 2
         },
 
@@ -29,18 +30,8 @@
           "name": "Proj4 (v2.3.14) String",
           "description": "A Proj4 String that defines the projection. See <a target='_blank' href='https://proj.org/en/9.4/operations/projections/index.html'>https://proj.org/en/9.4/operations/projections/index.html</a> for examples. Here is an example value of a lunar south-pole stereographic proj4 string: '+proj=stere +lat_0=-90 +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs'",
           "type": "text",
+          "disableSwitch": "projection.custom",
           "width": 10
-        }
-      ]
-    },
-    {
-      "components": [
-        {
-          "field": "projection.xmlpath",
-          "name": "Path to Basemap tilemapresource.xml",
-          "description": "Set the path to the tilemapresource.xml that was created with the base (and global) tileset. Used only to help auto-populate the remaining projection values below.",
-          "type": "text",
-          "width": 12
         }
       ]
     },
@@ -51,6 +42,7 @@
           "name": "Bounds Min X",
           "description": "Minimum easting value of the projection's spatial extent as stated by the base global tilemapresource.xml.",
           "type": "number",
+          "disableSwitch": "projection.custom",
           "width": 3
         },
         {
@@ -58,6 +50,7 @@
           "name": "Bounds Min Y",
           "description": "Minimum northing value of the projection's spatial extent as stated by the base global tilemapresource.xml.",
           "type": "number",
+          "disableSwitch": "projection.custom",
           "width": 3
         },
         {
@@ -65,6 +58,7 @@
           "name": "Bounds Max X",
           "description": "Maximum easting value of the projection's spatial extent as stated by the base global tilemapresource.xml.",
           "type": "number",
+          "disableSwitch": "projection.custom",
           "width": 3
         },
         {
@@ -72,6 +66,7 @@
           "name": "Bounds Max Y",
           "description": "Maximum northing value of the projection's spatial extent as stated by the base global tilemapresource.xml.",
           "type": "number",
+          "disableSwitch": "projection.custom",
           "width": 3
         }
       ]
@@ -83,6 +78,7 @@
           "name": "Origin X",
           "description": "Origin easting of the projection",
           "type": "number",
+          "disableSwitch": "projection.custom",
           "width": 3
         },
         {
@@ -90,6 +86,7 @@
           "name": "Origin Y",
           "description": "Origin northing of the projection",
           "type": "number",
+          "disableSwitch": "projection.custom",
           "width": 3
         },
         {
@@ -98,6 +95,7 @@
           "description": "A zoom level from the tilemapresource.xml to combine with the following units-per-pixel. Most often this can be set to a zoom level of '0'.",
           "type": "number",
           "min": 0,
+          "disableSwitch": "projection.custom",
           "width": 3
         },
         {
@@ -105,7 +103,29 @@
           "name": "... the units per pixel are",
           "description": "Based on the zoom level defined before and the tilemapresource.xml, the respective units-per-pixel to set the scaling of the projection.",
           "type": "number",
+          "disableSwitch": "projection.custom",
           "width": 3
+        }
+      ]
+    },
+    {
+      "section": "Actions",
+      "components": [
+        {
+          "field": "projection.xmlpath",
+          "name": "Path to Basemap tilemapresource.xml or ArcGIS MapServer",
+          "description": "Set the path to the tilemapresource.xml that was created with the base (and global) tileset or ArcGIS MapServer endpoint with ?f=pjson (e.g., services.arcgisonline.com/arcgis/rest/services/.../MapServer?f=pjson).. Used only to help auto-populate some projection values above.",
+          "type": "text",
+          "disableSwitch": "projection.custom",
+          "width": 8
+        },
+        {
+          "name": "Auto-Populate Projection Fields From tilemapresource.xml or ArcGIS MapServer",
+          "description": "Reads the file set above and auto-fills Bounds, Origin, and Resolution fields. Supports a local/relative tilemapresource.xml, or an ArcGIS MapServer endpoint with ?f=pjson (e.g., services.arcgisonline.com/arcgis/rest/services/.../MapServer?f=pjson).",
+          "type": "button",
+          "action": "projection-populate-from-x",
+          "disableSwitch": "projection.custom",
+          "width": 4
         }
       ]
     },
@@ -139,6 +159,7 @@
           "name": "Longitude Display Offset",
           "description": "",
           "type": "number",
+          "disableSwitch": "coordinates.coordll",
           "width": 3
         },
         {
@@ -146,6 +167,7 @@
           "name": "Latitude Display Offset",
           "description": "",
           "type": "number",
+          "disableSwitch": "coordinates.coordll",
           "width": 3
         }
       ]
@@ -166,6 +188,7 @@
           "name": "Easting Display Offset",
           "description": "",
           "type": "number",
+          "disableSwitch": "coordinates.coorden",
           "width": 3
         },
         {
@@ -173,6 +196,7 @@
           "name": "Northing Display Offset",
           "description": "",
           "type": "number",
+          "disableSwitch": "coordinates.coorden",
           "width": 3
         },
         {
@@ -180,6 +204,7 @@
           "name": "Easting Display Multiplier",
           "description": "",
           "type": "number",
+          "disableSwitch": "coordinates.coorden",
           "width": 2
         },
         {
@@ -187,6 +212,7 @@
           "name": "Northing Display Multiplier",
           "description": "",
           "type": "number",
+          "disableSwitch": "coordinates.coorden",
           "width": 2
         }
       ]
@@ -207,6 +233,7 @@
           "name": "Display Name",
           "description": "Optionally set a Display Name to aid users in identifying the projection.",
           "type": "text",
+          "disableSwitch": "coordinates.coordcustomproj",
           "width": 4
         },
         {
@@ -214,6 +241,7 @@
           "name": "X Coordinate Label",
           "description": "",
           "type": "text",
+          "disableSwitch": "coordinates.coordcustomproj",
           "width": 2
         },
         {
@@ -221,6 +249,7 @@
           "name": "Y Coordinate Label",
           "description": "",
           "type": "text",
+          "disableSwitch": "coordinates.coordcustomproj",
           "width": 2
         },
         {
@@ -228,6 +257,7 @@
           "name": "Z Coordinate Label",
           "description": "",
           "type": "text",
+          "disableSwitch": "coordinates.coordcustomproj",
           "width": 2
         }
       ]
@@ -248,6 +278,7 @@
           "name": "Display Name",
           "description": "Optionally set a Display Name to aid users in identifying the projection.",
           "type": "text",
+          "disableSwitch": "coordinates.coordsecondaryproj",
           "width": 4
         },
         {
@@ -255,6 +286,7 @@
           "name": "X Coordinate Label",
           "description": "",
           "type": "text",
+          "disableSwitch": "coordinates.coordsecondaryproj",
           "width": 2
         },
         {
@@ -262,6 +294,7 @@
           "name": "Y Coordinate Label",
           "description": "",
           "type": "text",
+          "disableSwitch": "coordinates.coordsecondaryproj",
           "width": 2
         },
         {
@@ -269,6 +302,7 @@
           "name": "Z Coordinate Label",
           "description": "",
           "type": "text",
+          "disableSwitch": "coordinates.coordsecondaryproj",
           "width": 2
         }
       ]
@@ -327,6 +361,7 @@
           "name": "DEM URL",
           "description": "The path to the mission's base DEM to query elevation values off of.",
           "type": "text",
+          "disableSwitch": "coordinates.coordelev",
           "width": 10
         }
       ]

--- a/configure/src/metaconfigs/tab-time-config.json
+++ b/configure/src/metaconfigs/tab-time-config.json
@@ -22,6 +22,7 @@
           "description": "Whether or not the Time user interface should be visible. This allows time to be enabled while restricting users from using its UI.",
           "type": "checkbox",
           "width": 3,
+          "disableSwitch": "time.enabled",
           "defaultChecked": true
         },
         {
@@ -30,6 +31,7 @@
           "description": "If enabled and visible, the Time UI will be initially open on the bottom of the screen.",
           "type": "checkbox",
           "width": 3,
+          "disableSwitch": "time.enabled",
           "defaultChecked": false
         }
       ]
@@ -42,6 +44,7 @@
           "name": "Time Format",
           "description": "The time format to be displayed on the Time UI. Uses D3 time format specifiers: <a target='_blank' href='https://github.com/d3/d3-time-format'>https://github.com/d3/d3-time-format</a>. Default: %Y-%m-%dT%H:%M:%SZ",
           "type": "text",
+          "disableSwitch": "time.enabled",
           "width": 6
         },
         {
@@ -50,6 +53,7 @@
           "description": "If enabled, the Time UI will start in Live (Present) mode.",
           "type": "checkbox",
           "width": 3,
+          "disableSwitch": "time.enabled",
           "defaultChecked": false
         },
         {
@@ -58,6 +62,7 @@
           "description": "The Time UI begins in the Range Mode and allows users to bound by start and end times. Point Mode has users only control the end time and has start time implied by negative infinity.",
           "type": "checkbox",
           "width": 3,
+          "disableSwitch": "time.enabled",
           "defaultChecked": false
         }
       ]
@@ -69,6 +74,7 @@
           "name": "Initial Start Time",
           "description": "The initial start time. It should be before the Initial End Time and it can be made relative by appending ' {+/-} {seconds}' - for instance: '2024-03-04T14:05:00Z + 864000'. Default: 1 month before Initial End Time",
           "type": "text",
+          "disableSwitch": "time.enabled",
           "width": 6
         },
         {
@@ -76,6 +82,7 @@
           "name": "Initial End Time",
           "description": "The initial end time. It should be after the Initial Start Time. You can use 'now' to have the end time be the present and you can make it relative by appending ' {+/-} {seconds}' - for instance: '2024-03-04T14:05:00Z + 864000'. Default: now",
           "type": "text",
+          "disableSwitch": "time.enabled",
           "width": 6
         }
       ]
@@ -87,6 +94,7 @@
           "name": "Initial Timeline Window Start Time",
           "description": "This does not control the time range for queries. This only allows the initial time window of the time line to differ from just being the Start Time to the End Time. A use-case for this would be to set the window times to fit the full extent of the temporal data but only set the Initial Start and End Times as a subset of that so as not to query everything on load. Can be made relative by appending ' {+/-} {seconds}' - for instance: '2024-03-04T14:05:00Z + 864000'. Default: Initial Start Time",
           "type": "text",
+          "disableSwitch": "time.enabled",
           "width": 6
         },
         {
@@ -94,6 +102,7 @@
           "name": "Initial Timeline Window End Time",
           "description": "This does not control the time range for queries. This only allows the initial time window of the time line to differ from just being the Start Time to the End Time. Should be after Initial Window End Time Use now to have the end time be the present. Can be made relative by appending ' {+/-} {seconds}' - for instance: '2024-03-04T14:05:00Z + 864000'. Default: Initial End Time",
           "type": "text",
+          "disableSwitch": "time.enabled",
           "width": 6
         }
       ]

--- a/configure/src/metaconfigs/tab-ui-config.json
+++ b/configure/src/metaconfigs/tab-ui-config.json
@@ -125,6 +125,7 @@
           "name": "DEM Fallback URL",
           "description": "A URL to an underlying and ever-present DEM terrain tileset to fill in any missing elevation tiles of active layers.",
           "type": "text",
+          "disableSwitch": "panels.globe",
           "width": 8
         },
         {
@@ -132,6 +133,7 @@
           "name": "DEM Fallback Format",
           "description": "",
           "type": "dropdown",
+          "disableSwitch": "panels.globe",
           "width": 2,
           "options": ["tms", "wmts", "wms"]
         },

--- a/configure/src/pages/Users/Modals/UpdateUserModal/UpdateUserModal.js
+++ b/configure/src/pages/Users/Modals/UpdateUserModal/UpdateUserModal.js
@@ -191,7 +191,10 @@ const UpdateUserModal = (props) => {
         {},
         (res) => {
           if (res?.missions) {
-            setAvailableMissions(res.missions);
+            const missions = res.missions
+              .slice()
+              .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
+            setAvailableMissions(missions);
           }
         },
         (res) => {

--- a/src/App.js
+++ b/src/App.js
@@ -67,7 +67,10 @@ function initApp() {
             'missions',
             {},
             function (s) {
-                continueOn(s.missions)
+                const missions = (s.missions || [])
+                    .slice()
+                    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+                continueOn(missions)
             },
             function (e) {
                 continueOn([])


### PR DESCRIPTION
…mart field dsiabling in /configure

Closes #731 

_With GPT-5_

### PR summary

- **Projection auto-populate for Coordinates tab**
  - Added a new action/button to `tab-coordinates-config.json`: “Auto-Populate Projection Fields From tilemapresource.xml or ArcGIS MapServer”.
  - Implemented handler in `Maker.js`:
    - Parses local/relative `tilemapresource.xml` (BoundingBox, Origin, TileSet order/units-per-pixel).
    - Parses ArcGIS MapServer `?f=pjson` for `fullExtent/initialExtent`, `tileInfo.origin`, `tileInfo.lods` (prefers level 0) [ArcGIS MapServer pjson](https://services.arcgisonline.com/arcgis/rest/services/Polar/Arctic_Ocean_Base/MapServer?f=pjson).
    - Updates: `projection.bounds`, `projection.origin`, `projection.reszoomlevel`, `projection.resunitsperpixel`.
    - Shows success/error snackbars.

- **Make “Custom Projection” state obvious in UI (disable while off)**
  - Introduced a generic `disableSwitch` meta key for any component in metaconfigs:
    - If set (e.g., `"disableSwitch": "projection.custom"`), the component is disabled and greyed out unless the referenced boolean is true.
  - Applied to these Coordinates tab fields and button:
    - `projection.epsg`, `projection.proj`, `projection.bounds.[0-3]`, `projection.origin.[0-1]`, `projection.reszoomlevel`, `projection.resunitsperpixel`, `projection.xmlpath`, and the `projection-populate-from-x` button.
  - Renderer behavior:
    - Honors the current config value of the referenced switch.
    - If unset, falls back to the switch’s `defaultChecked` in the same row (fixes cases like `coordinates.coordll`).

- **Case-insensitive mission sorting (Configure + Landing)**
  - Frontend:
    - `configure/src/core/Configure.js`: Sort missions via `localeCompare(..., { sensitivity: 'base' })` before storing.
    - `src/App.js`: Sort missions case-insensitively before passing to `LandingPage.init`.
    - `configure/src/pages/Users/Modals/UpdateUserModal/UpdateUserModal.js`: Sort available missions in the multiselect.
  - Backend:
    - `API/Backend/Config/routes/configs.js`: Returns missions sorted case-insensitively.

### Files changed (high-level)
- `configure/src/core/Maker.js`: New `projectionPopulateFromX`, button action wiring, generic `disableSwitch` support across component types, fallback to `defaultChecked`.
- `configure/src/metaconfigs/tab-coordinates-config.json`: New button for auto-populate; `disableSwitch` on all projection inputs and action; minor copy update for `xmlpath`.
- `configure/src/core/Configure.js`, `src/App.js`, `configure/src/pages/Users/Modals/UpdateUserModal/UpdateUserModal.js`: Case-insensitive sorting on missions.
- `API/Backend/Config/routes/configs.js`: Case-insensitive sorting on missions response.

### How to test
- Configure → Coordinates:
  - With `projection.custom` OFF, verify all projection fields and the auto-populate button are disabled.
  - Toggle ON; verify fields/buttons enable.
  - Enter a valid `tilemapresource.xml` path and click auto-populate → fields fill and success snackbar appears.
  - Enter a valid ArcGIS MapServer URL with `?f=pjson` and click auto-populate → fields fill as above.
- Configure sidebar:
  - Missions list appears A–Z regardless of case.
- Landing page:
  - Missions appear A–Z regardless of case.
- Users → Update User modal:
  - Assigned Missions multiselect options appear A–Z regardless of case.

### Compatibility and docs
- Backward compatible. `disableSwitch` is optional and non-breaking.
- Consider adding a brief note to the metaconfig authoring docs about the new `"disableSwitch": "<boolean field path>"` behavior.

### Security/other
- Only reads local mission-relative XML when provided; ArcGIS JSON fetched from explicit URL. No new write endpoints added.
