### PR TITLE
#775 Quick select day/month/year times

### DIFF
--- a/src/essence/Ancillary/TimeUI.css
+++ b/src/essence/Ancillary/TimeUI.css
@@ -145,6 +145,7 @@
     height: 100%;
     width: 100%;
     position: absolute;
+    cursor: pointer;
 }
 .mmgisTimeUITick {
     position: absolute;
@@ -224,9 +225,23 @@
     transition: margin-top 0.2s ease-in-out;
 }
 
+#mmgisTimeUITimelineHover {
+    opacity: 0;
+    height: 100%;
+    position: absolute;
+    background: rgba(255, 255, 255, 0.1);
+    transition: opacity 0.1s ease-in-out;
+    pointer-events: none;
+    z-index: 1;
+}
+
 #mmgisTimeUIModeDropdown {
     background: var(--color-a-5);
     width: 80px;
+}
+#mmgisTimeUIQuickSelectDropdown {
+    background: var(--color-a-5);
+    width: 100px;
 }
 #mmgisTimeUIStepWithinBeyondDropdown {
     background: var(--color-a-5);
@@ -241,11 +256,13 @@
     width: 110px;
 }
 #mmgisTimeUIModeDropdown .dropy__title i,
+#mmgisTimeUIQuickSelectDropdown .dropy__title i,
 #mmgisTimeUIStepWithinBeyondDropdown .dropy__title i,
 #mmgisTimeUIStepDropdown .dropy__title i,
 #mmgisTimeUIRateDropdown .dropy__title i {
     color: var(--color-a5);
 }
+#mmgisTimeUIQuickSelectDropdown .dropy__title i,
 #mmgisTimeUIStepDropdown .dropy__title i,
 #mmgisTimeUIStepWithinBeyondDropdown .dropy__title i,
 #mmgisTimeUIRateDropdown .dropy__title i {
@@ -256,6 +273,7 @@
     padding: 14px 0px 14px 12px;
     color: var(--color-a5);
 }
+#mmgisTimeUIQuickSelectDropdown .dropy__title span,
 #mmgisTimeUIStepWithinBeyondDropdown .dropy__title span,
 #mmgisTimeUIStepDropdown .dropy__title span,
 #mmgisTimeUIRateDropdown .dropy__title span {
@@ -269,6 +287,7 @@
 }
 
 #mmgisTimeUIModeDropdown li a,
+#mmgisTimeUIQuickSelectDropdown li a,
 #mmgisTimeUIStepWithinBeyondDropdown li a,
 #mmgisTimeUIStepDropdown li a,
 #mmgisTimeUIRateDropdown li a {
@@ -321,12 +340,27 @@
     color: var(--color-a7);
 }
 
+#mmgisTimeUIQuickSelectTrigger,
 #mmgisTimeUIPlayTrigger {
     margin: 0;
     width: 40px;
     height: 40px;
     line-height: 40px;
     color: var(--color-a5);
+}
+
+#timeUIQuickSelectPopover {
+    display: none;
+    background: var(--color-a);
+    box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.4);
+    width: 100px;
+    border-top: 1px solid var(--color-a1);
+    border-bottom: 1px solid var(--color-a1);
+    transition: left 0.2s ease-out;
+}
+
+#mmgisTimeUIQuickSelectDropdown .dropy {
+    margin-bottom: 0px;
 }
 
 #timeUIPlayPopover {
@@ -337,6 +371,12 @@
     border-top: 1px solid var(--color-a1);
     border-bottom: 1px solid var(--color-a1);
     transition: left 0.2s ease-out;
+}
+
+#mmgisTimeUIQuickSelectList {
+    display: flex;
+    justify-content: space-between;
+    padding: 0;
 }
 
 #mmgisTimeUIPopoverBottom {

--- a/src/essence/Basics/Formulae_/Formulae_.js
+++ b/src/essence/Basics/Formulae_/Formulae_.js
@@ -173,11 +173,28 @@ var Formulae_ = {
                         startDate.getDate()
                     )
                 )
+
+                // Helper function to add ordinal suffix
+                function getOrdinalSuffix(day) {
+                    if (day > 3 && day < 21) return day + 'th'
+                    switch (day % 10) {
+                        case 1:
+                            return day + 'st'
+                        case 2:
+                            return day + 'nd'
+                        case 3:
+                            return day + 'rd'
+                        default:
+                            return day + 'th'
+                    }
+                }
+
                 while (currentDate < endDate) {
                     currentDate.setUTCDate(currentDate.getUTCDate() + 1)
+                    const dayNum = currentDate.getUTCDate()
                     timeStarts.push({
                         ts: Date.parse(currentDate),
-                        label: currentDate.getUTCDate(),
+                        label: getOrdinalSuffix(dayNum),
                     })
                 }
                 break
@@ -194,7 +211,7 @@ var Formulae_ = {
                     currentDate.setUTCHours(currentDate.getUTCHours() + 1)
                     timeStarts.push({
                         ts: Date.parse(currentDate),
-                        label: currentDate.getUTCHours(),
+                        label: currentDate.getUTCHours() + 'h',
                     })
                 }
                 break
@@ -212,7 +229,7 @@ var Formulae_ = {
                     currentDate.setUTCMinutes(currentDate.getUTCMinutes() + 1)
                     timeStarts.push({
                         ts: Date.parse(currentDate),
-                        label: currentDate.getUTCMinutes(),
+                        label: currentDate.getUTCMinutes() + 'm',
                     })
                 }
                 break
@@ -231,7 +248,7 @@ var Formulae_ = {
                     currentDate.setUTCSeconds(currentDate.getUTCSeconds() + 1)
                     timeStarts.push({
                         ts: Date.parse(currentDate),
-                        label: currentDate.getUTCSeconds(),
+                        label: currentDate.getUTCSeconds() + 's',
                     })
                 }
                 break
@@ -810,14 +827,14 @@ var Formulae_ = {
     },
     csvToJSON: function (csv) {
         if (csv == null) return {}
-        
+
         // Ensure csv is a string
         if (typeof csv !== 'string') {
             return {}
         }
 
         var lines = csv.split('\n')
-        lines = lines.filter(i => i.length > 0)
+        lines = lines.filter((i) => i.length > 0)
 
         var result = []
 


### PR DESCRIPTION
Summary

  Implements quick select functionality for UTC calendar periods in the TimeUI
  component, allowing users to rapidly navigate to specific time ranges through two      
  intuitive methods: a dropdown menu and timeline double-clicking.

  Changes

  New Features

  1. Quick Select Dropdown Menu
  - Added icon button in TimeUI that opens a popover with period selection dropdown
  - Supports: Decade, Year, Month, Day, Hour, Minute
  - Range mode: Selects full UTC calendar period (e.g., entire day, month, or year)
  - Point mode: Selects start of UTC calendar period
  - Dropdown auto-opens when popover is triggered and auto-closes after selection
  - Automatically disables Present mode and stops playback when selecting a period

  2. Double-Click Timeline Selection
  - Double-clicking on timeline selects the time interval at the current zoom level      
  - Adapts to current zoom: clicking on decade/year/month/day/hour/minute/second
  ticks
  - Visual feedback: hover highlight shows the period boundary before clicking
  - Tooltip: "Double-Click to Select Period"

  Enhancements

  Timeline Labels
  - Day labels now use ordinal suffixes (1st, 2nd, 3rd, ..., 31st) instead of plain      
  numbers
  - Added helper function getOrdinalSuffix() in Formulae_.js

  Visual Feedback
  - Added hover highlight (mmgisTimeUITimelineHover) that illuminates the hoverable      
  period
  - Hover highlight automatically hides during zoom operations to prevent covering       
  incorrect ranges
  - Pointer cursor indicates clickable timeline areas

  Timezone Handling
  - Fixed timezone offset bugs by consistently using .toISOString() instead of
  .toDate()
  - Ensures UTC calendar periods are correctly selected regardless of local timezone     

  Technical Details

  Special Decade Handling
  - moment.js doesn't support 'decade' as a unit, so implemented manual calculation:     
  const year = referenceTime.year()
  const decadeStart = Math.floor(year / 10) * 10
  periodStart = moment.utc().year(decadeStart).startOf('year')
  periodEnd = moment.utc().year(decadeStart + 10).startOf('year')

  Timeline Integration
  - Quick select automatically adjusts timeline window to show selected period
  - Double-click respects current mode (Range vs Point)
  - Hover highlight boundary clamping prevents UI overflow

  Files Modified

  - src/essence/Ancillary/TimeUI.js - Main implementation, quick select logic,
  double-click handler, hover effects
  - src/essence/Ancillary/TimeUI.css - Styling for quick select popover, hover
  highlight, button states
  - src/essence/Basics/Formulae_/Formulae_.js - Added ordinal day suffix helper
  function

  Test Plan

  - Test quick select dropdown in Range mode - verify full period is selected
  - Test quick select dropdown in Point mode - verify period start is selected
  - Test double-click on timeline at various zoom levels (decade, year, month, day,      
  hour, minute, second)
  - Verify hover highlight shows correct period boundaries and doesn't overflow
  - Verify hover highlight hides during zoom operations
  - Test in different timezones to ensure UTC periods are correctly selected
  - Verify Present mode is disabled when using quick select
  - Verify playback stops when using quick select
  - Test that timeline window auto-adjusts to show selected periods

  Screenshots/Demo

  [Add screenshots showing the quick select dropdown and timeline double-click
  functionality]

  ---
  🤖 Generated with https://claude.com/claude-code

  Fixes #775