### PR TITLE
#853 If Time and Refresh Interval Enabled, do not set to layernotfound

### DIFF
--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.2.5-20260114",
+  "version": "4.2.6-20260123",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.2.5-20260114",
+  "version": "4.2.6-20260123",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -36,6 +36,7 @@ const L_ = {
         filters: {}, // layerFilters
         nameToUUID: {},
         refreshIntervals: {}, // In order to reloadLayer
+        refreshFailed: {}, // Track layers with failed refreshes
     },
     // ===== Private ======
     //Index -> layer name

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -929,6 +929,29 @@ async function makeVectorLayer(
                         `ERROR: ${layerObj.display_name} has invalid GeoJSON!`
                     )
                 }
+
+                // For refresh operations, preserve the existing layer on failure
+                // to prevent temporary network issues from marking the layer as "layernotfound"
+                if (isRefresh && data === null) {
+                    const existingLayer = L_.layers.layer[layerObj.name]
+                    if (existingLayer != null && existingLayer !== false) {
+                        console.warn(
+                            `[${new Date().toISOString()}] Refresh failed for ${layerObj.display_name}, ` +
+                            `keeping existing layer. Next refresh in ${layerObj.time?.refreshIntervalAmount || 60}s`
+                        )
+                        // Mark layer as having a failed refresh
+                        L_.layers.refreshFailed[layerObj.name] = true
+                        // Dispatch event so LayersTool can update the UI
+                        const event = new CustomEvent('layerRefreshStatusChanged', {
+                            detail: { layerName: layerObj.name, failed: true }
+                        })
+                        document.dispatchEvent(event)
+                        resolve()
+                        return
+                    }
+                }
+
+                // Only set to null for initial loads or if no existing layer
                 L_._layersLoaded[
                     L_._layersOrdered.indexOf(layerObj.name)
                 ] = true
@@ -965,6 +988,16 @@ async function makeVectorLayer(
 
             L_.layers.attachments[layerObj.name] = vl.sublayers
             L_.layers.layer[layerObj.name] = vl.layer
+
+            // Clear refresh failed status on successful load/refresh
+            if (L_.layers.refreshFailed[layerObj.name]) {
+                L_.layers.refreshFailed[layerObj.name] = false
+                // Dispatch event so LayersTool can update the UI
+                const event = new CustomEvent('layerRefreshStatusChanged', {
+                    detail: { layerName: layerObj.name, failed: false }
+                })
+                document.dispatchEvent(event)
+            }
 
             // For refresh operations, turn the new layer back on if the old one was on
             if (isRefresh && wasOnForRefresh) {

--- a/src/essence/Tools/Layers/LayersTool.css
+++ b/src/essence/Tools/Layers/LayersTool.css
@@ -400,6 +400,7 @@
 }
 
 #layersTool .reload,
+#layersTool .refreshWarning,
 #layersTool .setGlobalTimeFromExtent,
 #layersTool .reset,
 #layersTool .resetCog,
@@ -424,6 +425,12 @@
 #layersTool .locate,
 #layersTool .LayersToolInfo {
     color: transparent;
+}
+#layersTool .refreshWarning {
+    color: var(--color-h);
+    display: none;
+    align-items: center;
+    justify-content: center;
 }
 #layersTool .reload:hover,
 #layersTool .layerDownload:hover,

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -1362,6 +1362,9 @@ function interfaceWithMMGIS(fromInit) {
                                     `<div class="layerName" title="${node[i].display_name}">`,
                                         node[i].display_name,
                                     '</div>',
+                                    '<div class="refreshWarning" title="Layer refresh failed. Using cached data." style="display: none;">',
+                                        '<i class="mdi mdi-alert mdi-18px"></i>',
+                                    '</div>',
                                     node[i].type === 'vector' ?
                                     ['<div class="reload" title="Reload Layer">',
                                         '<i class="mdi mdi-refresh mdi-18px"></i>',
@@ -1548,6 +1551,16 @@ function interfaceWithMMGIS(fromInit) {
     })
 
     setSublayerEvents()
+
+    // Initialize refresh warning icons for layers that already have failed refreshes
+    Object.keys(L_.layers.refreshFailed).forEach((layerName) => {
+        if (L_.layers.refreshFailed[layerName]) {
+            const safeName = F_.getSafeName(layerName)
+            const layerElement = $(`#LayersTool${safeName}`)
+            const warningIcon = layerElement.find('.refreshWarning')
+            warningIcon.css('display', 'flex')
+        }
+    })
 
     // Collapse header
     $('.layersToolHeader').on('click', function () {
@@ -3078,9 +3091,27 @@ function interfaceWithMMGIS(fromInit) {
         )
     }
 
+    // Listen for layer refresh status changes
+    const handleRefreshStatusChange = (event) => {
+        const { layerName, failed } = event.detail
+        const safeName = F_.getSafeName(layerName)
+        const layerElement = $(`#LayersTool${safeName}`)
+        const warningIcon = layerElement.find('.refreshWarning')
+
+        if (failed) {
+            warningIcon.css('display', 'flex')
+        } else {
+            warningIcon.css('display', 'none')
+        }
+    }
+
+    document.addEventListener('layerRefreshStatusChanged', handleRefreshStatusChange)
+
     //Share everything. Don't take things that aren't yours.
     // Put things back where you found them.
-    function separateFromMMGIS() {}
+    function separateFromMMGIS() {
+        document.removeEventListener('layerRefreshStatusChanged', handleRefreshStatusChange)
+    }
 }
 
 //Other functions


### PR DESCRIPTION
Closes #853

_With Claude_


Instead of locking a Refresh Interval layer forever if a single refresh hits a network problem, instead keep showing the existing cached layer data and show a yellow warning icon by the layer icon to indicate that it's using cached data.
<img width="354" height="94" alt="Screenshot 2026-01-22 195508" src="https://github.com/user-attachments/assets/b0d8b698-518e-4b56-aeb8-f973c6b7e930" />
