### PR TITLE
#740 Add mission planet radii

### DIFF
--- a/configure/src/components/Panel/Modals/NewMissionModal/NewMissionModal.js
+++ b/configure/src/components/Panel/Modals/NewMissionModal/NewMissionModal.js
@@ -24,6 +24,10 @@ import TextField from "@mui/material/TextField";
 import FormGroup from "@mui/material/FormGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Checkbox from "@mui/material/Checkbox";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
 
 import { makeStyles, useTheme } from "@mui/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
@@ -94,7 +98,17 @@ const useStyles = makeStyles((theme) => ({
   backgroundIcon: {
     margin: "7px 8px 0px 0px",
   },
+  planetDropdown: {
+    width: "100%",
+    margin: "8px 0px 4px 0px !important",
+  },
 }));
+
+const PLANET_RADII = {
+  Earth: { major: 6371008, minor: 6371008 },
+  Mars: { major: 3396190, minor: 3396190 },
+  "The Moon": { major: 1737400, minor: 1737400 },
+};
 
 const MODAL_NAME = "newMission";
 const NewMissionModal = (props) => {
@@ -110,6 +124,7 @@ const NewMissionModal = (props) => {
 
   const [missionName, setMissionName] = useState("");
   const [createDir, setCreateDir] = useState(true);
+  const [selectedPlanet, setSelectedPlanet] = useState("Earth");
 
   const handleClose = () => {
     // close modal
@@ -126,11 +141,24 @@ const NewMissionModal = (props) => {
       return;
     }
 
+    const planetRadius = PLANET_RADII[selectedPlanet];
+    
+    // Build the config with just the radius values
+    const config = {
+      msv: {
+        radius: {
+          major: planetRadius.major,
+          minor: planetRadius.minor,
+        },
+      },
+    };
+
     calls.api(
       "add",
       {
         mission: missionName,
         makedir: createDir,
+        config: config,
       },
       (res) => {
         calls.api(
@@ -150,6 +178,7 @@ const NewMissionModal = (props) => {
             // reset fields
             setMissionName("");
             setCreateDir(true);
+            setSelectedPlanet("Earth");
 
             // and then close
             handleClose();
@@ -165,6 +194,7 @@ const NewMissionModal = (props) => {
             // reset fields
             setMissionName("");
             setCreateDir(true);
+            setSelectedPlanet("Earth");
 
             // and then close
             handleClose();
@@ -224,6 +254,21 @@ const NewMissionModal = (props) => {
         />
         <Typography className={c.subtitle2}>
           {`A new and unique name for a mission. No special characters allowed and it should not start with a number.`}
+        </Typography>
+        <FormControl className={c.planetDropdown} variant="filled">
+          <InputLabel>Planet</InputLabel>
+          <Select
+            value={selectedPlanet}
+            onChange={(e) => setSelectedPlanet(e.target.value)}
+            label="Planet"
+          >
+            <MenuItem value="Earth">Earth</MenuItem>
+            <MenuItem value="Mars">Mars</MenuItem>
+            <MenuItem value="The Moon">The Moon</MenuItem>
+          </Select>
+        </FormControl>
+        <Typography className={c.subtitle2}>
+          {`Select the planet to set the default radius values for this mission. You can always change this later.`}
         </Typography>
         <FormGroup>
           <FormControlLabel


### PR DESCRIPTION
Closes #740 

(Code formatter introduced extra changes)

_With Claude 3.5 Sonnet Bedrock_

Adds a planet selection dropdown to the Configure page's "New Mission" modal, allowing      
  users to automatically set appropriate planet radius values when creating new missions.

  Changes Made

  Frontend (configure/src/components/Panel/Modals/NewMissionModal/NewMissionModal.js)

  - Added MUI Select components for planet dropdown
  - Added planet configuration with radius values for Earth, Mars, and The Moon
  - Implemented planet selection state that defaults to "Earth"
  - Updated mission creation API call to include radius configuration
  - Added UI dropdown between Mission Name and Create Directory checkbox

  Backend (API/Backend/Config/routes/configs.js)

  - Fixed config merging: Modified the add function to use deepmerge when a config is provided,       
  ensuring custom radius values are properly merged with the default template
  - Fixed makedir bug: Updated directory creation check to accept both boolean and string "true"      
  values, fixing an issue where directories weren't being created

  Technical Details

  - Planet radius values are stored as numbers (not strings) for cleaner code
  - Backward compatibility is maintained as MMGIS already handles both number and string radius       
  values
  - The config template structure is preserved with only radius values being overridden

  Testing

  The implementation properly:
  - Sets Earth radius to 6371008 meters
  - Sets Mars radius to 3396190 meters
  - Sets Moon radius to 1737400 meters
  - Creates mission directories when requested
  - Maintains all other default configuration values