### PR TITLE
#765 Add Webhook Endpoint Authorization

### DIFF
--- a/API/Backend/Webhooks/setup.js
+++ b/API/Backend/Webhooks/setup.js
@@ -7,12 +7,14 @@ let setup = {
   onceInit: (s) => {
     s.app.use(
       s.ROOT_PATH + "/api/webhooks",
+      s.ensureAdmin(),
       s.checkHeadersCodeInjection,
       routerWebhooks
     );
     if (process.env.NODE_ENV === "development") {
       s.app.use(
         s.ROOT_PATH + "/api/testwebhooks",
+        s.ensureAdmin(),
         s.checkHeadersCodeInjection,
         routerTestWebhooks
       );


### PR DESCRIPTION
Closes #765 

/api/webhooks now uses the ensureAdmin middleware.