### PR TITLE
Include amd64 Docker image suffix and build it last

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -110,29 +110,6 @@ jobs:
           echo "REGISTRY_TAGS_PR_NUMBER=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_OUTPUT
 
-  # Build and push AMD64 image on x64 runner
-  build-amd64:
-    needs: generate-tags
-    runs-on: ubuntu-latest  # x64 runner for native AMD64 builds
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GHCR
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.actor }} --password-stdin ghcr.io
-
-      - name: Docker buildx build and push (AMD64)
-        run: |
-          docker buildx build \
-            --platform linux/amd64 \
-            ${{ needs.generate-tags.outputs.registry-tags }} \
-            --push \
-            --no-cache \
-            .
-
   # Build and push ARM64 image on ARM64 runner
   build-arm64:
     needs: generate-tags
@@ -142,10 +119,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
       - name: Login to GHCR
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.actor }} --password-stdin ghcr.io
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker buildx build and push (ARM64)
         run: |
@@ -154,6 +135,35 @@ jobs:
           docker buildx build \
             --platform linux/arm64 \
             ${ARM64_TAGS} \
+            --push \
+            --no-cache \
+            .
+
+  # Build and push AMD64 image on x64 runner
+  build-amd64:
+    needs: [generate-tags, build-arm64] # Build amd64 last so that it shows as the latest
+    runs-on: ubuntu-latest  # x64 runner for native AMD64 builds
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+
+      - name: Login to GHCR
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker buildx build and push (AMD64)
+        run: |
+          # Generate AMD64-specific tags by adding -amd64 suffix
+          AMD64_TAGS="${{ needs.generate-tags.outputs.registry-tags }}-amd64"
+          docker buildx build \
+            --platform linux/amd64 \
+            ${AMD64_TAGS} \
             --push \
             --no-cache \
             .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -118,9 +118,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
-
       - name: Login to GHCR
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:
@@ -132,8 +129,7 @@ jobs:
         run: |
           # Generate ARM64-specific tags by adding -arm64 suffix
           ARM64_TAGS="${{ needs.generate-tags.outputs.registry-tags }}-arm64"
-          docker buildx build \
-            --platform linux/arm64 \
+          docker build \
             ${ARM64_TAGS} \
             --push \
             --no-cache \
@@ -147,9 +143,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
-
       - name: Login to GHCR
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:
@@ -161,8 +154,7 @@ jobs:
         run: |
           # Generate AMD64-specific tags by adding -amd64 suffix
           AMD64_TAGS="${{ needs.generate-tags.outputs.registry-tags }}-amd64"
-          docker buildx build \
-            --platform linux/amd64 \
+          docker build \
             ${AMD64_TAGS} \
             --push \
             --no-cache \


### PR DESCRIPTION
## Purpose
- Include amd64 Docker image suffix and build it last so that it takes precedent over arm64.
- Remove extraneous image tags and unknown OS when building Docker images with GitHub Actions.
## Proposed Changes
- Add -amd64 to the end of "default" Docker image names
- Build amd64 after arm64 to ensure it's the latest
- Revert to using Docker build instead of buildx to prevent extraneous image tags
## Issues
- #652 
## Testing
- Testing builds with PR