### PR TITLE
#745 Live Follow Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,7 @@ sessions
 docker-compose.yml
 docker-compose.env.yml
 
+.mcp.json
+.serena
+.claude
 #tools

--- a/src/css/mmgisUI.css
+++ b/src/css/mmgisUI.css
@@ -1619,7 +1619,7 @@ input::-webkit-inner-spin-button {
 }
 #toast-container {
     position: fixed !important;
-    bottom: 40px !important;
+    bottom: 80px !important;
     right: 5px !important;
     z-index: 1001 !important;
 }

--- a/src/essence/Ancillary/QueryURL.js
+++ b/src/essence/Ancillary/QueryURL.js
@@ -5,6 +5,7 @@ import L_ from '../Basics/Layers_/Layers_'
 import T_ from '../Basics/ToolController_/ToolController_'
 import calls from '../../pre/calls'
 import TimeControl from './TimeControl'
+import TimeUI from './TimeUI'
 
 var QueryURL = {
     checkIfMission: function () {
@@ -38,6 +39,7 @@ var QueryURL = {
         var startTime = this.getSingleQueryVariable('startTime')
         var endTime = this.getSingleQueryVariable('endTime')
         var live = this.getSingleQueryVariable('live')
+        var follow = this.getSingleQueryVariable('follow')
 
         if (urlSite !== false) {
             L_.FUTURES.site = urlSite
@@ -180,6 +182,11 @@ var QueryURL = {
         if (live !== false) {
             const liveStr = (live + '').toLowerCase()
             L_.FUTURES.live = liveStr === 'true' || liveStr === '1'
+        }
+
+        if (follow !== false) {
+            const followStr = (follow + '').toLowerCase()
+            L_.FUTURES.follow = followStr === 'true' || followStr === '1'
         }
 
         if (layersOn !== false || selected !== false) {
@@ -408,6 +415,11 @@ var QueryURL = {
                 urlAppendage += '&endTime=' + TimeControl.endTime
             if (TimeControl.timeUI && typeof TimeControl.timeUI.now === 'boolean')
                 urlAppendage += '&live=' + (TimeControl.timeUI.now ? '1' : '0')
+            
+            // Follow state
+            if (typeof TimeUI !== 'undefined' && TimeUI.followEnabled && TimeUI.followedFeature) {
+                urlAppendage += '&follow=1'
+            }
         }
 
         var url = encodeURI(urlAppendage)


### PR DESCRIPTION
Closes #745

_With Claude (bedrock)_

  Summary

  This PR introduces a Live Follow Mode feature to MMGIS's time control interface, allowing
  users to automatically track and follow selected features as they update in real-time. When      
  enabled, the map view automatically pans to keep the followed feature centered as new
  time-based data updates occur.

  Key Changes

  New Follow Feature Functionality

  - Added a new "Follow Selected Feature" button to the TimeUI with crosshairs icon
  - Implemented automatic map panning to keep followed features in view during real-time
  updates
  - Follow mode works exclusively with time-enabled layers that have real-time updates
  - Automatically disables when Present/Live mode is turned off

  Enhanced Time Control

  - Preserves active feature selection when reloading time-enabled layers
  - Restores follow state from deeplinks after layers are loaded
  - Intelligently handles feature restoration using layer keys or coordinates

  User Experience Improvements

  - Toast notifications guide users when selecting features for following
  - Clear visual feedback with icon highlighting when follow mode is active
  - Validation ensures only compatible layers can be followed

  Technical Enhancements

  - Added followEnabled and followedFeature state management
  - Implemented deeplink support with &follow=1 parameter
  - Smart feature restoration using useKeyAsId or useKeyAsName when available
  - Adjusted toast container positioning to avoid UI overlap

  Files Modified

  - src/essence/Ancillary/TimeUI.js - Core follow mode implementation
  - src/essence/Ancillary/TimeControl.js - Feature preservation during layer reloads
  - src/essence/Ancillary/QueryURL.js - Deeplink support for follow state
  - src/css/mmgisUI.css - Minor UI positioning adjustment
  - .gitignore - Added development tool directories

  Testing Recommendations

  - Test with various time-enabled layers
  - Verify feature selection persistence during layer reloads
  - Confirm deeplink functionality with &follow=1 parameter
  - Test follow mode toggle with and without active features
  - Verify automatic disabling when exiting Present mode
  
![mmgis-follow](https://github.com/user-attachments/assets/a3961f4e-fdbf-44be-82e4-e58c4d485b45)
