### PR TITLE
Add new callback for madeLegendTool

### DIFF
--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.2.6-20260128",
+  "version": "4.2.7-20260203",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/docs/pages/APIs/JavaScript/Main/Main.md
+++ b/docs/pages/APIs/JavaScript/Main/Main.md
@@ -608,7 +608,7 @@ window.mmgisAPI.updateLayersTime();
 
 ### addEventListener(eventName, functionReference)
 
-This function adds a map event or MMGIS action listener added using the MMGIS API. This function takes in one of the following events: `onPan`, `onZoom`, `onClick`, `toolChange`, `layerVisibilityChange`. The MMGIS action listener (`toolChange`, `layerVisibilityChange`, `websocketChange`, `toggleSeparatedTool`, `newActiveFeature`) functions are called with an `event` parameter.
+This function adds a map event or MMGIS action listener added using the MMGIS API. This function takes in one of the following events: `onPan`, `onZoom`, `onClick`, `toolChange`, `layerVisibilityChange`. The MMGIS action listener (`toolChange`, `layerVisibilityChange`, `websocketChange`, `toggleSeparatedTool`, `newActiveFeature`, `layersToolHeaderStateChange`, `madeLegendTool`) functions are called with an `event` parameter.
 
 #### Function parameters
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.2.6-20260128",
+  "version": "4.2.7-20260203",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -40,6 +40,13 @@ var LegendTool = {
         })
 
         this.made = true
+
+        let _event = new CustomEvent('madeLegendTool', {
+            detail: {
+                made: true,
+            },
+        })
+        document.dispatchEvent(_event)
     },
     destroy: function () {
         this.MMWebGISInterface.separateFromMMWebGIS()

--- a/src/essence/mmgisAPI/mmgisAPI.js
+++ b/src/essence/mmgisAPI/mmgisAPI.js
@@ -421,6 +421,7 @@ var mmgisAPI_ = {
             'toggleSeparatedTool',
             'newActiveFeature',
             'layersToolHeaderStateChange',
+            'madeLegendTool',
         ]
         return validEvents.includes(eventName)
     },
@@ -691,7 +692,7 @@ var mmgisAPI = {
     getVisibleLayers: mmgisAPI_.getVisibleLayers,
 
     /** addEventListener - adds map event or MMGIS action listener.
-     * @param {string} - eventName - name of event to add listener to. Available events: onPan, onZoom, onClick, toolChange, layerVisibilityChange, toggleSeparatedTool, newActiveFeature
+     * @param {string} - eventName - name of event to add listener to. Available events: onPan, onZoom, onClick, toolChange, layerVisibilityChange, toggleSeparatedTool, newActiveFeature, layersToolHeaderStateChange, madeLegendTool
 
      * @param {function} - functionReference - function reference to listener event callback function. null value removes all functions for a given eventName
 


### PR DESCRIPTION
This adds a callback for `madeLegendTool`, which sends an event whenever the LegendTool's `make` function is called. This is useful for overriding what is displayed in the LegendTool by default.