### PR TITLE
Fix LegendTool overflow

### DIFF
--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.2.3-20251223",
+  "version": "4.2.4-20260113",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.2.3-20251223",
+  "version": "4.2.4-20260113",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -265,9 +265,8 @@ function drawLegendHeader() {
             'overflow-y': 'auto'
         })
     tools.append(legendContainer)
-    const toolsContainer = legendContainer
 
-    return tools
+    return legendContainer
 }
 
 function drawLegends(tools, _legend, layerUUID, display_name, opacity, shift) {


### PR DESCRIPTION
## Purpose
This makes sure the LegendTool items are attached to the correct container, otherwise there is no scrollbar.

Before -> After
<img width="250" alt="Screenshot 2026-01-13 at 9 36 58 AM" src="https://github.com/user-attachments/assets/e3a73926-2c08-4645-9635-c0c17c66d095" /> <img width="250" alt="Screenshot 2026-01-13 at 9 37 08 AM" src="https://github.com/user-attachments/assets/2104594a-41d0-4044-abae-e01346928828" />
