### PR TITLE
Fix viewer and globe splitter icons

### DIFF
--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.2.4-20260113",
+  "version": "4.2.5-20260114",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.2.4-20260113",
+  "version": "4.2.5-20260114",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/src/essence/Basics/UserInterface_/UserInterfaceDefault_.js
+++ b/src/essence/Basics/UserInterface_/UserInterfaceDefault_.js
@@ -410,10 +410,10 @@ var UserInterface = {
             .html('Viewer')
         this.mapSplitInner.append(mapSplitInnerViewerInfo)
 
-        this.mapSplitInner
-            .append('div')
+        const mapSplitInnerVMapInfo = $('<div>')
             .attr('id', 'mapSplitInnerVMapInfo')
             .html('Map')
+        this.mapSplitInner.append(mapSplitInnerVMapInfo)
 
         //The globe screen
         this.globeScreen = $('<div>')
@@ -552,10 +552,10 @@ var UserInterface = {
             .html('Globe')
         this.globeSplitInner.append(mapSplitInnerGlobeInfo)
 
-        this.globeSplitInner
-            .append('div')
+        const mapSplitInnerGMapInfo = $('<div>')
             .attr('id', 'mapSplitInnerGMapInfo')
             .html('Map')
+        this.globeSplitInner.append(mapSplitInnerGMapInfo)
 
         //thumb lines
         /*


### PR DESCRIPTION
## Purpose
This restores the arrow buttons for the split viewer and globe.

Before -> After
<img width="400" height="1688" alt="Screenshot 2026-01-14 at 11 13 34 AM" src="https://github.com/user-attachments/assets/72c791e7-04f7-447f-aab8-0915c8962a40" /> <img width="400" height="1688" alt="Screenshot 2026-01-14 at 11 12 47 AM" src="https://github.com/user-attachments/assets/a79cab03-1a44-4375-9688-66f6df8caeac" />

Before -> After
<img width="400" height="1688" alt="Screenshot 2026-01-14 at 11 22 02 AM" src="https://github.com/user-attachments/assets/46278bde-0087-45d4-853d-73be60d1708c" /> <img width="400" height="1688" alt="Screenshot 2026-01-14 at 11 21 39 AM" src="https://github.com/user-attachments/assets/e570fae4-3f44-4d81-aaad-79b2ae8c0ee1" />

