### PR TITLE
#738 Fix GeoDataset LOCAL

### DIFF
--- a/src/essence/Basics/Layers_/LayerCapturer.js
+++ b/src/essence/Basics/Layers_/LayerCapturer.js
@@ -115,7 +115,7 @@ export const captureVector = (layerObj, options, cb, dynamicCb) => {
                                     : null,
                         }
 
-                        if (layerData.time?.enabled === true) {
+                        if (layerData.time?.enabled === true && layerData.time?.type === 'requery') {
                             body.starttime = layerData.time.start
                             body.startProp = layerData.time.startProp
                             body.endtime = layerData.time.end
@@ -257,7 +257,7 @@ export const captureVector = (layerObj, options, cb, dynamicCb) => {
                             zoom: zoom,
                         }
 
-                        if (layerData.time?.enabled === true) {
+                        if (layerData.time?.enabled === true && layerData.time?.type === 'requery') {
                             body.starttime = layerData.time.start
                             body.startProp = layerData.time.startProp
                             body.endtime = layerData.time.end
@@ -400,7 +400,7 @@ export const captureVector = (layerObj, options, cb, dynamicCb) => {
                     layer: urlSplitRaw[1],
                     type: 'geojson',
                 }
-                if (layerData.time?.enabled === true) {
+                if (layerData.time?.enabled === true && layerData.time?.type === 'requery') {
                     body.starttime = layerData.time.start
                     body.endtime = layerData.time.end
                 }


### PR DESCRIPTION
Closes #738 

_With Claude 3.5 Sonnet Bedrock_

This PR fixes an issue where geodataset layers configured with time.type = "local" were incorrectly sending time
  parameters (starttime, endtime, startProp, endProp) to the backend API. According to the MMGIS time filtering
  design:

  - REQUERY time-type layers should send time parameters for server-side filtering
  - LOCAL time-type layers should receive unfiltered data and perform time filtering client-side

  The bug caused LOCAL time-type geodataset layers to be filtered server-side, preventing the client from accessing     
  the full dataset needed for local time filtering.

  Changes

  - Modified LayerCapturer.js to check both time.enabled AND time.type === 'requery' before adding time parameters      
  to geodataset API requests
  - Applied this fix in all three locations where geodataset queries are constructed:
    - Dynamic geodataset queries (lines 118 and 260)
    - Static geodataset queries (line 403)

  Impact

  - REQUERY layers: No change - continue to work as expected with server-side time filtering
  - LOCAL layers: Now correctly receive unfiltered geodatasets, enabling proper client-side time filtering
  - No breaking changes to existing functionality

  Test Plan

  - Test REQUERY time-type geodataset layers still filter correctly on the server
  - Test LOCAL time-type geodataset layers now receive full unfiltered data
  - Verify time controls work properly for both time types
  - Confirm no regression in non-time-enabled geodataset layers

  Fixes #738