### PR TITLE
#778 Support TiTiler expressions

### DIFF
--- a/configure/src/metaconfigs/layer-image-config.json
+++ b/configure/src/metaconfigs/layer-image-config.json
@@ -158,6 +158,21 @@
               "type": "colordropdown",
               "width": 3,
               "options": "{{COLORMAP_NAMES}}"
+            },
+            {
+              "field": "cogExpression",
+              "name": "Band Math Expression",
+              "description": "TiTiler/rio-tiler band math expression. Uses standard math operators (+-/*) where asset_bX represents band X of an asset (e.g., 'asset_b1*2', '(asset_b1+asset_b2)/2'). For RGB output, use semicolons (e.g., 'asset_b1;asset_b2;asset_b3'). For multiple STAC assets, use different asset names (e.g., 'assetname1_b1 + assetname2_b1'). If you omit the asset prefix (e.g., 'b1'), it will automatically default to 'asset_b1'. When specified, this replaces the 'Tile Bands' parameter.",
+              "type": "textnotrim",
+              "width": 6
+            },
+            {
+              "field": "cogExpressionEditable",
+              "name": "Allow User Expression Editing",
+              "description": "If true, users can modify the band math expression in the LayersTool settings panel.",
+              "type": "switch",
+              "width": 3,
+              "defaultChecked": false
             }
           ]
         },

--- a/configure/src/metaconfigs/layer-tile-config.json
+++ b/configure/src/metaconfigs/layer-tile-config.json
@@ -132,105 +132,6 @@
           ]
         },
         {
-          "name": "Cloud-Optimized GeoTiffs (COG)",
-          "components": [
-            {
-              "field": "throughTileServer",
-              "name": "Use TiTiler",
-              "description": "Uses the TiTiler service to serve tiles if URL is a Cloud-Optimized GeoTiff (COG). TiTiler must be configured via the .env.",
-              "type": "switch",
-              "width": 3,
-              "defaultChecked": false
-            },
-            {
-              "field": "tileMatrixSet",
-              "name": "Tile Matrix Set",
-              "description": "If using TiTiler or if using a 'stac-collection:{collection}' URL, specify the projection for which to serve the tiles. Defaults to 'WebMercatorQuad'.",
-              "type": "searchdropdown",
-              "width": 5,
-              "options": "{{TILE_MATRIX_SETS}}"
-            },
-            {
-              "field": "cogResampling",
-              "name": "Resampling Method",
-              "description": "The resampling method for generated tiles through TiTiler. Defaults to 'nearest'.",
-              "type": "dropdown",
-              "width": 4,
-              "options": [
-                "nearest",
-                "bilinear",
-                "cubic",
-                "cubic_spline",
-                "lanczos",
-                "average",
-                "mode",
-                "gauss",
-                "rms"
-              ]
-            }
-          ]
-        },
-        {
-          "components": [
-            {
-              "field": "cogBands",
-              "name": "Tile Bands",
-              "description": "Which bands from the COG from which to generate tiles. Defaults to '1,2,3' as RGB or '1' if it's a Transformed 32-bit COG. Can be a single number or a comma-separated list of numbers. Order matters.",
-              "type": "textarray",
-              "width": 4
-            },
-            {
-              "field": "cogBandsQuery",
-              "name": "Query Bands",
-              "description": "Which bands from the COG upon which to perform queries. Defaults to value of 'Tile Bands'.",
-              "type": "textarray",
-              "width": 4
-            }
-          ]
-        },
-        {
-          "subname": "32-bit COGs",
-          "components": [
-            {
-              "field": "cogTransform",
-              "name": "Transform 32-bit COG",
-              "description": "Enable rescaling and coloring 32-bit COGs on the fly. Will use TiTiler.",
-              "type": "switch",
-              "width": 3,
-              "defaultChecked": false
-            },
-            {
-              "field": "cogMin",
-              "name": "Minimum Pixel Data Value",
-              "description": "If using TiTiler, STAC and 32-bit COGs, the default minimum value for which to rescale.",
-              "type": "number",
-              "width": 2
-            },
-            {
-              "field": "cogMax",
-              "name": "Maximum Pixel Data Value",
-              "description": "If using TiTiler, STAC and 32-bit COGs, the default maximum value for which to rescale.",
-              "type": "number",
-              "width": 2
-            },
-            {
-              "field": "cogUnits",
-              "name": "Units",
-              "description": "Units string by which to suffix values. For instance if the units are meters, use 'm' so that values are displayed as '100m'.",
-              "type": "textnotrim",
-              "width": 2
-            },
-            {
-              "field": "cogColormap",
-              "name": "Colormap",
-              "description": "",
-              "type": "colordropdown",
-              "width": 3,
-              "options": "{{COLORMAP_NAMES}}"
-            }
-          ]
-        },
-        {
           "name": "Digital Elevation Model (DEM) Tiles",
           "components": [
             {
@@ -271,6 +172,131 @@
               "type": "button",
               "action": "tile-populate-from-x",
               "width": 6
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "COG",
+      "rows": [
+        {
+          "name": "TiTiler Configuration",
+          "components": [
+            {
+              "field": "throughTileServer",
+              "name": "Use TiTiler",
+              "description": "Uses the TiTiler service to serve tiles if URL is a Cloud-Optimized GeoTiff (COG). TiTiler must be configured via the .env.",
+              "type": "switch",
+              "width": 3,
+              "defaultChecked": false
+            },
+            {
+              "field": "tileMatrixSet",
+              "name": "Tile Matrix Set",
+              "description": "If using TiTiler or if using a 'stac-collection:{collection}' URL, specify the projection for which to serve the tiles. Defaults to 'WebMercatorQuad'.",
+              "type": "searchdropdown",
+              "width": 5,
+              "options": "{{TILE_MATRIX_SETS}}"
+            },
+            {
+              "field": "cogResampling",
+              "name": "Resampling Method",
+              "description": "The resampling method for generated tiles through TiTiler. Defaults to 'nearest'.",
+              "type": "dropdown",
+              "width": 4,
+              "options": [
+                "nearest",
+                "bilinear",
+                "cubic",
+                "cubic_spline",
+                "lanczos",
+                "average",
+                "mode",
+                "gauss",
+                "rms"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Bands",
+          "components": [
+            {
+              "field": "cogBands",
+              "name": "Tile Bands",
+              "description": "Which bands from the COG from which to generate tiles. Defaults to '1,2,3' as RGB or '1' if it's a Transformed Single Data Band COG. Can be a single number or a comma-separated list of numbers. Order matters.",
+              "type": "textarray",
+              "width": 4
+            },
+            {
+              "field": "cogBandsQuery",
+              "name": "Query Bands",
+              "description": "Which bands from the COG upon which to perform queries. Defaults to value of 'Tile Bands'.",
+              "type": "textarray",
+              "width": 4
+            }
+          ]
+        },
+        {
+          "subname": "Band Math Expression",
+          "components": [
+            {
+              "field": "cogExpression",
+              "name": "Band Math Expression",
+              "description": "TiTiler/rio-tiler band math expression. Uses standard math operators (+-/*) where asset_bX represents band X of an asset (e.g., 'asset_b1*2', '(asset_b1+asset_b2)/2'). For RGB output, use semicolons (e.g., 'asset_b1;asset_b2;asset_b3'). For multiple STAC assets, use different asset names (e.g., 'assetname1_b1 + assetname2_b1'). If you omit the asset prefix (e.g., 'b1'), it will automatically default to 'asset_b1'. When specified, this replaces the 'Tile Bands' parameter.",
+              "type": "textnotrim",
+              "width": 9
+            },
+            {
+              "field": "cogExpressionEditable",
+              "name": "Allow User Expression Editing",
+              "description": "If true, users can modify the band math expression in the LayersTool settings panel.",
+              "type": "switch",
+              "width": 3,
+              "defaultChecked": false
+            }
+          ]
+        },
+        {
+          "name": "Single Data Band COG Transformation",
+          "components": [
+            {
+              "field": "cogTransform",
+              "name": "Transform Single Data Band COG",
+              "description": "Enable rescaling and coloring Single Data Band COGs on the fly. Will use TiTiler.",
+              "type": "switch",
+              "width": 3,
+              "defaultChecked": false
+            },
+            {
+              "field": "cogMin",
+              "name": "Minimum Pixel Data Value",
+              "description": "If using TiTiler, STAC and Single Data Band COGs, the default minimum value for which to rescale.",
+              "type": "number",
+              "width": 2
+            },
+            {
+              "field": "cogMax",
+              "name": "Maximum Pixel Data Value",
+              "description": "If using TiTiler, STAC and Single Data Band COGs, the default maximum value for which to rescale.",
+              "type": "number",
+              "width": 2
+            },
+            {
+              "field": "cogUnits",
+              "name": "Units",
+              "description": "Units string by which to suffix values. For instance if the units are meters, use 'm' so that values are displayed as '100m'.",
+              "type": "textnotrim",
+              "width": 2
+            },
+            {
+              "field": "cogColormap",
+              "name": "Colormap",
+              "description": "",
+              "type": "colordropdown",
+              "width": 3,
+              "options": "{{COLORMAP_NAMES}}"
             }
           ]
         }

--- a/src/essence/Basics/Layers_/leaflet-tilelayer-middleware.js
+++ b/src/essence/Basics/Layers_/leaflet-tilelayer-middleware.js
@@ -64,6 +64,21 @@ var colorFilterExtension = {
                 }
             }
 
+            // Add expression parameter if it exists (takes precedence over bands)
+            // Check currentCogExpression first (runtime value), then fall back to cogExpression (configured value)
+            const expressionToUse = this.options.currentCogExpression || this.options.cogExpression
+            if (expressionToUse && expressionToUse.trim() !== '') {
+                // Process expression to add asset_ prefix if needed
+                const processExpression = (expression) => {
+                    if (!expression || expression.trim() === '') return expression
+                    // Replace bX or BX (where X is a number) with asset_bX or asset_BX
+                    // Only replace if not already prefixed with an asset name (word_bX pattern)
+                    return expression.replace(/(?<!\w)([bB])(\d+)/g, 'asset_$1$2')
+                }
+                const processedExpression = processExpression(expressionToUse)
+                url += `${url.indexOf('?') === -1 ? '?' : '&'}expression=${encodeURIComponent(processedExpression)}`
+            }
+
             if (mmgisglobal.options?.stac?.mosaicItemLimit != null) {
                 url += `${url.indexOf('?') === -1 ? '?' : '&'}items_limit=${
                     mmgisglobal.options.stac.mosaicItemLimit

--- a/src/essence/Tools/Layers/LayersTool.css
+++ b/src/essence/Tools/Layers/LayersTool.css
@@ -402,6 +402,7 @@
 #layersTool .reload,
 #layersTool .reset,
 #layersTool .resetCog,
+#layersTool .tileexpressionreset,
 #layersTool .layerDownload,
 #layersTool .gears,
 #layersTool .locate,
@@ -431,15 +432,18 @@
     background: var(--color-k);
 }
 #layersTool .reset:hover,
-#layersTool .resetCog:hover {
+#layersTool .resetCog:hover,
+#layersTool .layerSettingsTitle .tileexpressionreset:hover {
     color: white;
 }
 #layersTool .reset,
-#layersTool .resetCog {
+#layersTool .resetCog,
+#layersTool .layerSettingsTitle .tileexpressionreset {
     display: none;
 }
 #layersTool #layersToolList > li.gears_on .reset,
-#layersTool #layersToolList > li.gears_on .resetCog {
+#layersTool #layersToolList > li.gears_on .resetCog,
+#layersTool #layersToolList > li.gears_on .layerSettingsTitle .tileexpressionreset {
     display: block;
 }
 
@@ -916,4 +920,78 @@
     font-size: 12px;
     color: var(--color-a4);
     font-family: monospace;
+}
+
+/* Band Math Expression Editor */
+#layersTool .tileCogExpression {
+    padding: 8px 0;
+}
+
+#layersTool .tileCogExpression > div:last-child {
+    display: block !important;
+}
+
+#layersTool .tileCogExpressionl {
+    font-size: 12px;
+    margin-bottom: 4px;
+}
+
+#layersTool .tileexpression {
+    width: 100%;
+    border: none;
+    background: #222;
+    color: #ddd;
+    height: 30px;
+    padding: 4px 8px;
+    font-family: monospace;
+}
+
+#layersTool .tileexpression:focus {
+    outline: none;
+    border-color: var(--color-p4);
+}
+
+#layersTool .expression-helper-text {
+    font-size: 13px !important;
+    color: var(--color-a6) !important;
+    margin-top: 6px;
+    font-style: italic;
+    line-height: 18px;
+}
+
+#layersTool .expression-stac-info {
+    font-size: 12px;
+    color: var(--color-a6);
+    margin-top: 6px;
+    line-height: 16px;
+    display: none;
+}
+
+#layersTool .stac-header {
+    color: var(--color-a7);
+    font-weight: 500;
+    margin-bottom: 4px;
+}
+
+#layersTool .stac-band-item {
+    margin-left: 12px;
+    line-height: 18px;
+}
+
+#layersTool .expression-buttons {
+    height: 30px;
+    display: flex;
+}
+
+#layersTool .tileexpressionapply {
+    border: none;
+    padding: 4px 12px;
+    cursor: pointer;
+    font-size: 12px;
+    background: #3b8dd8;
+    color: white;
+}
+
+#layersTool .tileexpressionapply:hover {
+    background: #2a7fc7;
 }

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -270,7 +270,12 @@ var LayersTool = {
         canvasElement.width = 256
         canvasElement.height = 1
         const context = canvasElement.getContext('2d')
-        if (imgElement && imgElement.complete && imgElement.naturalHeight !== 0 && layer.type === 'tile') {
+        if (
+            imgElement &&
+            imgElement.complete &&
+            imgElement.naturalHeight !== 0 &&
+            layer.type === 'tile'
+        ) {
             context.drawImage(imgElement, 0, 0, 256, 1, 0, 0, 256, 1)
         }
 
@@ -299,7 +304,12 @@ var LayersTool = {
             }
 
             let color
-            if (imgElement && imgElement.complete && imgElement.naturalHeight !== 0 && layer.type === 'tile') {
+            if (
+                imgElement &&
+                imgElement.complete &&
+                imgElement.naturalHeight !== 0 &&
+                layer.type === 'tile'
+            ) {
                 const c = context.getImageData(
                     parseInt((255 / 9) * i),
                     0,
@@ -311,7 +321,9 @@ var LayersTool = {
                 layer.type === 'image' ||
                 layer.type === 'velocity' ||
                 !imgElement ||
-                (imgElement && imgElement.naturalHeight === 0 && layer.type === 'tile')
+                (imgElement &&
+                    imgElement.naturalHeight === 0 &&
+                    layer.type === 'tile')
             ) {
                 const layerColormap = ['tile', 'image'].includes(layer.type)
                     ? layer.cogColormap
@@ -592,16 +604,16 @@ function interfaceWithMMGIS(fromInit) {
             }
 
             function additionalSettingsJSColormapHelper(colormap, reverse) {
-                let additionalSettings = colormapData[
-                    colormap
-                ].colors.map((hex) => {
-                    let rgb = hex
-                        .map((v) => {
-                            return Math.floor(v * 255)
-                        })
-                        .join(',')
-                    return `<div style="background: rgb(${rgb}); width: 20px; height: 100%; margin: 0px; flex-grow: 1;"></div>`
-                })
+                let additionalSettings = colormapData[colormap].colors.map(
+                    (hex) => {
+                        let rgb = hex
+                            .map((v) => {
+                                return Math.floor(v * 255)
+                            })
+                            .join(',')
+                        return `<div style="background: rgb(${rgb}); width: 20px; height: 100%; margin: 0px; flex-grow: 1;"></div>`
+                    }
+                )
 
                 if (reverse === true) {
                     additionalSettings.reverse()
@@ -672,17 +684,52 @@ function interfaceWithMMGIS(fromInit) {
                     }
 
                     additionalSettings = ''
-                    if (
-                        node[i].cogTransform === true &&
+                    let expressionSettings = ''
+
+                    // Check if layer supports expressions (COG or STAC)
+                    const supportsExpressions =
                         typeof node[i].url === 'string' &&
                         (node[i].url.split(':')[0] === 'stac-collection' ||
                             node[i].url.split(':')[0] === 'COG')
+
+                    // Add expression editor if cogExpressionEditable is true and layer supports expressions
+                    if (
+                        supportsExpressions &&
+                        node[i].cogExpressionEditable === true
                     ) {
-                        let { colormap, reverse } =
-                            LayersTool.findJSColormap(
-                                node[i],
-                                node[i].cogColormap
-                            )
+                        // Check currentCogExpression first (runtime value), then fall back to cogExpression (configured value)
+                        const currentExpression =
+                            node[i].currentCogExpression ||
+                            node[i].cogExpression ||
+                            ''
+                        // prettier-ignore
+                        expressionSettings = [
+                            '<div class="layerSettingsTitle">',
+                                '<div>Band Math Expression</div>',
+                                `<div class="tileexpressionreset" title="Reset Expression to Default" layername="${node[i].name}">`,
+                                    '<i class="mdi mdi-restore mdi-18px"></i>',
+                                '</div>',
+                            '</div>',
+                            `<li class="tileCogExpression">`,
+                                '<div>',
+                                    `<input class="tileexpression" layername="${node[i].name}" type="text" value="${currentExpression}" placeholder="e.g., b1*2 or asset_b1*2">`,
+                                    '<div class="expression-buttons">',
+                                        `<button class="tileexpressionapply" layername="${node[i].name}">Apply</button>`,
+                                    '</div>',
+                                '</div>',
+                                '<div>',
+                                    '<div class="expression-helper-text">Use asset_bX for bands (e.g., asset_b1, asset_b2). Supports math operators: +, -, *, /, () for grouping. For RGB output: asset_b1;asset_b2;asset_b3. Shorthand bX will auto-prefix to asset_bX.</div>',
+                                    `<div class="expression-stac-info" data-layername="${node[i].name}"></div>`,
+                                '</div>',
+                            '</li>',
+                        ].join('\n')
+                    }
+
+                    if (node[i].cogTransform === true && supportsExpressions) {
+                        let { colormap, reverse } = LayersTool.findJSColormap(
+                            node[i],
+                            node[i].cogColormap
+                        )
 
                         if (window.mmgisglobal.WITH_TITILER === 'true') {
                             // prettier-ignore
@@ -693,7 +740,11 @@ function interfaceWithMMGIS(fromInit) {
                                 data-colormap="${colormap}" data-colormap-reverse="${reverse}"></img>`,
                             ].join('\n')
                         } else {
-                            additionalSettings = additionalSettingsJSColormapHelper(colormap, reverse)
+                            additionalSettings =
+                                additionalSettingsJSColormapHelper(
+                                    colormap,
+                                    reverse
+                                )
                         }
 
                         // prettier-ignore
@@ -719,7 +770,7 @@ function interfaceWithMMGIS(fromInit) {
                             '<li id="tileCogLegend_4" class="tileCogLegend">-</li>',
                             '<li id="tileCogLegend_3" class="tileCogLegend">-</li>',
                             '<li id="tileCogLegend_2" class="tileCogLegend">-</li>',
-                            '<li id="tileCogLegend_1" class="tileCogLegend">-</li>',    
+                            '<li id="tileCogLegend_1" class="tileCogLegend">-</li>',
                             `<li class="tileCogMin">`,
                                 '<div>',
                                     '<div>Rescale Min Value</div>',
@@ -736,8 +787,12 @@ function interfaceWithMMGIS(fromInit) {
                                         `<ul id="tileCogColormapMapLines"></ul>`,
                                     `</div>`,
                                 '</li>',
-                            '</div>'
+                            '</div>',
+                            expressionSettings
                         ].join('\n')
+                    } else if (expressionSettings) {
+                        // If only expression settings (no COG transform), just show expression editor
+                        additionalSettings = expressionSettings
                     }
                     // prettier-ignore
                     settings = [
@@ -863,11 +918,10 @@ function interfaceWithMMGIS(fromInit) {
                         currentOpacity = L_.layers.opacity[node[i].name]
 
                     if (node[i].kind === 'streamlines') {
-                        let { colormap, reverse } =
-                            LayersTool.findJSColormap(
-                                node[i],
-                                node[i].variables?.streamlines?.colorScale
-                            )
+                        let { colormap, reverse } = LayersTool.findJSColormap(
+                            node[i],
+                            node[i].variables?.streamlines?.colorScale
+                        )
 
                         if (window.mmgisglobal.WITH_TITILER === 'true') {
                             // prettier-ignore
@@ -878,7 +932,11 @@ function interfaceWithMMGIS(fromInit) {
                                 data-colormap="${colormap}" data-colormap-reverse="${reverse}"></img>`,
                             ].join('\n')
                         } else {
-                            additionalSettings = additionalSettingsJSColormapHelper(colormap, reverse)
+                            additionalSettings =
+                                additionalSettingsJSColormapHelper(
+                                    colormap,
+                                    reverse
+                                )
                         }
 
                         // prettier-ignore
@@ -950,12 +1008,10 @@ function interfaceWithMMGIS(fromInit) {
                         L_.layers.layer[node[i].name].georasters[0]
                             .numberOfRasters === 1
                     ) {
-
-                        let { colormap, reverse } =
-                            LayersTool.findJSColormap(
-                                node[i],
-                                node[i].cogColormap
-                            )
+                        let { colormap, reverse } = LayersTool.findJSColormap(
+                            node[i],
+                            node[i].cogColormap
+                        )
 
                         if (window.mmgisglobal.WITH_TITILER === 'true') {
                             // prettier-ignore
@@ -966,7 +1022,11 @@ function interfaceWithMMGIS(fromInit) {
                                 data-colormap="${colormap}" data-colormap-reverse="${reverse}"></img>`,
                             ].join('\n')
                         } else {
-                            additionalSettings = additionalSettingsJSColormapHelper(colormap, reverse)
+                            additionalSettings =
+                                additionalSettingsJSColormapHelper(
+                                    colormap,
+                                    reverse
+                                )
                         }
 
                         // prettier-ignore
@@ -1262,15 +1322,20 @@ function interfaceWithMMGIS(fromInit) {
             if (window.mmgisglobal.WITH_TITILER === 'true') {
                 // Check if TiTiler images loaded
                 if ($(`#titlerCogColormapImage_${node[i].name}`).length) {
-                    $(`#titlerCogColormapImage_${node[i].name}`)
-                        .on('error', function() {
+                    $(`#titlerCogColormapImage_${node[i].name}`).on(
+                        'error',
+                        function () {
                             // Fallback to colormap JS library
                             var t = $(this).first()
                             t.parent().prepend(
-                                additionalSettingsJSColormapHelper(t.data('colormap'), t.data('colormap-reverse'))
+                                additionalSettingsJSColormapHelper(
+                                    t.data('colormap'),
+                                    t.data('colormap-reverse')
+                                )
                             )
                             t.remove()
-                        })
+                        }
+                    )
                 }
             }
 
@@ -1460,6 +1525,80 @@ function interfaceWithMMGIS(fromInit) {
         $('.layerDownload').parent().parent().removeClass('download_on')
         $('.gears').parent().parent().removeClass('gears_on')
         if (!wasOn) li.addClass('gears_on')
+
+        // Fetch STAC asset/band info if applicable
+        if (!wasOn && type === 'tile') {
+            const layerUUID = L_.asLayerUUID(layerName)
+            const layerData = L_.layers.data[layerUUID]
+
+            // Check if this is a STAC collection layer with expression editing enabled
+            if (
+                layerData.url?.startsWith('stac-collection:') &&
+                layerData.cogExpressionEditable === true
+            ) {
+                const collectionName = layerData.url
+                    .split('stac-collection:')[1]
+                    .split('?')[0]
+
+                // Fetch STAC items (lazy load on first open)
+                const stacUrl = `${window.location.origin}${(
+                    window.location.pathname || ''
+                ).replace(
+                    /\/$/g,
+                    ''
+                )}/stac/collections/${collectionName}/items?limit=1`
+
+                fetch(stacUrl)
+                    .then((response) => response.json())
+                    .then((data) => {
+                        if (data.features && data.features.length > 0) {
+                            const assets = data.features[0].assets
+                            const bandList = []
+
+                            // Parse each asset and its bands, combining into asset_band format
+                            for (const [assetName, assetData] of Object.entries(
+                                assets
+                            )) {
+                                const bands = assetData['eo:bands'] || []
+
+                                // Combine asset name with band name
+                                if (bands.length > 0) {
+                                    bands.forEach((b) => {
+                                        const fullBandName = `${assetName}_${b.name}`
+                                        const description = b.description
+                                            ? ` (${b.description})`
+                                            : ''
+                                        bandList.push(
+                                            `<div class="stac-band-item">${fullBandName}${description}</div>`
+                                        )
+                                    })
+                                } else {
+                                    bandList.push(
+                                        `<div class="stac-band-item">${assetName} (no band info)</div>`
+                                    )
+                                }
+                            }
+
+                            // Update the info display
+                            const infoDiv = li.find(
+                                `.expression-stac-info[data-layername="${layerName}"]`
+                            )
+                            if (bandList.length > 0) {
+                                infoDiv.html(
+                                    `<div class="stac-header">Available Assets:</div>${bandList.join(
+                                        ''
+                                    )}`
+                                )
+                                infoDiv.show()
+                            }
+                        }
+                    })
+                    .catch((err) => {
+                        // Silently fail - don't show the section
+                        console.warn('Failed to fetch STAC asset info:', err)
+                    })
+            }
+        }
 
         //Support Filtering 1
         if (['vector', 'query'].includes(type)) {
@@ -1832,6 +1971,80 @@ function interfaceWithMMGIS(fromInit) {
         }
 
         LayersTool.populateCogScale(layer.name)
+        LegendTool.refreshLegends()
+    })
+
+    // Expression Apply button handler
+    $('.tileexpressionapply').on('click', function () {
+        let layerName = $(this).attr('layername')
+        let layerUUID = L_.asLayerUUID(layerName)
+        let layer = L_.layers.data[layerUUID]
+
+        if (L_.layers.layer[layer.name] === null) return
+
+        // Get the expression value from the input - look for it in the closest li.tileCogExpression
+        const expressionInput = $(this)
+            .closest('li.tileCogExpression')
+            .find('.tileexpression')
+        const newExpression = expressionInput.val().trim()
+
+        // Update the layer's currentCogExpression (runtime value) in the layer data
+        layer.currentCogExpression = newExpression
+
+        // Also update in the original layers configuration if it exists
+        if (L_.layers.data[layerUUID]) {
+            L_.layers.data[layerUUID].currentCogExpression = newExpression
+        }
+
+        // Refresh the layer to apply the expression, passing it as an update option
+        if (layer.type === 'tile') {
+            L_.layers.layer[layer.name].refresh(null, true, {
+                currentCogExpression: newExpression,
+            })
+        } else if (layer.type === 'image') {
+            L_.layers.layer[layer.name].refresh(null, true, {
+                currentCogExpression: newExpression,
+            })
+        }
+
+        // Refresh legends in case they're affected
+        LegendTool.refreshLegends()
+    })
+
+    // Expression Reset button handler
+    $('.tileexpressionreset').on('click', function () {
+        let layerName = $(this).attr('layername')
+        let layerUUID = L_.asLayerUUID(layerName)
+        const layerData = L_.layers.data[layerUUID]
+
+        if (L_.layers.layer[layerData.name] === null) return
+
+        // Get the original/configured expression (cogExpression is never modified, only currentCogExpression is)
+        const originalExpression = layerData.cogExpression || ''
+
+        // Reset currentCogExpression to the original/configured expression
+        // Setting it to null/undefined will make the system fall back to cogExpression
+        layerData.currentCogExpression = null
+
+        // Update the input field - the reset button is in the title, find the next li.tileCogExpression
+        $(this)
+            .closest('.layerSettingsTitle')
+            .next('li.tileCogExpression')
+            .find('.tileexpression')
+            .val(originalExpression)
+
+        // Refresh the layer, passing currentCogExpression as null to use the original
+        if (layerData.type === 'tile') {
+            L_.layers.layer[layerData.name].refresh(null, true, {
+                currentCogExpression: null,
+            })
+        } else if (layerData.type === 'image') {
+            L_.layers.layer[layerData.name].refresh(null, true, {
+                currentCogExpression: null,
+            })
+        }
+
+        // Refresh legends
         LegendTool.refreshLegends()
     })
 


### PR DESCRIPTION
Closes #778

_With Claude (bedrock)_

- TiTiler tile layer support band math expressions
- As does the IdentifierTool
- User can, if configured to permit them to, modify the expression within the given layer's LayersTool settings. 
- The Admin can configure the default band math expression for COG raster layers
- The Admin can also configure whether users will be able to customize the band math expression in the LayersTool raster layer settings or not.
- The COG settings for tile layers in the configure page has moved the Core Tab to a new COG tab.

### Expression Syntax
Expressions seem to be mainly a standard math expression ()+-/*  where bX (or BX) (where X is the band number) are the variables for bands. I'm not sure if you'll need to worry about this part but, when constructing an RGB image from an expression, it would use ; to denote each output band (so red_expression;green_expression;blue_expression). To represent a different asset within the STAC item, use a `_` between the asset name and band: `assetname_bX`

Example: `asset1_b1 + asset2_b1 / assest3_b1 + 50`

### Images

<img width="341" height="704" alt="Screenshot 2025-10-23 140738" src="https://github.com/user-attachments/assets/f092bfb7-7cc2-453d-b916-d8b566b2859b" />


<img width="1971" height="898" alt="Screenshot 2025-10-23 140829" src="https://github.com/user-attachments/assets/e8512515-0258-4a68-915f-8f4d759796af" />
