### PR TITLE
#757 Preliminary Video Support

### DIFF
--- a/API/Backend/Config/validate.js
+++ b/API/Backend/Config/validate.js
@@ -95,6 +95,12 @@ const validateLayers = (config) => {
         // Check zooms
         errs = errs.concat(isValidZooms(layer));
         break;
+      case "video":
+        // Check url
+        errs = errs.concat(isValidUrl(layer));
+        // Check bounding box
+        errs = errs.concat(isValidBoundingBox(layer));
+        break;
       default:
         errs = errs.concat(
           err(`Unknown layer type: '${layer.type}'`, ["layers[layer].type"])
@@ -279,6 +285,62 @@ const isValidModelParams = (layer) => {
   return errs;
 };
 
+const isValidBoundingBox = (layer) => {
+  const errs = [];
+
+  if (!layer.boundingBox) {
+    errs.push(
+      err(`Layer '${layer.name}' is missing Bounding Box.`, [
+        "layers[layer].boundingBox",
+      ])
+    );
+  } else if (!Array.isArray(layer.boundingBox)) {
+    errs.push(
+      err(`Layer '${layer.name}' has invalid Bounding Box format.`, [
+        "layers[layer].boundingBox",
+      ])
+    );
+  } else if (layer.boundingBox.length !== 4) {
+    errs.push(
+      err(`Layer '${layer.name}' has invalid Bounding Box length. Expected 4 values (minx,miny,maxx,maxy).`, [
+        "layers[layer].boundingBox",
+      ])
+    );
+  } else {
+    // Validate each coordinate
+    if (isNaN(parseFloat(layer.boundingBox[0]))) {
+      errs.push(
+        err(`Layer '${layer.name}' has invalid Bounding Box minx value.`, [
+          "layers[layer].boundingBox",
+        ])
+      );
+    }
+    if (isNaN(parseFloat(layer.boundingBox[1]))) {
+      errs.push(
+        err(`Layer '${layer.name}' has invalid Bounding Box miny value.`, [
+          "layers[layer].boundingBox",
+        ])
+      );
+    }
+    if (isNaN(parseFloat(layer.boundingBox[2]))) {
+      errs.push(
+        err(`Layer '${layer.name}' has invalid Bounding Box maxx value.`, [
+          "layers[layer].boundingBox",
+        ])
+      );
+    }
+    if (isNaN(parseFloat(layer.boundingBox[3]))) {
+      errs.push(
+        err(`Layer '${layer.name}' has invalid Bounding Box maxy value.`, [
+          "layers[layer].boundingBox",
+        ])
+      );
+    }
+  }
+
+  return errs;
+};
+
 const hasNonHeaderWithSublayers = (config) => {
   const errs = [];
   Utils.traverseLayers(config.layers, (layer) => {
@@ -327,6 +389,10 @@ const fillInMissingFieldsWithDefaults = (layer) => {
       layer.style.className = layer.name.replace(/ /g, "").toLowerCase();
       break;
     case "model":
+      break;
+    case "video":
+      layer.style = layer.style || {};
+      layer.style.className = layer.name.replace(/ /g, "").toLowerCase();
       break;
     default:
   }

--- a/configure/src/components/Tabs/Layers/Layers.js
+++ b/configure/src/components/Tabs/Layers/Layers.js
@@ -30,6 +30,7 @@ import GridViewIcon from "@mui/icons-material/GridView"; // Vector tile
 import ViewInArIcon from "@mui/icons-material/ViewInAr"; // Model
 import AirIcon from "@mui/icons-material/Air"; // Velocity
 import ImageIcon from '@mui/icons-material/Image'; // Image
+import VideoFileIcon from '@mui/icons-material/VideoFile'; // Video
 import AddIcon from "@mui/icons-material/Add";
 
 import VisibilityIcon from "@mui/icons-material/Visibility";
@@ -391,6 +392,10 @@ export default function Layers() {
                     case "image":
                       iconType = <ImageIcon fontSize="small" />;
                       color = "#b0518f";
+                      break;
+                    case "video":
+                      iconType = <VideoFileIcon fontSize="small" />;
+                      color = "#8f3a73";
                       break;
                     default:
                   }

--- a/configure/src/components/Tabs/Layers/Layers.js
+++ b/configure/src/components/Tabs/Layers/Layers.js
@@ -29,8 +29,8 @@ import LanguageIcon from "@mui/icons-material/Language"; // Tile
 import GridViewIcon from "@mui/icons-material/GridView"; // Vector tile
 import ViewInArIcon from "@mui/icons-material/ViewInAr"; // Model
 import AirIcon from "@mui/icons-material/Air"; // Velocity
-import ImageIcon from '@mui/icons-material/Image'; // Image
-import VideoFileIcon from '@mui/icons-material/VideoFile'; // Video
+import ImageIcon from "@mui/icons-material/Image"; // Image
+import VideoFileIcon from "@mui/icons-material/VideoFile"; // Video
 import AddIcon from "@mui/icons-material/Add";
 
 import VisibilityIcon from "@mui/icons-material/Visibility";
@@ -395,7 +395,7 @@ export default function Layers() {
                       break;
                     case "video":
                       iconType = <VideoFileIcon fontSize="small" />;
-                      color = "#8f3a73";
+                      color = "#7b2323";
                       break;
                     default:
                   }

--- a/configure/src/components/Tabs/Layers/Modals/LayerModal/LayerModal.js
+++ b/configure/src/components/Tabs/Layers/Modals/LayerModal/LayerModal.js
@@ -46,6 +46,7 @@ import vectorConfig from "../../../../../metaconfigs/layer-vector-config.json";
 import vectortileConfig from "../../../../../metaconfigs/layer-vectortile-config.json";
 import velocityConfig from "../../../../../metaconfigs/layer-velocity-config.json";
 import imageConfig from "../../../../../metaconfigs/layer-image-config.json";
+import videoConfig from "../../../../../metaconfigs/layer-video-config.json";
 
 const useStyles = makeStyles((theme) => ({
   Modal: {
@@ -199,6 +200,10 @@ const LayerModal = (props) => {
 
     case "image":
       config = imageConfig;
+      break;
+
+    case "video":
+      config = videoConfig;
       break;
 
     default:

--- a/configure/src/components/VideoPreview/VideoPreview.js
+++ b/configure/src/components/VideoPreview/VideoPreview.js
@@ -1,0 +1,98 @@
+import React, { useEffect, useRef } from "react";
+import { makeStyles } from "@mui/styles";
+import { publicUrlMainSite } from "../../core/constants";
+import { isUrlAbsolute } from "../../core/utils";
+
+const useStyles = makeStyles((theme) => ({
+  VideoPreview: {
+    width: "100%",
+    height: "100%",
+    background: theme.palette.swatches.grey[100],
+    position: "relative",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    border: `1px solid ${theme.palette.swatches.grey[300]}`,
+    borderRadius: "4px",
+  },
+  video: {
+    width: "100%",
+    height: "100%",
+    objectFit: "contain",
+    background: "#000",
+  },
+  placeholder: {
+    color: theme.palette.swatches.grey[400],
+    fontSize: "14px",
+    textAlign: "center",
+    padding: "20px",
+  },
+  error: {
+    color: theme.palette.swatches.red[400],
+    fontSize: "14px",
+    textAlign: "center",
+    padding: "20px",
+  },
+}));
+
+const VideoPreview = ({ layer, configuration }) => {
+  const videoRef = useRef(null);
+  const c = useStyles();
+
+  // Handle relative URLs by prepending the public URL and mission path
+  const getFullVideoUrl = (url) => {
+    if (!url) return null;
+
+    if (isUrlAbsolute(url)) {
+      return url;
+    }
+
+    // For relative URLs, prepend publicUrlMainSite and mission path
+    const missionPath = `Missions/${configuration?.msv?.mission || ""}`;
+    return `${publicUrlMainSite}/${missionPath}/${url}`;
+  };
+
+  const fullVideoUrl = getFullVideoUrl(layer?.url);
+
+  useEffect(() => {
+    if (videoRef.current && fullVideoUrl) {
+      // Reset video when URL changes
+      videoRef.current.load();
+    }
+  }, [fullVideoUrl]);
+
+  const handleVideoLoaded = () => {
+    if (videoRef.current) {
+      // Ensure video is muted and paused for preview
+      videoRef.current.muted = true;
+      videoRef.current.pause();
+    }
+  };
+
+  if (!fullVideoUrl) {
+    return (
+      <div className={c.VideoPreview}>
+        <div className={c.placeholder}>Enter a video URL to see preview</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={c.VideoPreview}>
+      <video
+        ref={videoRef}
+        className={c.video}
+        src={fullVideoUrl}
+        muted
+        onLoadedData={handleVideoLoaded}
+        controls={true}
+      >
+        <div className={c.error}>
+          Video format not supported or failed to load
+        </div>
+      </video>
+    </div>
+  );
+};
+
+export default VideoPreview;

--- a/configure/src/core/Maker.js
+++ b/configure/src/core/Maker.js
@@ -690,6 +690,10 @@ const getComponent = (
       let text_array_f = getIn(directConf, com.field, []);
       if (text_array_f != null && typeof text_array_f.join === "function")
         text_array_f = text_array_f.join(",");
+
+      // Check if field is required and has validation error
+      const textArrayHasError = isRequired && (text_array_f === "" || text_array_f == null || (Array.isArray(text_array_f) && text_array_f.length === 0));
+
       inner = (
         <TextField
           className={c.text}
@@ -697,6 +701,12 @@ const getComponent = (
           variant="filled"
           size="small"
           disabled={disabled}
+          required={isRequired}
+          error={textArrayHasError}
+          helperText={textArrayHasError ? "This field is required" : ""}
+          FormHelperTextProps={{
+            className: c.noMarginHelperText
+          }}
           inputProps={{
             autoComplete: "off",
           }}

--- a/configure/src/core/Maker.js
+++ b/configure/src/core/Maker.js
@@ -43,6 +43,7 @@ import {
 import { isFieldRequired } from "./validators";
 
 import Map from "../components/Map/Map";
+import VideoPreview from "../components/VideoPreview/VideoPreview";
 import ColorButton from "../components/ColorButton/ColorButton";
 import MDEditor from "@uiw/react-md-editor";
 import CodeMirror from "@uiw/react-codemirror";
@@ -1450,6 +1451,12 @@ const getComponent = (
       return (
         <div className={c.map} style={{ height: com.height || "200px" }}>
           <Map layer={layer} configuration={configuration} />
+        </div>
+      );
+    case "videopreview":
+      return (
+        <div className={c.map} style={{ height: com.height || "200px" }}>
+          <VideoPreview layer={layer} configuration={configuration} />
         </div>
       );
     default:

--- a/configure/src/core/validators.js
+++ b/configure/src/core/validators.js
@@ -147,10 +147,33 @@ export const validateLayer = (layer) => {
       }
       break;
       
+    case "video":
+      if (!layer.url || layer.url === "" || layer.url === "undefined") {
+        errors.push({ field: "url", message: "URL is required" });
+      }
+      if (!layer.boundingBox || !Array.isArray(layer.boundingBox) || layer.boundingBox.length !== 4) {
+        errors.push({ field: "boundingBox", message: "Bounding Box is required (minx,miny,maxx,maxy)" });
+      } else {
+        // Validate bounding box coordinates are numbers
+        if (isNaN(parseFloat(layer.boundingBox[0]))) {
+          errors.push({ field: "boundingBox", message: "Bounding Box minx must be a number" });
+        }
+        if (isNaN(parseFloat(layer.boundingBox[1]))) {
+          errors.push({ field: "boundingBox", message: "Bounding Box miny must be a number" });
+        }
+        if (isNaN(parseFloat(layer.boundingBox[2]))) {
+          errors.push({ field: "boundingBox", message: "Bounding Box maxx must be a number" });
+        }
+        if (isNaN(parseFloat(layer.boundingBox[3]))) {
+          errors.push({ field: "boundingBox", message: "Bounding Box maxy must be a number" });
+        }
+      }
+      break;
+
     case "header":
       // No additional required fields for header
       break;
-      
+
     default:
       if (layer.type) {
         errors.push({ field: "type", message: `Unknown layer type: ${layer.type}` });

--- a/configure/src/metaconfigs/layer-data-config.json
+++ b/configure/src/metaconfigs/layer-data-config.json
@@ -21,7 +21,8 @@
                 "tile",
                 "vector",
                 "vectortile",
-                "velocity"
+                "velocity",
+                "video"
               ]
             },
             {

--- a/configure/src/metaconfigs/layer-image-config.json
+++ b/configure/src/metaconfigs/layer-image-config.json
@@ -20,7 +20,9 @@
                 "query",
                 "tile",
                 "vector",
-                "vectortile"
+                "vectortile",
+                "velocity",
+                "video"
               ]
             },
             {

--- a/configure/src/metaconfigs/layer-model-config.json
+++ b/configure/src/metaconfigs/layer-model-config.json
@@ -21,7 +21,8 @@
                 "tile",
                 "vector",
                 "vectortile",
-                "velocity"
+                "velocity",
+                "video"
               ]
             },
             {

--- a/configure/src/metaconfigs/layer-query-config.json
+++ b/configure/src/metaconfigs/layer-query-config.json
@@ -21,7 +21,8 @@
                 "tile",
                 "vector",
                 "vectortile",
-                "velocity"
+                "velocity",
+                "video"
               ]
             },
             {

--- a/configure/src/metaconfigs/layer-tile-config.json
+++ b/configure/src/metaconfigs/layer-tile-config.json
@@ -21,7 +21,8 @@
                 "tile",
                 "vector",
                 "vectortile",
-                "velocity"
+                "velocity",
+                "video"
               ]
             },
             {

--- a/configure/src/metaconfigs/layer-vector-config.json
+++ b/configure/src/metaconfigs/layer-vector-config.json
@@ -21,7 +21,8 @@
                 "tile",
                 "vector",
                 "vectortile",
-                "velocity"
+                "velocity",
+                "video"
               ]
             },
             {

--- a/configure/src/metaconfigs/layer-vectortile-config.json
+++ b/configure/src/metaconfigs/layer-vectortile-config.json
@@ -21,7 +21,8 @@
                 "tile",
                 "vector",
                 "vectortile",
-                "velocity"
+                "velocity",
+                "video"
               ]
             },
             {

--- a/configure/src/metaconfigs/layer-velocity-config.json
+++ b/configure/src/metaconfigs/layer-velocity-config.json
@@ -15,12 +15,14 @@
               "options": [
                 "data",
                 "header",
+                "image",
                 "model",
                 "query",
                 "tile",
                 "vector",
                 "vectortile",
-                "velocity"
+                "velocity",
+                "video"
               ]
             },
             {

--- a/configure/src/metaconfigs/layer-video-config.json
+++ b/configure/src/metaconfigs/layer-video-config.json
@@ -30,7 +30,7 @@
               "name": "Layer Name",
               "description": "",
               "type": "textnotrim",
-              "width": 8,
+              "width": 4,
               "required": true
             },
             {
@@ -40,6 +40,11 @@
               "type": "checkbox",
               "width": 2,
               "defaultChecked": false
+            },
+            {
+              "type": "videopreview",
+              "width": 4,
+              "height": "354px"
             }
           ]
         },
@@ -51,7 +56,7 @@
               "name": "Video URL",
               "description": "Path to the video file (.webm or .mp4 format)",
               "type": "text",
-              "width": 12,
+              "width": 8,
               "required": true
             },
             {
@@ -59,13 +64,13 @@
               "name": "Bounding Box",
               "description": "Geographic bounds: nw_lng,nw_lat,se_lng,se_lat",
               "type": "textarray",
-              "width": 12,
+              "width": 8,
               "required": true
             }
           ]
         },
         {
-          "name": "Display Settings",
+          "subname": "Display Settings",
           "components": [
             {
               "field": "initialOpacity",
@@ -75,31 +80,13 @@
               "min": 0,
               "max": 1,
               "step": 0.1,
-              "width": 4,
+              "width": 3,
               "defaultValue": 1
-            },
-            {
-              "field": "minZoom",
-              "name": "Minimum Zoom",
-              "description": "Minimum zoom level to display this layer",
-              "type": "number",
-              "min": 0,
-              "step": 1,
-              "width": 4
-            },
-            {
-              "field": "maxZoom",
-              "name": "Maximum Zoom",
-              "description": "Maximum zoom level to display this layer",
-              "type": "number",
-              "min": 0,
-              "step": 1,
-              "width": 4
             }
           ]
         },
         {
-          "name": "Video Playback Options",
+          "subname": "Video Playback Options",
           "components": [
             {
               "field": "variables.video.autoplay",

--- a/configure/src/metaconfigs/layer-video-config.json
+++ b/configure/src/metaconfigs/layer-video-config.json
@@ -4,7 +4,7 @@
       "name": "Core",
       "rows": [
         {
-          "name": "Core",
+          "forceHeight": "64px",
           "components": [
             {
               "field": "type",
@@ -34,12 +34,118 @@
               "required": true
             },
             {
-              "field": "expanded",
-              "name": "Expanded",
-              "description": "Whether all child layers under the header default to being expanded (as opposed to being collapsed).",
+              "field": "visibility",
+              "name": "Initially On",
+              "description": "",
               "type": "checkbox",
               "width": 2,
               "defaultChecked": false
+            }
+          ]
+        },
+        {
+          "subname": "Source",
+          "components": [
+            {
+              "field": "url",
+              "name": "Video URL",
+              "description": "Path to the video file (.webm or .mp4 format)",
+              "type": "text",
+              "width": 12,
+              "required": true
+            },
+            {
+              "field": "boundingBox",
+              "name": "Bounding Box",
+              "description": "Geographic bounds: nw_lng,nw_lat,se_lng,se_lat",
+              "type": "textarray",
+              "width": 12,
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Display Settings",
+          "components": [
+            {
+              "field": "initialOpacity",
+              "name": "Initial Opacity",
+              "description": "0 (transparent) to 1 (opaque)",
+              "type": "number",
+              "min": 0,
+              "max": 1,
+              "step": 0.1,
+              "width": 4,
+              "defaultValue": 1
+            },
+            {
+              "field": "minZoom",
+              "name": "Minimum Zoom",
+              "description": "Minimum zoom level to display this layer",
+              "type": "number",
+              "min": 0,
+              "step": 1,
+              "width": 4
+            },
+            {
+              "field": "maxZoom",
+              "name": "Maximum Zoom",
+              "description": "Maximum zoom level to display this layer",
+              "type": "number",
+              "min": 0,
+              "step": 1,
+              "width": 4
+            }
+          ]
+        },
+        {
+          "name": "Video Playback Options",
+          "components": [
+            {
+              "field": "variables.video.autoplay",
+              "name": "Autoplay",
+              "description": "Automatically start playing when layer is enabled",
+              "type": "checkbox",
+              "width": 3,
+              "defaultChecked": false
+            },
+            {
+              "field": "variables.video.loop",
+              "name": "Loop",
+              "description": "Loop the video continuously",
+              "type": "checkbox",
+              "width": 3,
+              "defaultChecked": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Interface",
+      "rows": [
+        {
+          "name": "Interface",
+          "subname": "Key Bindings",
+          "components": [
+            {
+              "field": "variables.shortcutSuffix",
+              "name": "Alt + {letter} Toggle Shortcut",
+              "description": "A single letter to 'ALT + {letter}' toggle the layer on and off. Please verify that your chosen shortcut does not conflict with other system or browser-level keyboard shortcuts.",
+              "type": "text",
+              "width": 6
+            }
+          ]
+        },
+        {
+          "subname": "Downloads",
+          "components": [
+            {
+              "field": "variables.downloadURL",
+              "name": "Download URL",
+              "description": "Provides a menu option for users to download the specified source video file for the layer.",
+              "type": "text",
+              "width": 12
             }
           ]
         }

--- a/configure/src/themes/light.js
+++ b/configure/src/themes/light.js
@@ -82,6 +82,7 @@ export const palette = {
     model: "#a98732",
     velocity: "#24807c",
     image: "#b0518f",
+    video: "#8f3a73",
   },
 };
 

--- a/configure/src/themes/light.js
+++ b/configure/src/themes/light.js
@@ -82,7 +82,7 @@ export const palette = {
     model: "#a98732",
     velocity: "#24807c",
     image: "#b0518f",
-    video: "#8f3a73",
+    video: "#7b2323",
   },
 };
 

--- a/docs/pages/Configure/Layers/Video/Video.md
+++ b/docs/pages/Configure/Layers/Video/Video.md
@@ -1,0 +1,117 @@
+---
+layout: page
+title: Video
+permalink: /configure/layers/video
+parent: Layers
+grand_parent: Configure
+---
+
+# Video Layer
+
+Video layers display .webm, .mp4, and .gif video files overlaid on the map using Leaflet's VideoOverlay API. The video is positioned on the map using a bounding box and can be controlled through the LayersTool settings panel.
+
+#### Layer Name
+
+_type:_ string
+The unique display name and identifier of the layer. It must be unique and contain no special characters.
+
+#### URL
+
+_type:_ string
+A file path that points to a video file (.webm, .mp4, or .gif). If the path is relative, it will be relative to the mission's directory. The video will be displayed as an overlay on the map.
+
+#### Bounding Box
+
+_type:_ array
+A comma-separated array of four numbers defining the video overlay's position: `[minx, miny, maxx, maxy]` in longitude/latitude coordinates. This defines where on the map the video will be positioned.
+
+Example: `[-122.5, 37.7, -122.3, 37.9]`
+
+#### Initial Visibility
+
+_type:_ bool
+Whether the layer is on initially.
+
+#### Initial Opacity
+
+_type:_ float
+A value from 0 (transparent) to 1 (opaque) of the layer's initial opacity. 1 is fully opaque.
+
+#### Minimum Zoom
+
+_type:_ integer _optional_
+The lowest (smallest number) zoom level for which to show this layer. If the current Map's zoom level is less than this, the layer will not be rendered even if the layer is still on.
+
+#### Maximum Zoom
+
+_type:_ integer _optional_
+The highest (greatest number) zoom level for which to show this layer. If the current Map's zoom level is higher/deeper than this, the layer will not be rendered even if the layer is still on.
+
+## Video Settings
+
+#### Autoplay
+
+_type:_ bool
+Whether the video should automatically start playing when the layer is loaded.
+
+#### Loop
+
+_type:_ bool
+Whether the video should loop continuously when it reaches the end.
+
+#### Muted
+
+_type:_ bool
+Whether the video should be muted by default. Note that many browsers require videos to be muted for autoplay to work.
+
+#### Plays Inline
+
+_type:_ bool
+Forces the video to play inline rather than in fullscreen mode on mobile devices.
+
+## Playback Controls
+
+Video layers include playback controls in the LayersTool settings panel:
+
+- **Play/Pause**: Toggle video playback
+- **Restart**: Restart the video from the beginning
+- **Mute/Unmute**: Toggle audio on/off
+
+These controls allow users to interact with the video overlay directly from the MMGIS interface without needing to access browser video controls.
+
+## Supported Formats
+
+Video layers support the following video formats:
+
+- **.webm** - Recommended for web use, good compression and quality
+- **.mp4** - Widely supported format, good for compatibility
+- **.gif** - Animated GIF files (though .webm or .mp4 are recommended for better performance)
+
+## Performance Notes
+
+- Video layers use the browser's native video element, so performance depends on the video file size and format
+- For best performance, use optimized video files with appropriate resolutions for your map scale
+- Consider using .webm format for better compression and web performance
+- Large video files may take time to load and could impact map performance on slower connections
+
+## Example Configuration
+
+```json
+{
+  "name": "Weather Animation",
+  "type": "video",
+  "url": "data/weather_animation.webm",
+  "boundingBox": [-118.5, 34.0, -117.8, 34.5],
+  "visibility": true,
+  "initialOpacity": 0.8,
+  "minZoom": 10,
+  "maxZoom": 16,
+  "variables": {
+    "video": {
+      "autoplay": false,
+      "loop": true,
+      "muted": true
+    }
+  }
+}
+```

--- a/docs/pages/Configure/Tabs/Panels/Panels_Tab.md
+++ b/docs/pages/Configure/Tabs/Panels/Panels_Tab.md
@@ -10,7 +10,7 @@ grand_parent: Configure
 
 ## Viewer
 
-The Viewer sits to the left of the main Map. It can be expanded by clicking the double arrow in the middle left of the page. The Viewer can render images, DZIs, mosaics and models attached to layer features. A feature is configured to use the Viewer on click through an array under `properties` called `images`. Other tools may use the Viewer in their own way.
+The Viewer sits to the left of the main Map. It can be expanded by clicking the double arrow in the middle left of the page. The Viewer can render images (including animated GIFs), videos, DZIs, mosaics and models attached to layer features. A feature is configured to use the Viewer on click through an array under `properties` called `images`. Other tools may use the Viewer in their own way.
 
 ```javascript
 "properties": {
@@ -27,8 +27,23 @@ The Viewer sits to the left of the main Map. It can be expanded by clicking the 
             "type": "image"
         },
         {
+            "name": "Animated GIF Example",
+            "url": "https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif",
+            "type": "image"
+        },
+        {
             "url": "sample.pdf",
             "type": "document"
+        },
+        {
+            "name": "Video Example (MP4)",
+            "url": "https://labs.mapbox.com/bites/00188/patricia_nasa.mp4",
+            "type": "video"
+        },
+        {
+            "name": "Video Example (WebM)",
+            "url": "https://labs.mapbox.com/bites/00188/patricia_nasa.webm",
+            "type": "video"
         },
         {
                 "url": "Layers/GPR/Data/GPR_radargram.jpg",
@@ -71,11 +86,15 @@ _Note: The first image in the images array is loaded on feature click._
 
 ### Regular Image
 
-A standard image. Simply provide a url. If a name is not set, the file name is used instead.
+A standard image. Simply provide a url. If a name is not set, the file name is used instead. Animated GIFs are supported and will play automatically while preserving their animation.
 
 ### Document
 
-Current only .pdf files are supported here.
+Currently only .pdf files are supported here.
+
+### Video
+
+Video files in .mp4 and .webm formats are supported. Videos are displayed with native HTML5 video controls including play, pause, seek, volume, and fullscreen capabilities. The video player is constrained within the viewer panel to prevent UI elements from covering the video controls.
 
 ### Radargram
 

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -506,6 +506,7 @@ let helmetConfig = {
       styleSrc: ["*", "data:", "blob:", "'unsafe-inline'"],
       fontSrc: ["*", "data:", "blob:", "'unsafe-inline'"],
       connectSrc: ["*"],
+      mediaSrc: ["*", "data:", "blob:"],
       frameAncestors: process.env.FRAME_ANCESTORS
         ? JSON.parse(process.env.FRAME_ANCESTORS)
         : "none",

--- a/src/css/mmgis.css
+++ b/src/css/mmgis.css
@@ -127,7 +127,7 @@ body {
     --color-model: #a98732;
     --color-velocity: #24807c;
     --color-image: #b0518f;
-    --color-video: #8f3a73;
+    --color-video: #7b2323;
 }
 
 #nodeenv {

--- a/src/css/mmgis.css
+++ b/src/css/mmgis.css
@@ -127,6 +127,7 @@ body {
     --color-model: #a98732;
     --color-velocity: #24807c;
     --color-image: #b0518f;
+    --color-video: #8f3a73;
 }
 
 #nodeenv {
@@ -401,6 +402,10 @@ body {
 }
 
 .velocity-overlay {
+    transition: opacity 0.2s ease-in;
+}
+
+.video-overlay {
     transition: opacity 0.2s ease-in;
 }
 

--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -3464,6 +3464,11 @@ const L_ = {
                             master: props.images[i].master,
                         })
                     } else {
+                        // Check if it's a video or gif file
+                        const urlLower = url.toLowerCase()
+                        const isVideo = urlLower.match(/\.(webm|mp4)$/) != null
+                        const isGif = urlLower.match(/\.gif$/) != null
+
                         if (props.images[i].isPanoramic) {
                             images.push({
                                 ...props.images[i],
@@ -3483,11 +3488,15 @@ const L_ = {
                         images.push({
                             url: url,
                             name:
-                                props.images[i].name ||
-                                props.images[i].url.match(/([^\/]*)\/*$/)[1],
-                            type: props.images[i].type || 'image',
+                                (props.images[i].name ||
+                                    props.images[i].url.match(/([^\/]*)\/*$/)[1]) +
+                                (isVideo ? ' [Video]' : '') +
+                                (isGif ? ' [GIF]' : ''),
+                            type: props.images[i].type || (isVideo ? 'video' : 'image'),
                             isPanoramic: false,
                             isModel: false,
+                            isVideo: isVideo,
+                            isGif: isGif,
                             values: props.images[i].values || {},
                             master: props.images[i].master,
                         })
@@ -3504,12 +3513,14 @@ const L_ = {
                     null
             ) {
                 let url = props[p]
+                const isGif = url.toLowerCase().match(/\.gif$/) != null
                 if (!F_.isUrlAbsolute(url)) url = L_.missionPath + url
                 images.push({
                     url: url,
-                    name: p,
+                    name: p + (isGif ? ' [GIF]' : ''),
                     isPanoramic: false,
                     isModel: false,
+                    isGif: isGif,
                 })
             } else if (
                 typeof props[p] === 'string' &&
@@ -3523,6 +3534,20 @@ const L_ = {
                     type: 'document',
                     isPanoramic: false,
                     isModel: false,
+                })
+            } else if (
+                typeof props[p] === 'string' &&
+                props[p].toLowerCase().match(/\.(webm|mp4)$/) != null
+            ) {
+                let url = props[p]
+                if (!F_.isUrlAbsolute(url)) url = L_.missionPath + url
+                images.push({
+                    url: url,
+                    name: p + ' [Video]',
+                    type: 'video',
+                    isPanoramic: false,
+                    isModel: false,
+                    isVideo: true,
                 })
             } else if (
                 typeof props[p] === 'string' &&

--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -869,6 +869,19 @@ const L_ = {
                         map.addLayer(
                             L_.layers.layer[L_.layers.dataFlat[i].name]
                         )
+
+                        // Ensure video layers start muted when added to map
+                        if (L_.layers.dataFlat[i].type === 'video') {
+                            const videoLayer =
+                                L_.layers.layer[L_.layers.dataFlat[i].name]
+                            if (videoLayer && videoLayer.getElement) {
+                                const videoElement = videoLayer.getElement()
+                                if (videoElement) {
+                                    videoElement.muted = true
+                                    videoElement.setAttribute('muted', 'true')
+                                }
+                            }
+                        }
                         // Refresh opacity
                         if (L_.layers.dataFlat[i].type === 'vector') {
                             const lname = L_.layers.dataFlat[i].name
@@ -3200,7 +3213,8 @@ const L_ = {
             layerConfig.type === 'vector' &&
             layerConfig.time.type === 'local' &&
             layerConfig.time.endProp != null &&
-            layer != false && layer != null &&
+            layer != false &&
+            layer != null &&
             layer._sourceGeoJSON != null
         ) {
             const filteredGeoJSON = JSON.parse(
@@ -3489,10 +3503,14 @@ const L_ = {
                             url: url,
                             name:
                                 (props.images[i].name ||
-                                    props.images[i].url.match(/([^\/]*)\/*$/)[1]) +
+                                    props.images[i].url.match(
+                                        /([^\/]*)\/*$/
+                                    )[1]) +
                                 (isVideo ? ' [Video]' : '') +
                                 (isGif ? ' [GIF]' : ''),
-                            type: props.images[i].type || (isVideo ? 'video' : 'image'),
+                            type:
+                                props.images[i].type ||
+                                (isVideo ? 'video' : 'image'),
                             isPanoramic: false,
                             isModel: false,
                             isVideo: isVideo,

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -1769,23 +1769,28 @@ function makeVideoLayer(layerObj) {
             videoOptions
         )
 
-        // Access the video element and set additional attributes that Leaflet doesn't handle
-        const videoElement = L_.layers.layer[layerObj.name].getElement()
-        if (videoElement) {
-            videoElement.muted = true // Always muted
-            videoElement.playsInline = true // For mobile compatibility
+        // Add updateFilter function to video layer for CSS filter support
+        L_.layers.layer[layerObj.name].updateFilter = function(filterArray) {
+            const videoElement = this.getElement()
+            if (videoElement) {
+                let cssFilters = []
 
-            // For autoplay to work reliably, we need to set it after the element is created
-            if (F_.getIn(layerObj, 'variables.video.autoplay', false)) {
-                videoElement.autoplay = true
-                // Try to play the video when it's loaded if autoplay is enabled
-                videoElement.addEventListener('loadeddata', () => {
-                    if (videoElement.autoplay) {
-                        videoElement.play().catch((err) => {
-                            console.warn('Video autoplay failed:', err)
-                        })
+                filterArray.forEach(filter => {
+                    const [property, value] = filter.split(':')
+                    // Skip blend mode for videos - only handle CSS filters
+                    if (property !== 'mix-blend-mode') {
+                        if (property === 'saturate') {
+                            cssFilters.push(`saturate(${parseFloat(value) * 100}%)`)
+                        } else if (property === 'brightness') {
+                            cssFilters.push(`brightness(${parseFloat(value) * 100}%)`)
+                        } else if (property === 'contrast') {
+                            cssFilters.push(`contrast(${parseFloat(value) * 100}%)`)
+                        }
                     }
                 })
+
+                // Apply CSS filters to video element
+                videoElement.style.filter = cssFilters.join(' ')
             }
         }
 

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -126,19 +126,19 @@ let Map_ = {
         ) {
             var cp = L_.configData.projection
             //console.log(cp)
-            
+
             // Calculate resolutions array from zoom level and units per pixel
             var resolutions = []
             var baseResolution = parseFloat(cp.resunitsperpixel)
             var zoomLevel = parseInt(cp.reszoomlevel) || 0
-            
+
             // Generate resolutions for zoom levels (typically 0-20)
             for (var i = 0; i <= 20; i++) {
                 var zoomDiff = i - zoomLevel
                 var resolution = baseResolution / Math.pow(2, zoomDiff)
                 resolutions.push(resolution)
             }
-            
+
             var crs = new L.Proj.CRS(
                 Number.isFinite(parseInt(cp.epsg[0]))
                     ? `EPSG:${cp.epsg}`
@@ -729,6 +729,9 @@ async function makeLayer(
                 case 'model':
                     //Globe only
                     makeModelLayer(layerObj)
+                    break
+                case 'video':
+                    makeVideoLayer(layerObj)
                     break
                 default:
                     console.warn('Unknown layer type: ' + layerObj.type)
@@ -1720,6 +1723,88 @@ function makeImageLayer(layerObj) {
             L_.layers.layer[layerObj.name] = null
             allLayersLoaded()
         })
+}
+
+function makeVideoLayer(layerObj) {
+    let layerUrl = L_.getUrl(layerObj.type, layerObj.url, layerObj)
+    if (!F_.isUrlAbsolute(layerUrl)) {
+        layerUrl = `${window.location.origin}${(
+            window.location.pathname || ''
+        ).replace(/\/$/g, '')}/${layerUrl}`
+    }
+
+    if (!layerObj.boundingBox || layerObj.boundingBox.length !== 4) {
+        console.warn(
+            `Video layer '${layerObj.name}' missing required bounding box`
+        )
+        L_._layersLoaded[L_._layersOrdered.indexOf(layerObj.name)] = true
+        L_.layers.layer[layerObj.name] = null
+        allLayersLoaded()
+        return
+    }
+
+    const bounds = [
+        [
+            parseFloat(layerObj.boundingBox[1]),
+            parseFloat(layerObj.boundingBox[0]),
+        ],
+        [
+            parseFloat(layerObj.boundingBox[3]),
+            parseFloat(layerObj.boundingBox[2]),
+        ],
+    ]
+
+    const videoOptions = {
+        opacity: layerObj.initialOpacity != null ? layerObj.initialOpacity : 1,
+        autoplay: F_.getIn(layerObj, 'variables.video.autoplay', false),
+        loop: F_.getIn(layerObj, 'variables.video.loop', true),
+        muted: true, // Always muted by default
+        playsInline: true,
+    }
+
+    try {
+        L_.layers.layer[layerObj.name] = L.videoOverlay(
+            layerUrl,
+            bounds,
+            videoOptions
+        )
+
+        // Access the video element and set additional attributes that Leaflet doesn't handle
+        const videoElement = L_.layers.layer[layerObj.name].getElement()
+        if (videoElement) {
+            videoElement.muted = true // Always muted
+            videoElement.playsInline = true // For mobile compatibility
+
+            // For autoplay to work reliably, we need to set it after the element is created
+            if (F_.getIn(layerObj, 'variables.video.autoplay', false)) {
+                videoElement.autoplay = true
+                // Try to play the video when it's loaded if autoplay is enabled
+                videoElement.addEventListener('loadeddata', () => {
+                    if (videoElement.autoplay) {
+                        videoElement.play().catch((err) => {
+                            console.warn('Video autoplay failed:', err)
+                        })
+                    }
+                })
+            }
+        }
+
+        L_.layers.layer[layerObj.name].setZIndex(
+            L_._layersOrdered.length +
+                1 -
+                L_._layersOrdered.indexOf(layerObj.name)
+        )
+
+        L_.setLayerOpacity(layerObj.name, L_.layers.opacity[layerObj.name])
+
+        L_._layersLoaded[L_._layersOrdered.indexOf(layerObj.name)] = true
+        allLayersLoaded()
+    } catch (e) {
+        console.warn(`WARNING - Unable to load video layer: ${layerUrl}`, e)
+        L_._layersLoaded[L_._layersOrdered.indexOf(layerObj.name)] = true
+        L_.layers.layer[layerObj.name] = null
+        allLayersLoaded()
+    }
 }
 
 //Because some layers load faster than others, check to see if

--- a/src/essence/Basics/Viewer_/Viewer_.css
+++ b/src/essence/Basics/Viewer_/Viewer_.css
@@ -64,3 +64,28 @@
 #viewer .react-pdf__Document {
     display: flex;
 }
+
+#viewer #imageVideo {
+    background: black;
+    top: 40px;
+    height: calc(100% - 80px);
+}
+
+#viewer #videoPlayer {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+#viewer #imageGif {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-a);
+}
+
+#viewer #gifImage {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}

--- a/src/essence/Basics/Viewer_/Viewer_.js
+++ b/src/essence/Basics/Viewer_/Viewer_.js
@@ -38,6 +38,8 @@ var Viewer_ = {
     imagePanorama: null,
     imageModel: null,
     imagePDF: null,
+    imageVideo: null,
+    imageGif: null,
     imageIntro: null,
     photosphere: null,
     modelviewer: null,
@@ -104,6 +106,45 @@ var Viewer_ = {
             .style('padding', '60px 0px')
             .style('height', 'calc(100% - 35px)')
 
+        this.imageVideo = d3
+            .select('#viewer')
+            .append('div')
+            .attr('id', 'imageVideo')
+            .style('position', 'absolute')
+            .style('width', '100%')
+            .style('top', '40px')
+            .style('height', 'calc(100% - 80px)')
+            .style('display', 'none')
+            .style('background', 'black')
+
+        this.imageVideo
+            .append('video')
+            .attr('id', 'videoPlayer')
+            .attr('controls', true)
+            .style('position', 'absolute')
+            .style('width', '100%')
+            .style('height', '100%')
+            .style('object-fit', 'contain')
+
+        this.imageGif = d3
+            .select('#viewer')
+            .append('div')
+            .attr('id', 'imageGif')
+            .style('position', 'absolute')
+            .style('width', '100%')
+            .style('height', '100%')
+            .style('display', 'none')
+            .style('align-items', 'center')
+            .style('justify-content', 'center')
+            .style('background', 'var(--color-a)')
+
+        this.imageGif
+            .append('img')
+            .attr('id', 'gifImage')
+            .style('max-width', '100%')
+            .style('max-height', '100%')
+            .style('object-fit', 'contain')
+
         this.imageIntro = d3
             .select('#viewer')
             .append('div')
@@ -158,6 +199,8 @@ var Viewer_ = {
         this.imageViewer.style('display', 'none')
         this.imageModel.style('display', 'none')
         this.imagePDF.style('display', 'none')
+        this.imageVideo.style('display', 'none')
+        this.imageGif.style('display', 'none')
         this.baseToolbar.style('display', 'none')
         this.imageIntro.style('display', 'block')
     },
@@ -220,6 +263,8 @@ var Viewer_ = {
             this.imagePDF.style('display', 'none')
             this.imagePanorama.style('display', 'none')
             this.imageViewer.style('display', 'none')
+            this.imageVideo.style('display', 'none')
+            this.imageGif.style('display', 'none')
             this.baseToolbar.style('display', 'none')
             this.imageIntro.style('display', 'block')
             return
@@ -248,6 +293,8 @@ var Viewer_ = {
             this.imagePDF.style('display', 'none')
             this.imagePanorama.style('display', 'none')
             this.imageViewer.style('display', 'none')
+            this.imageVideo.style('display', 'none')
+            this.imageGif.style('display', 'none')
             this.baseToolbar.style('display', 'none')
 
             this.imageIntro.style('display', 'none')
@@ -301,6 +348,8 @@ var Viewer_ = {
             this.imageViewer.style('display', 'none')
             this.imageModel.style('display', 'none')
             this.imagePDF.style('display', 'none')
+            this.imageVideo.style('display', 'none')
+            this.imageGif.style('display', 'none')
             this.baseToolbar.style('display', 'none')
             this.imageIntro.style('display', 'none')
 
@@ -344,6 +393,8 @@ var Viewer_ = {
             this.imagePanorama.style('display', 'none')
             this.imageViewer.style('display', 'none')
             this.imageModel.style('display', 'none')
+            this.imageVideo.style('display', 'none')
+            this.imageGif.style('display', 'none')
             this.baseToolbar.style('display', 'none')
             this.imageIntro.style('display', 'none')
 
@@ -358,11 +409,71 @@ var Viewer_ = {
                     console.log('here')
                 }
             })
+        } else if (o.isVideo || (extLow === 'webm' || extLow === 'mp4')) {
+            this.imageVideo.style('display', 'inherit')
+            this.imagePDF.style('display', 'none')
+            this.imagePanorama.style('display', 'none')
+            this.imageViewer.style('display', 'none')
+            this.imageModel.style('display', 'none')
+            this.imageGif.style('display', 'none')
+            this.baseToolbar.style('display', 'none')
+            this.imageIntro.style('display', 'none')
+
+            // Get the video element
+            const videoElement = document.getElementById('videoPlayer')
+
+            // Set the video source
+            videoElement.src = url
+
+            // Handle loading events
+            Viewer_.toolBarLoading.style('opacity', '1')
+
+            videoElement.onloadeddata = function() {
+                Viewer_.toolBarLoading.style('opacity', '0')
+            }
+
+            videoElement.onerror = function() {
+                Viewer_.toolBarLoading.html('Error loading video')
+                setTimeout(() => {
+                    Viewer_.toolBarLoading.style('opacity', '0')
+                }, 2000)
+            }
+        } else if (o.isGif || extLow === 'gif') {
+            this.imageGif.style('display', 'flex')
+            this.imageVideo.style('display', 'none')
+            this.imagePDF.style('display', 'none')
+            this.imagePanorama.style('display', 'none')
+            this.imageViewer.style('display', 'none')
+            this.imageModel.style('display', 'none')
+            this.baseToolbar.style('display', 'flex')
+            this.imageIntro.style('display', 'none')
+
+            // Get the img element
+            const imgElement = document.getElementById('gifImage')
+
+            // Set the image source
+            imgElement.src = url
+
+            // Handle loading events
+            Viewer_.toolBarLoading.style('opacity', '1')
+
+            imgElement.onload = function() {
+                Viewer_.toolBarLoading.style('opacity', '0')
+            }
+
+            imgElement.onerror = function() {
+                Viewer_.toolBarLoading.html('Error loading GIF')
+                setTimeout(() => {
+                    Viewer_.toolBarLoading.style('opacity', '0')
+                }, 2000)
+            }
         } else {
             this.imageViewer.style('display', 'inherit')
             this.imagePanorama.style('display', 'none')
             this.imageModel.style('display', 'none')
             this.imagePDF.style('display', 'none')
+            this.imageVideo.style('display', 'none')
+            this.imageGif.style('display', 'none')
             this.baseToolbar.style('display', 'flex')
             this.imageIntro.style('display', 'none')
 

--- a/src/essence/Tools/Layers/LayersTool.css
+++ b/src/essence/Tools/Layers/LayersTool.css
@@ -536,6 +536,9 @@
 .layersToolColor.image {
     background: var(--color-image);
 }
+.layersToolColor.video {
+    background: var(--color-video);
+}
 
 #LayersToolLayer.model {
     height: 33px;

--- a/src/essence/Tools/Layers/LayersTool.css
+++ b/src/essence/Tools/Layers/LayersTool.css
@@ -794,3 +794,123 @@
 .layersToolExportGo:hover {
     background-color: var(--color-a1-5);
 }
+
+#layersTool .videoControls {
+    margin: 8px 0;
+}
+
+#layersTool .videoControlButtons {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+#layersTool .videoControlButtons button {
+    min-width: 30px;
+    height: 30px;
+    padding: 0px 6px;
+    border: 1px solid var(--color-a2);
+    background: var(--color-a1);
+    color: var(--color-l);
+    border-radius: 3px;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+#layersTool .videoControlButtons button:hover {
+    background: var(--color-a1-5);
+}
+
+#layersTool .videoControlButtons button:active {
+    background: var(--color-a);
+}
+
+#layersTool .videoControlButtons button.playing {
+    background: var(--color-p4);
+    color: white;
+}
+
+#layersTool .videoControlButtons button.unmuted {
+    background: var(--color-c2);
+    color: white;
+}
+
+#layersTool .videoScrubBar {
+    margin-top: 12px;
+    display: flex;
+    justify-content: center;
+    flex-flow: column;
+}
+
+#layersTool .videoScrubContainer {
+    position: relative;
+    width: 100%;
+    height: 20px;
+    display: flex;
+    align-items: center;
+}
+
+#layersTool .videoScrubTrack {
+    position: relative;
+    width: 100%;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--color-a-5);
+}
+
+#layersTool .videoScrubProgress {
+    position: absolute;
+    top: 1px;
+    left: 1px;
+    height: 4px;
+    background: var(--color-p4);
+    border-radius: 3px;
+    width: 0%;
+    transition: width 0.1s ease-out;
+}
+
+#layersTool .videoScrubSlider {
+    position: absolute;
+    top: -13px;
+    left: 0;
+    width: 100% !important;
+    height: 20px;
+    background: transparent;
+    outline: none;
+    transition: opacity 0.2s;
+    cursor: pointer;
+    -webkit-appearance: none;
+    appearance: none;
+}
+
+#layersTool .videoScrubSlider:hover {
+    opacity: 1;
+}
+
+#layersTool .videoScrubSlider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--color-p4);
+    cursor: pointer;
+    border: 2px solid var(--color-a-5);
+}
+
+#layersTool .videoScrubSlider::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--color-p4);
+    cursor: pointer;
+    border: 2px solid var(--color-a-5);
+}
+
+#layersTool .videoTimeDisplay {
+    display: flex;
+    justify-content: center;
+    font-size: 12px;
+    color: var(--color-a4);
+    font-family: monospace;
+}

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -428,6 +428,10 @@ function interfaceWithMMGIS(fromInit) {
             let currentContrast
             let currentSaturation
             let currentBlend
+            let defaultBrightness
+            let defaultContrast
+            let defaultSaturation
+            let defaultBlend
             //Build layerExport
             var layerExport
             switch (node[i].type) {
@@ -603,22 +607,22 @@ function interfaceWithMMGIS(fromInit) {
                         node[i]?.style?.brightness != null
                             ? node[i].style.brightness
                             : 1
-                    const defaultBrightness = currentBrightness
+                    defaultBrightness = currentBrightness
                     currentContrast =
                         node[i]?.style?.contrast != null
                             ? node[i].style.contrast
                             : 1
-                    const defaultContrast = currentContrast
+                    defaultContrast = currentContrast
                     currentSaturation =
                         node[i]?.style?.saturation != null
                             ? node[i].style.saturation
                             : 1
-                    const defaultSaturation = currentSaturation
+                    defaultSaturation = currentSaturation
                     currentBlend =
                         node[i]?.style?.blend != null
                             ? node[i].style.blend
                             : 'none'
-                    const defaultBlend = currentBlend
+                    defaultBlend = currentBlend
 
                     if (L_.layers.filters[node[i].name]) {
                         let f = L_.layers.filters[node[i].name]
@@ -1078,6 +1082,40 @@ function interfaceWithMMGIS(fromInit) {
                     if (currentOpacity == null)
                         currentOpacity = L_.layers.opacity[node[i].name]
 
+                    // Video filter settings (reuse variables declared earlier)
+                    currentBrightness =
+                        node[i]?.style?.brightness != null
+                            ? node[i].style.brightness
+                            : 1
+                    defaultBrightness = currentBrightness
+                    currentContrast =
+                        node[i]?.style?.contrast != null
+                            ? node[i].style.contrast
+                            : 1
+                    defaultContrast = currentContrast
+                    currentSaturation =
+                        node[i]?.style?.saturation != null
+                            ? node[i].style.saturation
+                            : 1
+                    defaultSaturation = currentSaturation
+
+                    if (L_.layers.filters[node[i].name]) {
+                        let f = L_.layers.filters[node[i].name]
+
+                        currentBrightness =
+                            f['brightness'] == null
+                                ? currentBrightness
+                                : parseFloat(f['brightness'])
+                        currentContrast =
+                            f['contrast'] == null
+                                ? currentContrast
+                                : parseFloat(f['contrast'])
+                        currentSaturation =
+                            f['saturate'] == null
+                                ? currentSaturation
+                                : parseFloat(f['saturate'])
+                    }
+
                     // prettier-ignore
                     settings = [
                         '<ul>',
@@ -1085,6 +1123,24 @@ function interfaceWithMMGIS(fromInit) {
                                 '<div>',
                                     '<div>Opacity</div>',
                                     '<input class="transparencyslider slider2" layername="' + node[i].name + '" type="range" min="0" max="1" step="0.01" value="' + currentOpacity + '" default="' + L_.layers.opacity[node[i].name] + '">',
+                                '</div>',
+                            '</li>',
+                            '<li>',
+                                '<div>',
+                                    '<div>Brightness</div>',
+                                        '<input class="tilefilterslider slider2" filter="brightness" unit="%" layername="' + node[i].name + '" type="range" min="0" max="3" step="0.05" value="' + currentBrightness + '" default="' + defaultBrightness + '">',
+                                '</div>',
+                            '</li>',
+                            '<li>',
+                                '<div>',
+                                    '<div>Contrast</div>',
+                                    '<input class="tilefilterslider slider2" filter="contrast" unit="%" layername="' + node[i].name + '" type="range" min="0" max="4" step="0.05" value="' + currentContrast + '" default="' + defaultContrast + '">',
+                                '</div>',
+                            '</li>',
+                            '<li>',
+                                '<div>',
+                                    '<div>Saturation</div>',
+                                    '<input class="tilefilterslider slider2" filter="saturate" unit="%" layername="' + node[i].name + '" type="range" min="0" max="4" step="0.05" value="' + currentSaturation + '" default="' + defaultSaturation + '">',
                                 '</div>',
                             '</li>',
                             '<li class="videoControls" data-layername="' + node[i].name + '">',
@@ -1853,13 +1909,16 @@ function interfaceWithMMGIS(fromInit) {
         const videoLayer = L_.layers.layer[layerName]
         if (videoLayer && videoLayer.getElement) {
             const video = videoLayer.getElement()
+
             const icon = $(this).find('i')
             if (video.muted) {
                 video.muted = false
                 icon.removeClass('mdi-volume-off').addClass('mdi-volume-high')
+                $(this).addClass('unmuted')
             } else {
                 video.muted = true
                 icon.removeClass('mdi-volume-high').addClass('mdi-volume-off')
+                $(this).removeClass('unmuted')
             }
         }
     })
@@ -1939,7 +1998,7 @@ function interfaceWithMMGIS(fromInit) {
                 const currentTimeSpan = controls.find('.videoCurrentTime')
                 const durationSpan = controls.find('.videoDuration')
 
-                if (video.duration && isFinite(video.duration)) {
+                if (video && video.duration && isFinite(video.duration)) {
                     const percentage =
                         (video.currentTime / video.duration) * 100
                     slider.val(percentage)
@@ -1961,27 +2020,21 @@ function interfaceWithMMGIS(fromInit) {
             if (videoLayer && videoLayer.getElement) {
                 const video = videoLayer.getElement()
                 const controls = $(this)
-                const muteButton = controls.find('.videoMute')
-                const muteButtonIcon = muteButton.find('i')
                 const playButton = controls.find('.videoPlayPause')
                 const playButtonIcon = playButton.find('i')
-
-                // Sync mute button state
-                if (video.muted) {
-                    muteButtonIcon.removeClass('mdi-volume-high').addClass('mdi-volume-off')
-                    muteButton.removeClass('unmuted')
-                } else {
-                    muteButtonIcon.removeClass('mdi-volume-off').addClass('mdi-volume-high')
-                    muteButton.addClass('unmuted')
-                }
-
-                // Sync play button state
-                if (video.paused) {
-                    playButtonIcon.removeClass('mdi-pause').addClass('mdi-play')
-                    playButton.removeClass('playing')
-                } else {
-                    playButtonIcon.removeClass('mdi-play').addClass('mdi-pause')
-                    playButton.addClass('playing')
+                if (video) {
+                    // Sync play button state
+                    if (video.paused) {
+                        playButtonIcon
+                            .removeClass('mdi-pause')
+                            .addClass('mdi-play')
+                        playButton.removeClass('playing')
+                    } else {
+                        playButtonIcon
+                            .removeClass('mdi-play')
+                            .addClass('mdi-pause')
+                        playButton.addClass('playing')
+                    }
                 }
             }
         })

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -511,6 +511,26 @@ function interfaceWithMMGIS(fromInit) {
                         }
                     }
                     break
+                case 'video':
+                    // Use downloadURL if available, otherwise fallback to main URL
+                    const videoDownloadUrl =
+                        node[i].hasOwnProperty('variables') &&
+                        node[i].variables.hasOwnProperty('downloadURL')
+                            ? node[i].variables.downloadURL
+                            : node[i].url
+
+                    layerExport = [
+                        '<ul>',
+                        '<li>',
+                        '<div class="layersToolExportSourceGeoJSON">',
+                        `<div><a href="` +
+                            videoDownloadUrl +
+                            `" target="_blank">Download Video</a></div>`,
+                        '</div>',
+                        '</li>',
+                        '</ul>',
+                    ].join('\n')
+                    break
                 default:
                     layerExport = ''
             }
@@ -1052,6 +1072,46 @@ function interfaceWithMMGIS(fromInit) {
                     }
 */
                     settings = [settings.join('\n'), '</ul>'].join('\n')
+                    break
+                case 'video':
+                    currentOpacity = L_.getLayerOpacity(node[i].name)
+                    if (currentOpacity == null)
+                        currentOpacity = L_.layers.opacity[node[i].name]
+
+                    // prettier-ignore
+                    settings = [
+                        '<ul>',
+                            '<li>',
+                                '<div>',
+                                    '<div>Opacity</div>',
+                                    '<input class="transparencyslider slider2" layername="' + node[i].name + '" type="range" min="0" max="1" step="0.01" value="' + currentOpacity + '" default="' + L_.layers.opacity[node[i].name] + '">',
+                                '</div>',
+                            '</li>',
+                            '<li class="videoControls" data-layername="' + node[i].name + '">',
+                                '<div>',
+                                    '<div>Video Controls</div>',
+                                    '<div class="videoControlButtons">',
+                                        '<button class="videoPlayPause mmgisButton5" title="Play/Pause"><i class="mdi mdi-play"></i></button>',
+                                        '<button class="videoRestart mmgisButton5" title="Restart"><i class="mdi mdi-restart"></i></button>',
+                                        '<button class="videoMute mmgisButton5" title="Mute/Unmute"><i class="mdi mdi-volume-off"></i></button>',
+                                    '</div>',
+                                '</div>',
+                            '</li>',
+                            '<li class="videoControls" data-layername="' + node[i].name + '">',
+                                '<div class="videoScrubBar">',
+                                    '<div class="videoScrubContainer">',
+                                        '<div class="videoScrubTrack">',
+                                            '<div class="videoScrubProgress"></div>',
+                                            '<input type="range" class="videoScrubSlider" min="0" max="100" value="0" step="0.1" title="Video Progress">',
+                                        '</div>',
+                                    '</div>',
+                                    '<div class="videoTimeDisplay">',
+                                        '<span class="videoCurrentTime">0:00</span>&nbsp;/ <span class="videoDuration">0:00</span>',
+                                    '</div>',
+                                '</div>',
+                            '</li>',
+                        '</ul>',
+                    ].join('\n')
                     break
                 default:
                     settings = ''
@@ -1753,6 +1813,186 @@ function interfaceWithMMGIS(fromInit) {
         )
     })
 
+    // Video control event handlers
+    $('.videoPlayPause').on('click', function () {
+        const layerName = $(this)
+            .closest('.videoControls')
+            .attr('data-layername')
+        const videoLayer = L_.layers.layer[layerName]
+        if (videoLayer && videoLayer.getElement) {
+            const video = videoLayer.getElement()
+            const icon = $(this).find('i')
+            if (video.paused) {
+                video.play()
+                icon.removeClass('mdi-play').addClass('mdi-pause')
+            } else {
+                video.pause()
+                icon.removeClass('mdi-pause').addClass('mdi-play')
+            }
+        }
+    })
+
+    $('.videoRestart').on('click', function () {
+        const layerName = $(this)
+            .closest('.videoControls')
+            .attr('data-layername')
+        const videoLayer = L_.layers.layer[layerName]
+        if (videoLayer && videoLayer.getElement) {
+            const video = videoLayer.getElement()
+            video.currentTime = 0
+            if (!video.paused) {
+                video.play()
+            }
+        }
+    })
+
+    $('.videoMute').on('click', function () {
+        const layerName = $(this)
+            .closest('.videoControls')
+            .attr('data-layername')
+        const videoLayer = L_.layers.layer[layerName]
+        if (videoLayer && videoLayer.getElement) {
+            const video = videoLayer.getElement()
+            const icon = $(this).find('i')
+            if (video.muted) {
+                video.muted = false
+                icon.removeClass('mdi-volume-off').addClass('mdi-volume-high')
+            } else {
+                video.muted = true
+                icon.removeClass('mdi-volume-high').addClass('mdi-volume-off')
+            }
+        }
+    })
+
+    // Video scrub bar event handlers
+    let wasPausedBeforeScrubbing = {}
+
+    $('.videoScrubSlider').on('mousedown', function () {
+        // Start of scrub - pause if playing
+        const layerName = $(this)
+            .closest('.videoControls')
+            .attr('data-layername')
+        const videoLayer = L_.layers.layer[layerName]
+        if (videoLayer && videoLayer.getElement) {
+            const video = videoLayer.getElement()
+            wasPausedBeforeScrubbing[layerName] = video.paused
+            if (!video.paused) {
+                video.pause()
+            }
+        }
+    })
+
+    $('.videoScrubSlider').on('input', function () {
+        const layerName = $(this)
+            .closest('.videoControls')
+            .attr('data-layername')
+        const videoLayer = L_.layers.layer[layerName]
+        if (videoLayer && videoLayer.getElement) {
+            const video = videoLayer.getElement()
+            const slider = $(this)
+            const controls = $(this).closest('.videoControls')
+            const progressBar = controls.find('.videoScrubProgress')
+            const percentage = slider.val()
+            const newTime = (percentage / 100) * video.duration
+
+            if (!isNaN(newTime) && isFinite(newTime)) {
+                video.currentTime = newTime
+                progressBar.css('width', percentage + '%')
+            }
+        }
+    })
+
+    $('.videoScrubSlider').on('mouseup', function () {
+        // End of scrub - resume if was playing before
+        const layerName = $(this)
+            .closest('.videoControls')
+            .attr('data-layername')
+        const videoLayer = L_.layers.layer[layerName]
+        if (videoLayer && videoLayer.getElement) {
+            const video = videoLayer.getElement()
+            if (!wasPausedBeforeScrubbing[layerName]) {
+                video.play()
+            }
+            delete wasPausedBeforeScrubbing[layerName]
+        }
+    })
+
+    // Helper function to format time in MM:SS format
+    function formatVideoTime(seconds) {
+        if (!isFinite(seconds) || isNaN(seconds)) return '0:00'
+        const minutes = Math.floor(seconds / 60)
+        const secs = Math.floor(seconds % 60)
+        return `${minutes}:${secs.toString().padStart(2, '0')}`
+    }
+
+    // Update scrub bar and time display for all video layers
+    function updateVideoScrubBars() {
+        $('.videoControls').each(function () {
+            const layerName = $(this).attr('data-layername')
+            const videoLayer = L_.layers.layer[layerName]
+
+            if (videoLayer && videoLayer.getElement) {
+                const video = videoLayer.getElement()
+                const controls = $(this)
+                const slider = controls.find('.videoScrubSlider')
+                const progressBar = controls.find('.videoScrubProgress')
+                const currentTimeSpan = controls.find('.videoCurrentTime')
+                const durationSpan = controls.find('.videoDuration')
+
+                if (video.duration && isFinite(video.duration)) {
+                    const percentage =
+                        (video.currentTime / video.duration) * 100
+                    slider.val(percentage)
+                    progressBar.css('width', percentage + '%')
+
+                    currentTimeSpan.text(formatVideoTime(video.currentTime))
+                    durationSpan.text(formatVideoTime(video.duration))
+                }
+            }
+        })
+    }
+
+    // Synchronize button states with actual video element states
+    function syncVideoButtonStates() {
+        $('.videoControls').each(function () {
+            const layerName = $(this).attr('data-layername')
+            const videoLayer = L_.layers.layer[layerName]
+
+            if (videoLayer && videoLayer.getElement) {
+                const video = videoLayer.getElement()
+                const controls = $(this)
+                const muteButton = controls.find('.videoMute')
+                const muteButtonIcon = muteButton.find('i')
+                const playButton = controls.find('.videoPlayPause')
+                const playButtonIcon = playButton.find('i')
+
+                // Sync mute button state
+                if (video.muted) {
+                    muteButtonIcon.removeClass('mdi-volume-high').addClass('mdi-volume-off')
+                    muteButton.removeClass('unmuted')
+                } else {
+                    muteButtonIcon.removeClass('mdi-volume-off').addClass('mdi-volume-high')
+                    muteButton.addClass('unmuted')
+                }
+
+                // Sync play button state
+                if (video.paused) {
+                    playButtonIcon.removeClass('mdi-pause').addClass('mdi-play')
+                    playButton.removeClass('playing')
+                } else {
+                    playButtonIcon.removeClass('mdi-play').addClass('mdi-pause')
+                    playButton.addClass('playing')
+                }
+            }
+        })
+    }
+
+    // Update scrub bars periodically while videos are playing
+    setInterval(() => {
+        updateVideoScrubBars()
+        syncVideoButtonStates()
+    }, 100)
+
     $('.tilerescalecogmin').on('change', function () {
         let layer = $(this).attr('layername')
         layer = L_.asLayerUUID(layer)
@@ -2247,15 +2487,23 @@ function interfaceWithMMGIS(fromInit) {
     function traverseHeaderLayersExpandedState(node, parent, depth) {
         for (var i = 0; i < node.length; i++) {
             if (node[i].type == 'header') {
-                if ((node[i].expanded && node[i].expanded === true)
-                        || (node[i].expanded === undefined
-                            && $(`#layersToolList > li#header_${parent.name}`).attr('childrenon') === true)) {
+                if (
+                    (node[i].expanded && node[i].expanded === true) ||
+                    (node[i].expanded === undefined &&
+                        $(`#layersToolList > li#header_${parent.name}`).attr(
+                            'childrenon'
+                        ) === true)
+                ) {
                     LayersTool.toggleHeader(`header_${node[i].name}`)
                 }
             }
 
             if (node[i].sublayers)
-                traverseHeaderLayersExpandedState(node[i].sublayers, node[i], depth + 1)
+                traverseHeaderLayersExpandedState(
+                    node[i].sublayers,
+                    node[i],
+                    depth + 1
+                )
         }
     }
 


### PR DESCRIPTION
# Part 1:
Add Video and Animated GIF Support to MMGIS Viewer Panel

  Overview

  This PR implements preliminary video support for the MMGIS Viewer Panel, allowing users to view
   .webm and .mp4 video files associated with map features through the properties.images
  metadata. Additionally, it fixes the issue where animated GIFs were only showing their first
  frame by implementing a dedicated GIF viewer.

  Changes Made

  1. Video Support Implementation

  - Modified propertiesToImages function (src/essence/Basics/Layers_/Layers_.js):
    - Added detection for .webm and .mp4 video files
    - Videos are marked with [Video] suffix in the dropdown selector
    - Added isVideo: true flag and type: 'video' for video objects
  - Added video container in Viewer (src/essence/Basics/Viewer_/Viewer_.js):
    - Created new imageVideo container with HTML5 video element
    - Implemented video playback with native controls (play, pause, seek, volume, fullscreen)        
    - Added loading state management and error handling
    - Constrained video display to prevent UI overlap (40px padding top/bottom)

  2. Animated GIF Support

  - Updated propertiesToImages function to detect and mark GIF files with isGif flag
  - Added dedicated GIF container that uses a standard <img> element instead of OpenSeadragon        
  - Implemented GIF display logic that preserves animations
  - GIFs are marked with [GIF] suffix in the dropdown selector

  3. CSS Updates (src/essence/Basics/Viewer_/Viewer_.css)

  - Added styling for video container with black background
  - Constrained video height to calc(100% - 80px) to prevent UI overlap
  - Added centered display styling for animated GIFs

  4. Documentation Updates (docs/pages/Configure/Tabs/Panels/Panels_Tab.md)

  - Updated Viewer description to include video and animated GIF support
  - Added configuration examples for both video formats and animated GIFs
  - Created new "Video" section explaining supported formats and features
  - Updated "Regular Image" section to mention animated GIF support

  Technical Details

  - Videos use native HTML5 <video> element with controls
  - GIFs use standard <img> element to preserve animations (OpenSeadragon was freezing them)
  - All media types properly hide/show when switching between different content
  - Loading indicators and error handling implemented for both videos and GIFs

  Testing Recommendations

  - Test with various video formats (.webm, .mp4)
  - Verify animated GIFs play correctly
  - Ensure dropdown selection works for all media types
  - Confirm video controls don't get covered by UI elements
  - Test switching between different media types (images, videos, GIFs, PDFs, models)
  - Verify existing functionality (regular images, PDFs, panoramas, models) still works
  
 ## Images
  
<img width="1024" height="668" alt="2358953" src="https://github.com/user-attachments/assets/8f6eaa09-e587-41ae-80c3-1679d8948e3a" />

# Part 2:
Add new Video Layer type

## Images

![mmgis-video-1](https://github.com/user-attachments/assets/2154ef2b-d34d-4601-ba2b-30b853069ecb)
