### PR TITLE
Fix issue with local versus UTC time in expanded timeline display

### DIFF
--- a/src/essence/Ancillary/TimeUI.js
+++ b/src/essence/Ancillary/TimeUI.js
@@ -1878,156 +1878,17 @@ const TimeUI = {
         // Populate Hours Row
         TimeUI._populateHoursRow()
 
-        // Update range indicators
-        TimeUI._updateRangeIndicators()
-
-        // Update highlighted buttons as range if mobile
-        if (L_.UserInterface_?.isMobile === true) {
+        if (L_.UserInterface_?.isMobile !== true) {
+            // Update range indicators
+            TimeUI._updateRangeIndicators()
+        } else {
+            // Update highlighted buttons as range if mobile
             TimeUI._updateRangeIndicatorsMobile()
         }
 
         // Convert UTC timestamps to local time using addOffset to match display
         const startTime = moment(TimeUI.removeOffset(TimeUI._startTimestamp))
         const endTime = moment(TimeUI.removeOffset(TimeUI._endTimestamp))
-    },
-    _calculateRangePositionsMobile(containerType) {
-        // Use UTC timestamps
-        const startTime = moment.utc(moment(TimeUI.removeOffset(TimeUI._startTimestamp)))
-        const endTime = moment.utc(moment(TimeUI.removeOffset(TimeUI._endTimestamp)))
-
-        let startPeriod = null
-        let endPeriod = null
-
-        if (containerType === 'years') {
-            startPeriod = moment(TimeUI._startTimestamp).year()
-            endPeriod = moment(TimeUI._endTimestamp).year()
-        } else if (containerType === 'months') {
-            // Calculate fractional range for months row (12 months)
-            const selectedYear = moment(TimeUI._endTimestamp).year()
-            const totalMonths = 12
-            // Calculate start position
-            if (startTime.year() === selectedYear) {
-                startPeriod = startTime.month()
-            } else if (startTime.year() < selectedYear) {
-                startPeriod = 0
-            } else {
-                startPeriod = 11
-            }
-
-            // Calculate end position
-            if (endTime.year() === selectedYear) {
-                const endMonthBegin = moment.utc([
-                    selectedYear,
-                    endTime.month(),
-                    1,
-                ])
-                endPeriod = endTime.month()
-            } else if (endTime.year() > selectedYear) {
-                endPeriod = 11
-            } else {
-                endPeriod = 0
-            }
-
-        } else if (containerType === 'days') {
-            // Calculate fractional range for days row
-            const selectedYear = moment(
-                TimeUI.removeOffset(TimeUI._endTimestamp)
-            ).year()
-            const selectedMonth = moment(
-                TimeUI.removeOffset(TimeUI._endTimestamp)
-            ).month()
-            const daysInMonth = moment(
-                TimeUI.removeOffset(TimeUI._endTimestamp)
-            ).daysInMonth()
-
-            // Calculate start position
-            if (
-                startTime.year() === selectedYear &&
-                startTime.month() === selectedMonth
-            ) {
-                startPeriod = startTime.date()
-            } else if (
-                startTime.isBefore(moment([selectedYear, selectedMonth, 1]))
-            ) {
-                startPeriod = 0
-            } else {
-                startPeriod = daysInMonth
-            }
-
-            // Calculate end position
-            if (
-                endTime.year() === selectedYear &&
-                endTime.month() === selectedMonth
-            ) {
-                endPeriod = endTime.date()
-            } else if (
-                endTime.isAfter(
-                    moment([selectedYear, selectedMonth, daysInMonth]).endOf(
-                        'day'
-                    )
-                )
-            ) {
-                endPeriod = daysInMonth
-            } else {
-                endPeriod = 0
-            }
-        } else if (containerType === 'hours') {
-            // Calculate fractional range for hours row (24 hours)
-            const selectedYear = moment(
-                TimeUI.removeOffset(TimeUI._endTimestamp)
-            ).year()
-            const selectedMonth = moment(
-                TimeUI.removeOffset(TimeUI._endTimestamp)
-            ).month()
-            const selectedDay = moment(
-                TimeUI.removeOffset(TimeUI._endTimestamp)
-            ).date()
-            const totalHours = 24
-
-            // Calculate start position
-            if (
-                startTime.year() === selectedYear &&
-                startTime.month() === selectedMonth &&
-                startTime.date() === selectedDay
-            ) {
-                startPeriod = startTime.hour()
-            } else if (
-                startTime.isBefore(
-                    moment([selectedYear, selectedMonth, selectedDay])
-                )
-            ) {
-                startPeriod = 0
-            } else {
-                startPeriod = totalHours
-            }
-
-            // Calculate end position
-            if (
-                endTime.year() === selectedYear &&
-                endTime.month() === selectedMonth &&
-                endTime.date() === selectedDay
-            ) {
-                endPeriod = endTime.hour()
-            } else if (
-                endTime.isAfter(
-                    moment([
-                        selectedYear,
-                        selectedMonth,
-                        selectedDay,
-                        23,
-                    ]).endOf('hour')
-                )
-            ) {
-                endPeriod = totalHours
-            } else {
-                endPeriod = 0
-            }
-        }
-
-        return {
-            startPeriod,
-            endPeriod,
-        }
     },
     _calculateRangePositions(containerType) {
         // Convert UTC timestamps to local time using addOffset to match display
@@ -2038,6 +1899,9 @@ const TimeUI = {
 
         let startPercent = 0
         let endPercent = 100
+
+        let startPeriod = null
+        let endPeriod = null
 
         if (containerType === 'years') {
             // Calculate fractional range for years row (last 20 years)
@@ -2067,6 +1931,8 @@ const TimeUI = {
                 ((endTime.year() - firstVisibleYear + endYearFraction) /
                     totalYears) *
                 100
+            startPeriod = moment(TimeUI._startTimestamp).year()
+            endPeriod = moment(TimeUI._endTimestamp).year()
         } else if (containerType === 'months') {
             // Calculate fractional range for months row (12 months)
             const selectedYear = moment.utc(moment(
@@ -2092,10 +1958,13 @@ const TimeUI = {
                 startPercent =
                     ((startTime.month() + startMonthFraction) / totalMonths) *
                     100
+                startPeriod = startTime.month()
             } else if (startTime.year() < selectedYear) {
                 startPercent = 0
+                startPeriod = 0
             } else {
                 startPercent = 100
+                startPeriod = 11
             }
 
             // Calculate end position
@@ -2115,10 +1984,13 @@ const TimeUI = {
                     (endMonthEnd.valueOf() - endMonthBegin.valueOf())
                 endPercent =
                     ((endTime.month() + endMonthFraction) / totalMonths) * 100
+                endPeriod = endTime.month()
             } else if (endTime.year() > selectedYear) {
                 endPercent = 100
+                endPeriod = 11
             } else {
                 endPercent = 0
+                endPeriod = 0
             }
         } else if (containerType === 'days') {
             // Calculate fractional range for days row
@@ -2150,12 +2022,15 @@ const TimeUI = {
                 startPercent =
                     ((startTime.date() - 1 + startDayFraction) / daysInMonth) *
                     100
+                startPeriod = startTime.date()
             } else if (
                 startTime.isBefore(moment([selectedYear, selectedMonth, 1]))
             ) {
                 startPercent = 0
+                startPeriod = 0
             } else {
                 startPercent = 100
+                endPeriod = 0
             }
 
             // Calculate end position
@@ -2174,6 +2049,7 @@ const TimeUI = {
                     (endDayEnd.valueOf() - endDayBegin.valueOf())
                 endPercent =
                     ((endTime.date() - 1 + endDayFraction) / daysInMonth) * 100
+                endPeriod = endTime.date()
             } else if (
                 endTime.isAfter(
                     moment([selectedYear, selectedMonth, daysInMonth]).endOf(
@@ -2182,6 +2058,7 @@ const TimeUI = {
                 )
             ) {
                 endPercent = 100
+                endPeriod = daysInMonth
             } else {
                 endPercent = 0
             }
@@ -2226,14 +2103,17 @@ const TimeUI = {
                     (startHourEnd.valueOf() - startHourBegin.valueOf())
                 startPercent =
                     ((startTime.hour() + startHourFraction) / totalHours) * 100
+                startPeriod = startTime.hour()
             } else if (
                 startTime.isBefore(
                     moment([selectedYear, selectedMonth, selectedDay])
                 )
             ) {
                 startPercent = 0
+                startPeriod = 0
             } else {
                 startPercent = 100
+                startPeriod = totalHours
             }
 
             // Calculate end position
@@ -2263,6 +2143,7 @@ const TimeUI = {
                     (endHourEnd.valueOf() - endHourBegin.valueOf())
                 endPercent =
                     ((endTime.hour() + endHourFraction) / totalHours) * 100
+                endPeriod = endTime.hour()
             } else if (
                 endTime.isAfter(
                     moment([
@@ -2274,8 +2155,10 @@ const TimeUI = {
                 )
             ) {
                 endPercent = 100
+                endPeriod = totalHours
             } else {
                 endPercent = 0
+                endPeriod = 0
             }
         }
 
@@ -2293,6 +2176,8 @@ const TimeUI = {
         return {
             left: startPercent,
             width: widthPercent,
+            startPeriod,
+            endPeriod,
         }
     },
     _updateRangeIndicators() {
@@ -2344,10 +2229,10 @@ const TimeUI = {
         )
     },
     _updateRangeIndicatorsMobile() {
-        const yearsRange = TimeUI._calculateRangePositionsMobile('years')
-        const monthsRange = TimeUI._calculateRangePositionsMobile('months')
-        const daysRange = TimeUI._calculateRangePositionsMobile('days')
-        const hoursRange = TimeUI._calculateRangePositionsMobile('hours')
+        const yearsRange = TimeUI._calculateRangePositions('years')
+        const monthsRange = TimeUI._calculateRangePositions('months')
+        const daysRange = TimeUI._calculateRangePositions('days')
+        const hoursRange = TimeUI._calculateRangePositions('hours')
 
         const applyMobileRange = (
             containerSelector,

--- a/src/essence/Ancillary/TimeUI.js
+++ b/src/essence/Ancillary/TimeUI.js
@@ -1892,8 +1892,8 @@ const TimeUI = {
     },
     _calculateRangePositionsMobile(containerType) {
         // Use UTC timestamps
-        const startTime = moment.utc(moment(TimeUI.removeOffset(TimeUI._startTimestamp))).utc()
-        const endTime = moment.utc(moment(TimeUI.removeOffset(TimeUI._endTimestamp))).utc()
+        const startTime = moment.utc(moment(TimeUI.removeOffset(TimeUI._startTimestamp)))
+        const endTime = moment.utc(moment(TimeUI.removeOffset(TimeUI._endTimestamp)))
 
         let startPeriod = null
         let endPeriod = null
@@ -2031,8 +2031,9 @@ const TimeUI = {
     },
     _calculateRangePositions(containerType) {
         // Convert UTC timestamps to local time using addOffset to match display
-        const startTime = moment(TimeUI.removeOffset(TimeUI._startTimestamp))
-        const endTime = moment(TimeUI.removeOffset(TimeUI._endTimestamp))
+        const startTime = moment.utc(moment(TimeUI.removeOffset(TimeUI._startTimestamp)))
+        const endTime = moment.utc(moment(TimeUI.removeOffset(TimeUI._endTimestamp)))
+
         const mode = TimeUI.modes[TimeUI.modeIndex]
 
         let startPercent = 0
@@ -2068,9 +2069,9 @@ const TimeUI = {
                 100
         } else if (containerType === 'months') {
             // Calculate fractional range for months row (12 months)
-            const selectedYear = moment(
+            const selectedYear = moment.utc(moment(
                 TimeUI.removeOffset(TimeUI._endTimestamp)
-            ).year()
+            )).year()
             const totalMonths = 12
 
             // Calculate start position
@@ -2121,15 +2122,15 @@ const TimeUI = {
             }
         } else if (containerType === 'days') {
             // Calculate fractional range for days row
-            const selectedYear = moment(
+            const selectedYear = moment.utc(moment(
                 TimeUI.removeOffset(TimeUI._endTimestamp)
-            ).year()
-            const selectedMonth = moment(
+            )).year()
+            const selectedMonth = moment.utc(moment(
                 TimeUI.removeOffset(TimeUI._endTimestamp)
-            ).month()
-            const daysInMonth = moment(
+            )).month()
+            const daysInMonth = moment.utc(moment(
                 TimeUI.removeOffset(TimeUI._endTimestamp)
-            ).daysInMonth()
+            )).daysInMonth()
 
             // Calculate start position
             if (
@@ -2379,9 +2380,9 @@ const TimeUI = {
         const startYear = currentYear - 19
 
         // Determine which year is currently selected (use addOffset to get local time)
-        const selectedYear = moment(
+        const selectedYear = moment.utc(moment(
             TimeUI.removeOffset(TimeUI._endTimestamp)
-        ).year()
+        )).year()
 
         for (let year = startYear; year <= currentYear; year++) {
             const yearButton = $('<div>')
@@ -2412,9 +2413,9 @@ const TimeUI = {
         const months = moment.months()
 
         // Determine which month is currently selected (use addOffset to get local time)
-        const selectedMonth = moment(
+        const selectedMonth = moment.utc(moment(
             TimeUI.removeOffset(TimeUI._endTimestamp)
-        ).month()
+        )).month()
 
         for (let i = 0; i < months.length; i++) {
             const monthButton = $('<div>')
@@ -2481,7 +2482,10 @@ const TimeUI = {
     },
     _selectMonth(monthIndex) {
         // Select the entire month for the current year (use addOffset to get local time)
-        const selectedYear = moment(TimeUI._endTimestamp).year()
+        const selectedYear = moment.utc(moment(
+            TimeUI.removeOffset(TimeUI._endTimestamp)
+        )).utc().year()
+
         const startOfMonth = moment([selectedYear, monthIndex, 1])
             .startOf('month')
             .valueOf()
@@ -2504,7 +2508,10 @@ const TimeUI = {
     },
     _selectDay(day) {
         // Select the entire day for the current month/year (use addOffset to get local time)
-        const selectedMoment = moment(TimeUI._endTimestamp)
+        const selectedMoment = moment.utc(moment(
+            TimeUI.removeOffset(TimeUI._endTimestamp)
+        )).utc()
+
         const selectedYear = selectedMoment.year()
         const selectedMonth = selectedMoment.month()
         const startOfDay = moment([selectedYear, selectedMonth, day])
@@ -2534,7 +2541,10 @@ const TimeUI = {
         container.append(rangeIndicator)
 
         // Get the selected hour
-        const selectedMoment = moment(TimeUI._endTimestamp)
+        const selectedMoment = moment.utc(moment(
+            TimeUI.removeOffset(TimeUI._endTimestamp)
+        ))
+
         const selectedHour = selectedMoment.hour()
 
         // Generate 24 hours in 12-hour format with AM/PM


### PR DESCRIPTION
This fixes an issue where there was a local time versus UTC time offset in the expanded timeline display.

Before (End time set to 01/01/2025)
<img width="3002" height="360" alt="Screenshot 2025-12-03 at 12 52 01 PM" src="https://github.com/user-attachments/assets/64e6e0eb-18b9-4936-a146-3d3653ad9848" />
Before (End time set to 01/02/2025)
<img width="3002" height="360" alt="Screenshot 2025-12-03 at 12 52 06 PM" src="https://github.com/user-attachments/assets/d9ca5705-af3e-4ea0-b9a5-53c63bc45a9c" />

After (End time set to 01/01/2025)
<img width="3002" height="360" alt="Screenshot 2025-12-03 at 12 52 28 PM" src="https://github.com/user-attachments/assets/817031a0-ca89-4592-9eee-666008a37182" />
After (End time set to 01/02/2025)
<img width="3002" height="360" alt="Screenshot 2025-12-03 at 12 52 38 PM" src="https://github.com/user-attachments/assets/ca6ce91f-ea91-4b61-9905-88050b68d988" />

