### PR TITLE
Show color scale even if TiTiler PNG images are not available

### DIFF
--- a/configure/src/core/Maker.js
+++ b/configure/src/core/Maker.js
@@ -269,6 +269,113 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+const ColormapHelper = ({ colormapName }) => {
+  const c = useStyles();
+
+  let colormap_html = null;
+  let colormap = colormapName;
+
+  // js-colormaps data object only contains the non reversed color so we need to track if the color is reversed
+  let reverse = false;
+
+  // TiTiler colormap variables are all lower case so we need to format them correctly for js-colormaps
+  if (colormap.toLowerCase().endsWith("_r")) {
+    colormap = colormap.substring(0, colormap.length - 2);
+    reverse = true;
+  }
+
+  let index = Object.keys(colormapData).findIndex((v) => {
+    return v.toLowerCase() === colormap.toLowerCase();
+  });
+
+  if (index > -1) {
+    colormap = Object.keys(colormapData)[index];
+  } else {
+    console.warn(`The colormap '${colormap}' does not exist`);
+  }
+
+  if (colormap in colormapData) {
+    colormap_html = colormapData[colormap].colors.map((hex) => {
+      return (
+        <div
+          className={c.colorDropdownArrayHex}
+          style={{
+            background: `rgb(${hex
+              .map((v) => {
+                return Math.floor(v * 255);
+              })
+              .join(",")})`,
+          }}
+        ></div>
+      );
+    });
+
+    if (reverse === true) {
+      colormap_html.reverse();
+    }
+  } else if (colormap === "DEFAULT") {
+    // Default color for velocity layer
+    const defaultColors = [
+      "rgb(36,104, 180)",
+      "rgb(60,157, 194)",
+      "rgb(128,205,193 )",
+      "rgb(151,218,168 )",
+      "rgb(198,231,181)",
+      "rgb(238,247,217)",
+      "rgb(255,238,159)",
+      "rgb(252,217,125)",
+      "rgb(255,182,100)",
+      "rgb(252,150,75)",
+      "rgb(250,112,52)",
+      "rgb(245,64,32)",
+      "rgb(237,45,28)",
+      "rgb(220,24,32)",
+      "rgb(180,0,35)",
+    ];
+
+    colormap_html = defaultColors.map((hex) => {
+      return (
+        <div
+          className={c.colorDropdownArrayHex}
+          style={{ background: `${hex}` }}
+        ></div>
+      );
+    });
+  }
+  return colormap_html;
+}
+
+const DrawColormap = ({ src, colormapName }) => {
+  const [loaded, setLoaded] = useState(true);
+  const [error, setError] = useState(false);
+
+  const handleLoad = () => {
+    setLoaded(false);
+  };
+
+  const handleError = () => {
+    setLoaded(false);
+    setError(true);
+  };
+
+  return (
+    <>
+      {error
+        ? <ColormapHelper colormapName={colormapName} />
+        : <div style={{ width: "100%" }}>
+            <img
+              id="titlerCogColormapImage"
+              style={{ height: "20px", width: "100%" }}
+              src={src}
+              onLoad={handleLoad}
+              onError={handleError}
+            />
+          </div>
+      }
+    </>
+  );
+};
+
 const getComponent = (
   com,
   configuration,
@@ -1131,84 +1238,10 @@ const getComponent = (
       let colormap_html;
       if (window.mmgisglobal.WITH_TITILER === "true") {
         // Get colors from TiTiler if it is available
-        colormap_html = (
-          <div style={{ width: "100%" }}>
-            <img
-              id="titlerCogColormapImage"
-              style={{ height: "20px", width: "100%" }}
-              src={`${domain}titiler/colorMaps/${dropdown_value.toLowerCase()}?format=png`}
-            />
-          </div>
-        );
+        let source = `${domain}titiler/colorMaps/${dropdown_value.toLowerCase()}?format=png`
+        colormap_html = <DrawColormap src={source} colormapName={dropdown_value} />
       } else {
-        let colormap = dropdown_value;
-        // js-colormaps data object only contains the non reversed color so we need to track if the color is reversed
-        let reverse = false;
-
-        // TiTiler colormap variables are all lower case so we need to format them correctly for js-colormaps
-        if (colormap.toLowerCase().endsWith("_r")) {
-          colormap = colormap.substring(0, colormap.length - 2);
-          reverse = true;
-        }
-
-        let index = Object.keys(colormapData).findIndex((v) => {
-          return v.toLowerCase() === colormap.toLowerCase();
-        });
-
-        if (index > -1) {
-          colormap = Object.keys(colormapData)[index];
-        } else {
-          console.warn(`The colormap '${colormap}' does not exist`);
-        }
-
-        if (colormap in colormapData) {
-          colormap_html = colormapData[colormap].colors.map((hex) => {
-            return (
-              <div
-                className={c.colorDropdownArrayHex}
-                style={{
-                  background: `rgb(${hex
-                    .map((v) => {
-                      return Math.floor(v * 255);
-                    })
-                    .join(",")})`,
-                }}
-              ></div>
-            );
-          });
-
-          if (reverse === true) {
-            colormap_html.reverse();
-          }
-        } else if (colormap === "DEFAULT") {
-          // Default color for velocity layer
-          const defaultColors = [
-            "rgb(36,104, 180)",
-            "rgb(60,157, 194)",
-            "rgb(128,205,193 )",
-            "rgb(151,218,168 )",
-            "rgb(198,231,181)",
-            "rgb(238,247,217)",
-            "rgb(255,238,159)",
-            "rgb(252,217,125)",
-            "rgb(255,182,100)",
-            "rgb(252,150,75)",
-            "rgb(250,112,52)",
-            "rgb(245,64,32)",
-            "rgb(237,45,28)",
-            "rgb(220,24,32)",
-            "rgb(180,0,35)",
-          ];
-
-          colormap_html = defaultColors.map((hex) => {
-            return (
-              <div
-                className={c.colorDropdownArrayHex}
-                style={{ background: `${hex}` }}
-              ></div>
-            );
-          });
-        }
+        colormap_html = ColormapHelper({colormapName: dropdown_value});
       }
 
       return (
@@ -1216,7 +1249,9 @@ const getComponent = (
           {inlineHelp ? (
             <>
               {inner}
-              <div className={c.textArrayHexes}>{colormap_html || null}</div>
+              <div className={c.textArrayHexes}>
+                {colormap_html}
+              </div>
               <Typography className={c.subtitle2}>
                 {com.description || ""}
               </Typography>

--- a/configure/src/core/Maker.js
+++ b/configure/src/core/Maker.js
@@ -49,10 +49,7 @@ import CodeMirror from "@uiw/react-codemirror";
 import { json } from "@codemirror/lang-json";
 import { Button } from "@mui/material";
 
-import {
-  evaluate_cmap,
-  data as colormapData,
-} from "../external/js-colormaps.js";
+import { data as colormapData } from "../external/js-colormaps.js";
 
 import { calls } from "./calls";
 import { parseTileMatrixSetCRS } from "./crsUtils";
@@ -346,15 +343,9 @@ const ColormapHelper = ({ colormapName }) => {
 }
 
 const DrawColormap = ({ src, colormapName }) => {
-  const [loaded, setLoaded] = useState(true);
   const [error, setError] = useState(false);
 
-  const handleLoad = () => {
-    setLoaded(false);
-  };
-
   const handleError = () => {
-    setLoaded(false);
     setError(true);
   };
 
@@ -365,9 +356,9 @@ const DrawColormap = ({ src, colormapName }) => {
         : <div style={{ width: "100%" }}>
             <img
               id="titlerCogColormapImage"
+              alt=""
               style={{ height: "20px", width: "100%" }}
               src={src}
-              onLoad={handleLoad}
               onError={handleError}
             />
           </div>

--- a/configure/src/core/Maker.js
+++ b/configure/src/core/Maker.js
@@ -1235,13 +1235,10 @@ const getComponent = (
           : window.mmgisglobal.ROOT_PATH || "";
       if (domain.length > 0 && !domain.endsWith("/")) domain += "/";
 
-      let colormap_html;
+      let source = "";
       if (window.mmgisglobal.WITH_TITILER === "true") {
         // Get colors from TiTiler if it is available
-        let source = `${domain}titiler/colorMaps/${dropdown_value.toLowerCase()}?format=png`
-        colormap_html = <DrawColormap src={source} colormapName={dropdown_value} />
-      } else {
-        colormap_html = ColormapHelper({colormapName: dropdown_value});
+        source = `${domain}titiler/colorMaps/${dropdown_value.toLowerCase()}?format=png`
       }
 
       return (
@@ -1250,7 +1247,7 @@ const getComponent = (
             <>
               {inner}
               <div className={c.textArrayHexes}>
-                {colormap_html}
+                <DrawColormap src={source} colormapName={dropdown_value} />
               </div>
               <Typography className={c.subtitle2}>
                 {com.description || ""}

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -270,7 +270,7 @@ var LayersTool = {
         canvasElement.width = 256
         canvasElement.height = 1
         const context = canvasElement.getContext('2d')
-        if (imgElement && layer.type === 'tile') {
+        if (imgElement && imgElement.complete && imgElement.naturalHeight !== 0 && layer.type === 'tile') {
             context.drawImage(imgElement, 0, 0, 256, 1, 0, 0, 256, 1)
         }
 
@@ -299,7 +299,7 @@ var LayersTool = {
             }
 
             let color
-            if (imgElement && layer.type === 'tile') {
+            if (imgElement && imgElement.complete && imgElement.naturalHeight !== 0 && layer.type === 'tile') {
                 const c = context.getImageData(
                     parseInt((255 / 9) * i),
                     0,
@@ -310,7 +310,8 @@ var LayersTool = {
             } else if (
                 layer.type === 'image' ||
                 layer.type === 'velocity' ||
-                !imgElement
+                !imgElement ||
+                (imgElement && imgElement.naturalHeight === 0 && layer.type === 'tile')
             ) {
                 const layerColormap = ['tile', 'image'].includes(layer.type)
                     ? layer.cogColormap
@@ -566,6 +567,31 @@ function interfaceWithMMGIS(fromInit) {
                 }
             }
 
+            function additionalSettingsJSColormapHelper(colormap, reverse) {
+                let additionalSettings = colormapData[
+                    colormap
+                ].colors.map((hex) => {
+                    let rgb = hex
+                        .map((v) => {
+                            return Math.floor(v * 255)
+                        })
+                        .join(',')
+                    return `<div style="background: rgb(${rgb}); width: 20px; height: 100%; margin: 0px; flex-grow: 1;"></div>`
+                })
+
+                if (reverse === true) {
+                    additionalSettings.reverse()
+                }
+
+                additionalSettings = [
+                    '<div id="titlerCogColormapCSS">',
+                    additionalSettings.join('\n'),
+                    '</div>',
+                ].join('\n')
+
+                return additionalSettings
+            }
+
             //Build settings object
             var settings
             let additionalSettings = ''
@@ -628,40 +654,22 @@ function interfaceWithMMGIS(fromInit) {
                         (node[i].url.split(':')[0] === 'stac-collection' ||
                             node[i].url.split(':')[0] === 'COG')
                     ) {
+                        let { colormap, reverse } =
+                            LayersTool.findJSColormap(
+                                node[i],
+                                node[i].cogColormap
+                            )
+
                         if (window.mmgisglobal.WITH_TITILER === 'true') {
                             // prettier-ignore
                             additionalSettings = [
                                 `<img id="titlerCogColormapImage_${node[i].name}" src="${window.location.origin}${(
                                             window.location.pathname || ''
-                                        ).replace(/\/$/g, '')}/titiler/colorMaps/${node[i].cogColormap}?format=png"></img>`,
+                                        ).replace(/\/$/g, '')}/titiler/colorMaps/${node[i].cogColormap}?format=png"
+                                data-colormap="${colormap}" data-colormap-reverse="${reverse}"></img>`,
                             ].join('\n')
                         } else {
-                            let { colormap, reverse } =
-                                LayersTool.findJSColormap(
-                                    node[i],
-                                    node[i].cogColormap
-                                )
-
-                            additionalSettings = colormapData[
-                                colormap
-                            ].colors.map((hex) => {
-                                let rgb = hex
-                                    .map((v) => {
-                                        return Math.floor(v * 255)
-                                    })
-                                    .join(',')
-                                return `<div style="background: rgb(${rgb}); width: 20px; height: 100%; margin: 0px; flex-grow: 1;"></div>`
-                            })
-
-                            if (reverse === true) {
-                                additionalSettings.reverse()
-                            }
-
-                            additionalSettings = [
-                                '<div id="titlerCogColormapCSS">',
-                                additionalSettings.join('\n'),
-                                '</div>',
-                            ].join('\n')
+                            additionalSettings = additionalSettingsJSColormapHelper(colormap, reverse)
                         }
 
                         // prettier-ignore
@@ -831,40 +839,22 @@ function interfaceWithMMGIS(fromInit) {
                         currentOpacity = L_.layers.opacity[node[i].name]
 
                     if (node[i].kind === 'streamlines') {
+                        let { colormap, reverse } =
+                            LayersTool.findJSColormap(
+                                node[i],
+                                node[i].variables?.streamlines?.colorScale
+                            )
+
                         if (window.mmgisglobal.WITH_TITILER === 'true') {
                             // prettier-ignore
                             additionalSettings = [
                                 `<img id="titlerCogColormapImage_${node[i].name}" src="${window.location.origin}${(
                                             window.location.pathname || ''
-                                        ).replace(/\/$/g, '')}/titiler/colorMaps/${node[i].variables?.streamlines?.colorScale?.toLowerCase() || 'rdylbu_r'}?format=png"></img>`,
+                                        ).replace(/\/$/g, '')}/titiler/colorMaps/${node[i].variables?.streamlines?.colorScale?.toLowerCase() || VELOCITY_DEFAULT_COLOR_RAMP}?format=png"
+                                data-colormap="${colormap}" data-colormap-reverse="${reverse}"></img>`,
                             ].join('\n')
                         } else {
-                            let { colormap, reverse } =
-                                LayersTool.findJSColormap(
-                                    node[i],
-                                    node[i].variables?.streamlines?.colorScale
-                                )
-
-                            additionalSettings = colormapData[
-                                colormap
-                            ].colors.map((hex) => {
-                                let rgb = hex
-                                    .map((v) => {
-                                        return Math.floor(v * 255)
-                                    })
-                                    .join(',')
-                                return `<div style="background: rgb(${rgb}); width: 20px; height: 100%; margin: 0px; flex-grow: 1;"></div>`
-                            })
-
-                            if (reverse === true) {
-                                additionalSettings.reverse()
-                            }
-
-                            additionalSettings = [
-                                '<div id="titlerCogColormapCSS">',
-                                additionalSettings.join('\n'),
-                                '</div>',
-                            ].join('\n')
+                            additionalSettings = additionalSettingsJSColormapHelper(colormap, reverse)
                         }
 
                         // prettier-ignore
@@ -936,40 +926,23 @@ function interfaceWithMMGIS(fromInit) {
                         L_.layers.layer[node[i].name].georasters[0]
                             .numberOfRasters === 1
                     ) {
+
+                        let { colormap, reverse } =
+                            LayersTool.findJSColormap(
+                                node[i],
+                                node[i].cogColormap
+                            )
+
                         if (window.mmgisglobal.WITH_TITILER === 'true') {
                             // prettier-ignore
                             additionalSettings = [
                                 `<img id="titlerCogColormapImage_${node[i].name}" src="${window.location.origin}${(
                                             window.location.pathname || ''
-                                        ).replace(/\/$/g, '')}/titiler/colorMaps/${node[i].cogColormap}?format=png"></img>`,
+                                        ).replace(/\/$/g, '')}/titiler/colorMaps/${node[i].cogColormap}?format=png"
+                                data-colormap="${colormap}" data-colormap-reverse="${reverse}"></img>`,
                             ].join('\n')
                         } else {
-                            let { colormap, reverse } =
-                                LayersTool.findJSColormap(
-                                    node[i],
-                                    node[i].cogColormap
-                                )
-
-                            additionalSettings = colormapData[
-                                colormap
-                            ].colors.map((hex) => {
-                                let rgb = hex
-                                    .map((v) => {
-                                        return Math.floor(v * 255)
-                                    })
-                                    .join(',')
-                                return `<div style="background: rgb(${rgb}); width: 20px; height: 100%; margin: 0px; flex-grow: 1;"></div>`
-                            })
-
-                            if (reverse === true) {
-                                additionalSettings.reverse()
-                            }
-
-                            additionalSettings = [
-                                '<div id="titlerCogColormapCSS">',
-                                additionalSettings.join('\n'),
-                                '</div>',
-                            ].join('\n')
+                            additionalSettings = additionalSettingsJSColormapHelper(colormap, reverse)
                         }
 
                         // prettier-ignore
@@ -1168,6 +1141,21 @@ function interfaceWithMMGIS(fromInit) {
                     }
 
                     break
+            }
+
+            if (window.mmgisglobal.WITH_TITILER === 'true') {
+                // Check if TiTiler images loaded
+                if ($(`#titlerCogColormapImage_${node[i].name}`).length) {
+                    $(`#titlerCogColormapImage_${node[i].name}`)
+                        .on('error', function() {
+                            // Fallback to colormap JS library
+                            var t = $(this).first()
+                            t.parent().prepend(
+                                additionalSettingsJSColormapHelper(t.data('colormap'), t.data('colormap-reverse'))
+                            )
+                            t.remove()
+                        })
+                }
             }
 
             if (node[i].sublayers)


### PR DESCRIPTION
If the TiTiler server is somehow down, but TiTiler is on according to the env, the color scales will display an error. We should fall back to use js-colormaps in this case for both the layers tab and the configure page.

<img width="400" height="982" alt="Screenshot 2025-09-12 at 1 01 33 PM" src="https://github.com/user-attachments/assets/6e870aca-1a97-4ab5-890a-365f76f554e1" />

<img width="400" height="976" alt="Screenshot 2025-09-15 at 11 08 35 AM" src="https://github.com/user-attachments/assets/ce8fe5e0-465d-4ce3-8fb1-be4da6683cc4" />

<img width="800" height="688" alt="Screenshot 2025-09-18 at 1 23 18 PM" src="https://github.com/user-attachments/assets/847d131d-03e6-48e0-90e6-ae70ae69b254" />

<img width="800" height="688" alt="Screenshot 2025-09-18 at 1 26 51 PM" src="https://github.com/user-attachments/assets/8452951f-b3af-45f0-a81a-3c1927cb2e5a" />

