### PR TITLE
Filter out blank csv entries in csvToJSON function

### DIFF
--- a/src/essence/Basics/Formulae_/Formulae_.js
+++ b/src/essence/Basics/Formulae_/Formulae_.js
@@ -817,6 +817,8 @@ var Formulae_ = {
         }
 
         var lines = csv.split('\n')
+        lines = lines.filter(i => i.length > 0)
+
         var result = []
 
         if (lines == null || lines[0] == null) return {}


### PR DESCRIPTION
It seems it's possible to read a csv file and get a blank entry at the end. We should probably filter those out.

<img width="300" height="948" alt="Screenshot 2025-08-25 at 1 44 46 PM" src="https://github.com/user-attachments/assets/1fcfff27-c9ec-4793-93af-0e4c9ab9133c" />
