### PR TITLE
Enable horizontal legends

### DIFF
--- a/configure/src/metaconfigs/layer-image-config.json
+++ b/configure/src/metaconfigs/layer-image-config.json
@@ -199,7 +199,16 @@
               "name": "Legend From URL",
               "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
-              "width": 10
+              "width": 8
+            },
+            {
+              "new": true,
+              "field": "variables.legendOrientation",
+              "name": "Legend Orientation",
+              "description": "Displays the legend horizontally or vertically.",
+              "type": "dropdown",
+              "width": 2,
+              "options": ["vertical", "horizontal"]
             },
             {
               "new": true,

--- a/configure/src/metaconfigs/layer-model-config.json
+++ b/configure/src/metaconfigs/layer-model-config.json
@@ -435,7 +435,16 @@
               "name": "Legend From URL",
               "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
-              "width": 10
+              "width": 8
+            },
+            {
+              "new": true,
+              "field": "variables.legendOrientation",
+              "name": "Legend Orientation",
+              "description": "Displays the legend horizontally or vertically.",
+              "type": "dropdown",
+              "width": 2,
+              "options": ["vertical", "horizontal"]
             },
             {
               "new": true,

--- a/configure/src/metaconfigs/layer-query-config.json
+++ b/configure/src/metaconfigs/layer-query-config.json
@@ -551,7 +551,16 @@
               "name": "Legend From URL",
               "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
-              "width": 10
+              "width": 8
+            },
+            {
+              "new": true,
+              "field": "variables.legendOrientation",
+              "name": "Legend Orientation",
+              "description": "Displays the legend horizontally or vertically.",
+              "type": "dropdown",
+              "width": 2,
+              "options": ["vertical", "horizontal"]
             },
             {
               "new": true,

--- a/configure/src/metaconfigs/layer-tile-config.json
+++ b/configure/src/metaconfigs/layer-tile-config.json
@@ -404,7 +404,16 @@
               "name": "Legend From URL",
               "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
-              "width": 10
+              "width": 8
+            },
+            {
+              "new": true,
+              "field": "variables.legendOrientation",
+              "name": "Legend Orientation",
+              "description": "Displays the legend horizontally or vertically.",
+              "type": "dropdown",
+              "width": 2,
+              "options": ["vertical", "horizontal"]
             },
             {
               "new": true,

--- a/configure/src/metaconfigs/layer-vector-config.json
+++ b/configure/src/metaconfigs/layer-vector-config.json
@@ -490,7 +490,16 @@
               "name": "Legend From URL",
               "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
-              "width": 10
+              "width": 8
+            },
+            {
+              "new": true,
+              "field": "variables.legendOrientation",
+              "name": "Legend Orientation",
+              "description": "Displays the legend horizontally or vertically.",
+              "type": "dropdown",
+              "width": 2,
+              "options": ["vertical", "horizontal"]
             },
             {
               "new": true,

--- a/configure/src/metaconfigs/layer-vectortile-config.json
+++ b/configure/src/metaconfigs/layer-vectortile-config.json
@@ -457,7 +457,16 @@
               "name": "Legend From URL",
               "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
-              "width": 10
+              "width": 8
+            },
+            {
+              "new": true,
+              "field": "variables.legendOrientation",
+              "name": "Legend Orientation",
+              "description": "Displays the legend horizontally or vertically.",
+              "type": "dropdown",
+              "width": 2,
+              "options": ["vertical", "horizontal"]
             },
             {
               "new": true,

--- a/configure/src/metaconfigs/layer-velocity-config.json
+++ b/configure/src/metaconfigs/layer-velocity-config.json
@@ -377,7 +377,16 @@
               "name": "Legend From URL",
               "description": "A URL to a static image or .csv with the following header: 'color,strokecolor,shape,value'. If the path is relative, it will be relative to the mission's directory. This legend is overridden if a legend is also configured below.",
               "type": "text",
-              "width": 10
+              "width": 8
+            },
+            {
+              "new": true,
+              "field": "variables.legendOrientation",
+              "name": "Legend Orientation",
+              "description": "Displays the legend horizontally or vertically.",
+              "type": "dropdown",
+              "width": 2,
+              "options": ["vertical", "horizontal"]
             },
             {
               "new": true,

--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -404,6 +404,7 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
                 color: _legend[d].color,
                 shape: shape,
                 value: _legend[d].value,
+                propertyValue: _legend[d].propertyValue,
             })
             lastShape = shape
         } else {
@@ -524,6 +525,7 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
             .style('flex-direction', 'column')
             .style('margin', orientation === 'horizontal' ? '8px 0px 8px 0px' : '0px 0px 8px 8px')
             .style('width', '100%') // Ensure full width
+            .style('position', 'relative') // Add relative positioning for absolute positioned children
 
         // Container for gradient and labels
         var legendContainer = r
@@ -793,7 +795,7 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
             // Extract units from all visible labels
             const values = visibleLabels.map(item => item.value)
             const { units } = extractUnits(values)
-            
+
             if (units) {
                 const unitsLabel = r
                     .append('div')
@@ -952,12 +954,12 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
                     const fraction = index - lowerIndex
                     
                     if (lowerIndex === upperIndex) {
-                        // Exact match
-                        value = legendEntries[lowerIndex].value
+                        // Prioritize propertyValue, if it exists, over value
+                        value = legendEntries[lowerIndex].propertyValue || legendEntries[lowerIndex].value
                     } else {
                         // Interpolate between continuous values
-                        const lowerValue = parseFloat(legendEntries[lowerIndex].value) || 0
-                        const upperValue = parseFloat(legendEntries[upperIndex].value) || 0
+                        const lowerValue = parseFloat(legendEntries[lowerIndex].propertyValue || legendEntries[lowerIndex].value) || 0
+                        const upperValue = parseFloat(legendEntries[upperIndex].propertyValue || legendEntries[upperIndex].value) || 0
                         const interpolatedValue = lowerValue + (upperValue - lowerValue) * fraction
                         value = interpolatedValue.toFixed(3).replace(/\.?0+$/, '') // Remove trailing zeros
                     }
@@ -965,7 +967,7 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
                     // For discrete legends, map position to discrete bands
                     const bandIndex = Math.floor(position * legendEntries.length)
                     const clampedIndex = Math.min(bandIndex, legendEntries.length - 1)
-                    value = legendEntries[clampedIndex].value
+                    value = legendEntries[clampedIndex].propertyValue || legendEntries[clampedIndex].value
                 }
                 
                 tooltip

--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -241,6 +241,32 @@ function drawLegendHeader() {
     tools.style('background', 'var(--color-k)')
     //Clear it
     tools.selectAll('*').remove()
+    
+    // Add CSS to make tooltips appear faster
+    if (!document.getElementById('legend-tooltip-styles')) {
+        const style = document.createElement('style')
+        style.id = 'legend-tooltip-styles'
+        style.textContent = `
+            [title] {
+                transition-delay: 0s !important;
+            }
+            [title]:hover::after {
+                content: attr(title);
+                position: absolute;
+                background: rgba(0, 0, 0, 0.8);
+                color: white;
+                padding: 4px 8px;
+                border-radius: 4px;
+                font-size: 12px;
+                white-space: nowrap;
+                z-index: 1000;
+                pointer-events: none;
+                margin-top: -25px;
+                margin-left: 10px;
+            }
+        `
+        document.head.appendChild(style)
+    }
     tools
         .append('div')
         .style('height', '30px')
@@ -311,7 +337,7 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
 
     if (isHeader) return
 
-    let lastContinues = []
+    let legendEntries = []
     let lastShape = ''
 
     // Check if _legend is an image URL (string)
@@ -369,12 +395,12 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
             ? _legend[d].shapeIcon : _legend[d].shape
         if (shape == 'continuous' || shape == 'discreet') {
             if (lastShape != shape) {
-                if (lastContinues.length > 0) {
-                    pushScale(lastContinues)
-                    lastContinues = []
+                if (legendEntries.length > 0) {
+                    pushScale(legendEntries)
+                    legendEntries = []
                 }
             }
-            lastContinues.push({
+            legendEntries.push({
                 color: _legend[d].color,
                 shape: shape,
                 value: _legend[d].value,
@@ -383,9 +409,9 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
         } else {
 
             // finalize discreet and continuous
-            if (lastContinues.length > 0) {
-                pushScale(lastContinues)
-                lastContinues = []
+            if (legendEntries.length > 0) {
+                pushScale(legendEntries)
+                legendEntries = []
             }
             var r = c
                 .append('div')
@@ -409,6 +435,9 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
                             .style('opacity', opacity)
                             .style('border', `1px solid ${_legend[d].strokecolor}`)
                             .style('border-radius', '50%')
+                            .style('position', 'relative')
+                            .style('cursor', 'crosshair')
+                            .attr('title', _legend[d].value)
                         break
                     case 'square':
                         r.append('div')
@@ -418,6 +447,9 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
                             .style('background', _legend[d].color)
                             .style('opacity', opacity)
                             .style('border', `1px solid ${_legend[d].strokecolor}`)
+                            .style('position', 'relative')
+                            .style('cursor', 'crosshair')
+                            .attr('title', _legend[d].value)
                         break
                     case 'rect':
                         r.append('div')
@@ -428,6 +460,9 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
                             .style('background', _legend[d].color)
                             .style('opacity', opacity)
                             .style('border', `1px solid ${_legend[d].strokecolor}`)
+                            .style('position', 'relative')
+                            .style('cursor', 'crosshair')
+                            .attr('title', _legend[d].value)
                         break
                     default:
                 }
@@ -444,16 +479,23 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
                         ? shape : L_.missionPath + shape})`)
                     .style('background-size', 'contain')
                     .style('background-repeat', 'no-repeat')
+                    .style('position', 'relative')
+                    .style('cursor', 'crosshair')
+                    .attr('title', _legend[d].value)
             } else { // try using shape from Material Design Icon (mdi) library    
-                r.append('div')
+                const iconContainer = r.append('div')
                     .attr('class', layerUUID + '_legendicon')
                     .style('width', '18px')
                     .style('height', '18px')
-                    .append('i')
-                        .attr('class', 'mdi mdi-18px mdi-' + shape)
-                        .style('color', _legend[d].color)
-                        .style('opacity', opacity)
-                        .style('border', `1px solid ${_legend[d].strokecolor}`)
+                    .style('position', 'relative')
+                    .style('cursor', 'crosshair')
+                    .attr('title', _legend[d].value)
+                
+                iconContainer.append('i')
+                    .attr('class', 'mdi mdi-18px mdi-' + shape)
+                    .style('color', _legend[d].color)
+                    .style('opacity', opacity)
+                    .style('border', `1px solid ${_legend[d].strokecolor}`)
             }
 
             r.append('div')
@@ -469,12 +511,12 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
             .text(_legend[d].value)
         }
     }
-    if (lastContinues.length > 0) {
-        pushScale(lastContinues)
-        lastContinues = []
+    if (legendEntries.length > 0) {
+        pushScale(legendEntries)
+        legendEntries = []
     }
 
-    function pushScale(lastContinues) {
+    function pushScale(legendEntries) {
         var r = c
             .append('div')
             .attr('class', 'row')
@@ -490,7 +532,9 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
             .style('flex-direction', orientation === 'horizontal' ? 'column' : 'row')
             .style('align-items', orientation === 'horizontal' ? 'flex-start' : 'center')
             .style('gap', orientation === 'horizontal' ? '4px' : '8px')
-            .style('width', orientation === 'horizontal' ? '100%' : 'auto') // Full width in horizontal mode
+            .style('width', orientation === 'horizontal' ? '320px' : 'auto') // Set to 320px for horizontal legends
+            .style('max-width', orientation === 'horizontal' ? '320px' : 'none') // Ensure it doesn't exceed 320px
+            .style('padding-left', orientation === 'horizontal' ? '8px' : '0px') // Add left padding to align with vertical legends
 
         // Calculate gradient width based on container width and number of sections
         const gradientWidth = orientation === 'horizontal' ? '100%' : '19px'
@@ -498,22 +542,73 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
         var gradient = legendContainer
             .append('div')
             .style('width', gradientWidth)
-            .style('height', orientation === 'horizontal' ? '19px' : (19 * lastContinues.length + 'px'))
+            .style('height', orientation === 'horizontal' ? '19px' : (19 * legendEntries.length + 'px'))
             .style('border', '1px solid black')
             .style('flex-shrink', '0')
+            .style('position', 'relative')
+            .style('cursor', 'crosshair')
+
+        // For horizontal legends, ensure data is in ascending order (min to max)
+        // Source data is typically in descending order, so we reverse it for horizontal display
+        if (orientation === 'horizontal') {
+            legendEntries = [...legendEntries].reverse()
+        }
+
+        // Start with all legend entries, reduce labels if needed for horizontal legends
+        let visibleLabels = legendEntries
 
         // Calculate available width per label in horizontal mode
-        const containerWidth = orientation === 'horizontal' ? r.node().getBoundingClientRect().width : 'auto'
-        const labelWidth = orientation === 'horizontal' ? (containerWidth / lastContinues.length) : 'auto'
+        const containerWidth = orientation === 'horizontal' ? 320 : 'auto'
+        let labelWidth = orientation === 'horizontal' ? (containerWidth / visibleLabels.length) : 'auto'
+        
+        // For horizontal legends, check if we need to reduce labels based on actual text overflow
+        if (orientation === 'horizontal') {
+            const maxWidth = 320
+            
+            // Calculate if labels would overflow with current setup
+            const maxLabelLength = Math.max(...visibleLabels.map(c => String(c.value).length))
+            const estimatedCharWidth = 7
+            const estimatedLabelWidth = maxLabelLength * estimatedCharWidth
+            const minViableWidth = estimatedLabelWidth * 0.6
+            
+            // Only reduce labels if the estimated width per label is too small
+            if (labelWidth < minViableWidth && visibleLabels.length > 2) {
+                const maxLabels = Math.floor(maxWidth / minViableWidth)
+                
+                if (visibleLabels.length > maxLabels) {
+                    // Always keep first and last labels
+                    const keepIndices = new Set([0, visibleLabels.length - 1])
+                    
+                    // Calculate how many intermediate labels we can show
+                    const intermediateSlots = Math.max(0, maxLabels - 2)
+                    
+                    if (intermediateSlots > 0) {
+                        // Distribute intermediate labels evenly
+                        const step = (visibleLabels.length - 1) / (intermediateSlots + 1)
+                        for (let i = 1; i <= intermediateSlots; i++) {
+                            const index = Math.round(i * step)
+                            if (index > 0 && index < visibleLabels.length - 1) {
+                                keepIndices.add(index)
+                            }
+                        }
+                    }
+                    
+                    // Create new array with only the selected labels
+                    visibleLabels = legendEntries.filter((_, index) => keepIndices.has(index))
+                    // Recalculate label width with reduced labels
+                    labelWidth = containerWidth / visibleLabels.length
+                }
+            }
+        }
         
         const calculateFontSize = () => {
             if (orientation === 'horizontal') {
-                const maxLabelLength = Math.max(...lastContinues.map(c => String(c.value).length))
+                const maxLabelLength = Math.max(...visibleLabels.map(c => String(c.value).length))
                 const baseSize = 14
-                const minSize = 8
+                const minSize = 9
                 const maxSize = 14
-                const averageCharWidth = 8
-                const availableWidth = labelWidth * 0.9 // Leave some margin
+                const averageCharWidth = 7
+                const availableWidth = labelWidth * 0.95 // Use more of the available space
                 const calculatedSize = (availableWidth / (maxLabelLength * averageCharWidth)) * baseSize
                 return Math.min(maxSize, Math.max(minSize, calculatedSize))
             }
@@ -524,15 +619,247 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
 
         var values = legendContainer
             .append('div')
-            .style('display', 'flex')
+            .style('display', (orientation === 'horizontal' && legendEntries[0].shape === 'continuous') ? 'block' : 'flex')
             .style('flex-direction', orientation === 'horizontal' ? 'row' : 'column')
             .style('justify-content', 'flex-start') // Left justify
             .style('width', orientation === 'horizontal' ? '100%' : 'auto')
-            .style('height', orientation === 'horizontal' ? 'auto' : (19 * lastContinues.length + 'px'))
+            .style('height', orientation === 'horizontal' ? 'auto' : (19 * visibleLabels.length + 'px'))
             .style('gap', orientation === 'horizontal' ? '0' : '0')
+            .style('position', 'relative')
+            .style('padding-left', (orientation === 'horizontal' && legendEntries[0].shape === 'continuous') ? '8px' : '0px')
+            .style('padding-right', (orientation === 'horizontal' && legendEntries[0].shape === 'continuous') ? '8px' : '0px')
+            .style('padding-bottom', (orientation === 'horizontal' && legendEntries[0].shape === 'continuous') ? '12px' : '0px')
 
+        // Create gradient using all legend entries for accurate color representation
         var gradientArray = []
-        for (let i = 0; i < lastContinues.length; i++) {
+        for (let i = 0; i < legendEntries.length; i++) {
+            if (legendEntries[i].shape == 'continuous') {
+                let color = legendEntries[i].color
+                if (i === 0)
+                    color += ' ' + (1 / legendEntries.length) * 50 + '%'
+                else if (i === legendEntries.length - 1)
+                    color += ' ' + (100 - (1 / legendEntries.length) * 50) + '%'
+                gradientArray.push(color)
+            } else {
+                gradientArray.push(
+                    legendEntries[i].color +
+                        ' ' +
+                        (i / legendEntries.length) * 100 +
+                        '%'
+                )
+                gradientArray.push(
+                    legendEntries[i].color +
+                        ' ' +
+                        ((i + 1) / legendEntries.length) * 100 +
+                        '%'
+                )
+            }
+        }
+
+        // Helper function to detect and extract units from legend values
+        const extractUnits = (values) => {
+            if (!values || values.length === 0) return { number: '', units: '' }
+            
+            const firstValue = String(values[0]).trim()
+            
+            // Find where non-numeric characters start
+            const match = firstValue.match(/^([0-9.,\-\s]+)(.*)$/)
+            if (match) {
+                const number = match[1].trim()
+                const units = match[2].trim()
+                
+                // Verify this pattern works for all values
+                const allValuesMatch = values.every(v => {
+                    const str = String(v).trim()
+                    const valMatch = str.match(/^([0-9.,\-\s]+)(.*)$/)
+                    return valMatch && valMatch[2].trim() === units
+                })
+                
+                if (allValuesMatch) {
+                    return { number, units }
+                }
+            }
+            
+            // No common units found
+            return { number: firstValue, units: '' }
+        }
+
+        // Add tick marks only for continuous legends
+        if (legendEntries.length > 0 && legendEntries[0].shape === 'continuous') {
+            for (let i = 0; i < visibleLabels.length; i++) {
+                // Calculate position for this tick mark
+                // For continuous legends, find the index in legendEntries
+                const originalIndex = legendEntries.findIndex(item => 
+                    item.value === visibleLabels[i].value && item.color === visibleLabels[i].color)
+                let tickPosition
+                if (originalIndex !== -1) {
+                    tickPosition = originalIndex / (legendEntries.length - 1)
+                } else {
+                    tickPosition = i / (visibleLabels.length - 1)
+                }
+
+                // Create tick mark
+                const tickMark = gradient
+                    .append('div')
+                    .style('position', 'absolute')
+                    .style('background', 'white')
+                    .style('mix-blend-mode', 'difference')
+                    .style('pointer-events', 'none')
+                    .style('z-index', '10')
+
+                if (orientation === 'horizontal') {
+                    // Horizontal tick marks
+                    tickMark
+                        .style('width', '1px')
+                        .style('height', '3px')
+                        .style('left', `${tickPosition * 100}%`)
+                        .style('top', '0px')
+                        .style('transform', 'translateX(-50%)')
+                    
+                    // Add a bottom tick mark for better visibility
+                    gradient
+                        .append('div')
+                        .style('position', 'absolute')
+                        .style('width', '1px')
+                        .style('height', '3px')
+                        .style('background', 'white')
+                        .style('mix-blend-mode', 'difference')
+                        .style('pointer-events', 'none')
+                        .style('z-index', '10')
+                        .style('left', `${tickPosition * 100}%`)
+                        .style('bottom', '0px')
+                        .style('transform', 'translateX(-50%)')
+                } else {
+                    // Vertical tick marks
+                    tickMark
+                        .style('width', '3px')
+                        .style('height', '1px')
+                        .style('top', `${tickPosition * 100}%`)
+                        .style('left', '0px')
+                        .style('transform', 'translateY(-50%)')
+                    
+                    // Add a right tick mark for better visibility
+                    gradient
+                        .append('div')
+                        .style('position', 'absolute')
+                        .style('width', '3px')
+                        .style('height', '1px')
+                        .style('background', 'white')
+                        .style('mix-blend-mode', 'difference')
+                        .style('pointer-events', 'none')
+                        .style('z-index', '10')
+                        .style('top', `${tickPosition * 100}%`)
+                        .style('right', '0px')
+                        .style('transform', 'translateY(-50%)')
+                }
+            }
+            
+            // Add units label above the last tick mark for horizontal continuous legends
+            if (orientation === 'horizontal') {
+                // Extract units from all visible labels
+                const values = visibleLabels.map(item => item.value)
+                const { units } = extractUnits(values)
+                
+                if (units) {
+                    // Calculate position of last tick mark
+                    const lastIndex = visibleLabels.length - 1
+                    const lastOriginalIndex = legendEntries.findIndex(item => 
+                        item.value === visibleLabels[lastIndex].value && item.color === visibleLabels[lastIndex].color)
+                    const lastTickPosition = lastOriginalIndex !== -1 ? 
+                        lastOriginalIndex / (legendEntries.length - 1) : 
+                        lastIndex / (visibleLabels.length - 1)
+                    
+                    // Add units label above the last tick mark
+                    gradient
+                        .append('div')
+                        .style('position', 'absolute')
+                        .style('right', '0px')
+                        .style('top', '-20px')
+                        .style('font-size', '12px')
+                        .style('color', 'var(--color-f)')
+                        .style('text-align', 'right')
+                        .style('white-space', 'nowrap')
+                        .style('z-index', '100')
+                        .style('background', 'var(--color-k)')
+                        .style('padding', '2px 4px')
+                        .style('border-radius', '2px')
+                        .text(units)
+                }
+            }
+        }
+        
+        // Add units label for non-continuous horizontal legends
+        if (orientation === 'horizontal' && (legendEntries.length === 0 || legendEntries[0].shape !== 'continuous')) {
+            // Extract units from all visible labels
+            const values = visibleLabels.map(item => item.value)
+            const { units } = extractUnits(values)
+            
+            if (units) {
+                const unitsLabel = r
+                    .append('div')
+                    .style('position', 'absolute')
+                    .style('top', '-20px')
+                    .style('right', '8px')
+                    .style('font-size', '12px')
+                    .style('color', 'var(--color-f)')
+                    .style('text-align', 'right')
+                    .style('white-space', 'nowrap')
+                    .style('z-index', '100')
+                    .style('background', 'var(--color-k)')
+                    .style('padding', '2px 4px')
+                    .style('border-radius', '2px')
+                    .text(units)
+            }
+        }
+
+        // Create labels using only the visible subset
+        for (let i = 0; i < visibleLabels.length; i++) {
+            // Determine if this is first or last label
+            const isFirstOrLast = i === 0 || i === visibleLabels.length - 1
+            
+            // Extract number and units from the value
+            const str = String(visibleLabels[i].value).trim()
+            
+            // Find where non-numeric characters start
+            const match = str.match(/^([0-9.,\-\s]+)(.*)$/)
+            let number, units
+            if (match) {
+                number = match[1].trim()
+                units = match[2].trim()
+            } else {
+                // Fallback: no units found
+                number = str
+                units = ''
+            }
+            
+            // For horizontal legends, show only numbers (units are displayed separately above)
+            let displayText
+            if (orientation === 'horizontal') {
+                displayText = number
+            } else {
+                // For vertical legends, show numbers only except for the first and last labels which keep units
+                if (i === 0 || i === visibleLabels.length - 1) {
+                    displayText = visibleLabels[i].value // Keep full value with units for first and last labels
+                } else {
+                    displayText = number // Show only number for intermediate labels
+                }
+            }
+
+            // Calculate the same position as the tick marks
+            let labelPosition
+            if (visibleLabels[i].shape === 'continuous') {
+                // For continuous legends, find the index in legendEntries
+                const originalIndex = legendEntries.findIndex(item => 
+                    item.value === visibleLabels[i].value && item.color === visibleLabels[i].color)
+                if (originalIndex !== -1) {
+                    labelPosition = originalIndex / (legendEntries.length - 1)
+                } else {
+                    labelPosition = i / (visibleLabels.length - 1)
+                }
+            } else {
+                labelPosition = i / (visibleLabels.length - 1)
+            }
+
             let v = values
                 .append('div')
                 .style('margin', '0')
@@ -540,52 +867,42 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
                 .style('height', '19px')
                 .style('line-height', '19px')
                 .style('font-size', `${fontSize}px`)
-                .style('position', 'relative')
                 .style('white-space', 'nowrap')
-                .style('text-align', orientation === 'horizontal' ? 'center' : 'left') // Center text in horizontal mode
-                .style('width', orientation === 'horizontal' ? `${100/lastContinues.length}%` : 'auto')
                 .style('overflow', 'hidden')
                 .style('text-overflow', 'ellipsis')
-                .attr('title', lastContinues[i].value)
-                .text(lastContinues[i].value)
+                .attr('title', visibleLabels[i].value) // Keep full value in tooltip
+                .text(displayText)
 
-            if (lastContinues[i].shape == 'continuous') {
-                v.append('div')
-                    .style('position', 'absolute')
-                    .style('width', '3px')
-                    .style('height', '1px')
-                    .style('background', 'white')
-                    .style(orientation === 'horizontal' ? 'top' : 'left', orientation === 'horizontal' ? '-23px' : '-23px')
-                    .style(orientation === 'horizontal' ? 'left' : 'top', orientation === 'horizontal' ? '10px' : '10px')
-                    .style('mix-blend-mode', 'difference')
-                v.append('div')
-                    .style('position', 'absolute')
-                    .style('width', '3px')
-                    .style('height', '1px')
-                    .style('background', 'white')
-                    .style(orientation === 'horizontal' ? 'top' : 'left', orientation === 'horizontal' ? '-9px' : '-9px')
-                    .style(orientation === 'horizontal' ? 'left' : 'top', orientation === 'horizontal' ? '10px' : '10px')
-                    .style('mix-blend-mode', 'difference')
-
-                let color = lastContinues[i].color
-                if (i === 0)
-                    color += ' ' + (1 / lastContinues.length) * 50 + '%'
-                else if (i === lastContinues.length - 1)
-                    color += ' ' + (100 - (1 / lastContinues.length) * 50) + '%'
-                gradientArray.push(color)
+            if (orientation === 'horizontal' && visibleLabels[i].shape === 'continuous') {
+                // Position labels to align exactly with tick marks for continuous legends only
+                // Adjust positioning to prevent leftmost labels from extending outside container
+                let adjustedPosition = labelPosition
+                let transform = 'translateX(-50%)'
+                
+                // For first label, shift it right to prevent left overflow
+                if (i === 0 && labelPosition < 0.1) {
+                    transform = 'translateX(0%)'
+                }
+                // Keep last label center-justified (no special transform)
+                
+                v.style('position', 'absolute')
+                 .style('left', `${adjustedPosition * 100}%`)
+                 .style('transform', transform)
+                 .style('text-align', 'center')
+                 .style('width', 'auto')
+                 .style('max-width', '80px') // Prevent overlap
+            } else if (orientation === 'horizontal') {
+                // For non-continuous horizontal legends, use original layout
+                v.style('position', 'relative')
+                 .style('text-align', visibleLabels[i].shape === 'continuous' ? 
+                     (i === 0 ? 'left' : i === visibleLabels.length - 1 ? 'right' : 'center') : 
+                     'center')
+                 .style('width', `${100/visibleLabels.length}%`)
             } else {
-                gradientArray.push(
-                    lastContinues[i].color +
-                        ' ' +
-                        (i / lastContinues.length) * 100 +
-                        '%'
-                )
-                gradientArray.push(
-                    lastContinues[i].color +
-                        ' ' +
-                        ((i + 1) / lastContinues.length) * 100 +
-                        '%'
-                )
+                // For vertical legends, keep original positioning
+                v.style('position', 'relative')
+                 .style('text-align', 'left')
+                 .style('width', 'auto')
             }
         }
 
@@ -595,6 +912,71 @@ function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {
                 ? 'linear-gradient(to right, ' + gradientArray.join(',') + ')'
                 : 'linear-gradient(to bottom, ' + gradientArray.join(',') + ')'
         )
+
+        // Add hover functionality for gradient legends
+        const tooltip = gradient
+            .append('div')
+            .style('position', 'absolute')
+            .style('background', 'rgba(0, 0, 0, 0.8)')
+            .style('color', 'white')
+            .style('padding', '4px 8px')
+            .style('border-radius', '4px')
+            .style('font-size', '12px')
+            .style('pointer-events', 'none')
+            .style('z-index', '1000')
+            .style('visibility', 'hidden')
+            .style('white-space', 'nowrap')
+
+        gradient
+            .on('mousemove', function(event) {
+                const rect = this.getBoundingClientRect()
+                let position, value
+                
+                if (orientation === 'horizontal') {
+                    const x = event.clientX - rect.left
+                    position = x / rect.width
+                } else {
+                    const y = event.clientY - rect.top
+                    position = y / rect.height // Top = min (index 0), bottom = max (index max)
+                }
+                
+                // Clamp position between 0 and 1
+                position = Math.max(0, Math.min(1, position))
+                
+                // Calculate the value based on position
+                if (legendEntries[0].shape === 'continuous') {
+                    // For continuous legends, interpolate between values
+                    const index = position * (legendEntries.length - 1)
+                    const lowerIndex = Math.floor(index)
+                    const upperIndex = Math.ceil(index)
+                    const fraction = index - lowerIndex
+                    
+                    if (lowerIndex === upperIndex) {
+                        // Exact match
+                        value = legendEntries[lowerIndex].value
+                    } else {
+                        // Interpolate between continuous values
+                        const lowerValue = parseFloat(legendEntries[lowerIndex].value) || 0
+                        const upperValue = parseFloat(legendEntries[upperIndex].value) || 0
+                        const interpolatedValue = lowerValue + (upperValue - lowerValue) * fraction
+                        value = interpolatedValue.toFixed(3).replace(/\.?0+$/, '') // Remove trailing zeros
+                    }
+                } else {
+                    // For discrete legends, map position to discrete bands
+                    const bandIndex = Math.floor(position * legendEntries.length)
+                    const clampedIndex = Math.min(bandIndex, legendEntries.length - 1)
+                    value = legendEntries[clampedIndex].value
+                }
+                
+                tooltip
+                    .style('visibility', 'visible')
+                    .style('left', (event.clientX - rect.left - 15) + 'px')
+                    .style('top', (event.clientY - rect.top - 30) + 'px')
+                    .text(value)
+            })
+            .on('mouseleave', function() {
+                tooltip.style('visibility', 'hidden')
+            })
     }
 }
 


### PR DESCRIPTION
## Purpose
- Enable an option to display legends horizontally in addition to the default of vertically.
## Proposed Changes
- New configuration option to select horizontal or vertical legend
- Display continuous or discrete legends with ticks and appropriate label sizes (will condense labels if too many for display)
- Condense units and display at the top of the legend to avoid label cluttering
- Show tooltips of legend values when hovering over the legends (any type of legend including vertical)
## Issues
- (https://github.com/NASA-AMMOS/MMGIS/issues/756)
## Testing
- Tested with various legend types and ensured existing legends work properly.
- Examples:

<img width="333" height="198" alt="Screenshot 2025-09-22 at 7 03 54 PM" src="https://github.com/user-attachments/assets/16a11344-c3a1-4759-b1ea-431a82fbaf3b" />
<p>
<img width="336" height="160" alt="Screenshot 2025-09-22 at 6 57 26 PM" src="https://github.com/user-attachments/assets/abb3e438-78c4-4c25-882b-ea786573768d" />
