### PR TITLE
Add font types as asset to webpack

### DIFF
--- a/configuration/webpack.config.js
+++ b/configuration/webpack.config.js
@@ -63,6 +63,8 @@ const cssRegex = /\.css$/;
 const cssModuleRegex = /\.module\.css$/;
 const sassRegex = /\.(scss|sass)$/;
 const sassModuleRegex = /\.module\.(scss|sass)$/;
+const fontRegex = /\.(eot|woff|woff2|ttf)$/;
+
 
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
@@ -492,6 +494,10 @@ module.exports = function (webpackEnv) {
                 },
                 "sass-loader"
               ),
+            },
+            {
+              test: fontRegex,
+              type: 'asset/resource',
             },
             // "file" loader makes sure those assets get served by WebpackDevServer.
             // When you `import` an asset, you get its (virtual) filename.

--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.2.11-20260217",
+  "version": "4.2.12-20260226",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.2.11-20260217",
+  "version": "4.2.12-20260226",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {


### PR DESCRIPTION
This is an attempt to fix an issue where the material design icons all show up as boxes because the fonts seem to be missing. We're not able to consistently replicate this bug.

<img width="1000" alt="Screenshot 2026-02-26 at 9 19 24 AM" src="https://github.com/user-attachments/assets/46f8c16a-13d0-4ba0-8baa-a3f55aeeaf55" />
