### PR TITLE
Fix issues in mobile version

### DIFF
--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.2.12-20260226",
+  "version": "4.2.13-20260226",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.2.12-20260226",
+  "version": "4.2.13-20260226",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/src/essence/Basics/ToolController_/ToolController_.js
+++ b/src/essence/Basics/ToolController_/ToolController_.js
@@ -210,7 +210,7 @@ let ToolController_ = {
                     .attr('class', 'toolButton')
                     .css(
                         'width',
-                        L_.UserInterface_.isMobile === true ? '36px' : '100%'
+                        L_.UserInterface_.isMobile === true ? '45px' : '100%'
                     )
                     .css(
                         'height',
@@ -322,13 +322,14 @@ let ToolController_ = {
         ) {
             let timeSelect = $('<div>')
                 .attr('id', 'toggleTimeUI')
+                .attr('class', 'toolButton')
                 .css({
                     'position': 'relative',
-                    'width': '30px',
-                    'height': '30px',
+                    'width': '45px',
+                    'height': '45px',
                     'display': 'inline-block',
                     'text-align': 'center',
-                    'line-height': '30px',
+                    'line-height': '45px',
                     'vertical-align': 'middle',
                     'cursor': 'pointer',
                     'transition': 'all 0.2s ease-in',
@@ -395,13 +396,14 @@ let ToolController_ = {
         ) {
             let coordSelect = $('<div>')
                 .attr('id', 'coordinatesDiv')
+                .attr('class', 'toolButton')
                 .css({
                     'position': 'relative',
-                    'width': '30px',
-                    'height': '30px',
+                    'width': '45px',
+                    'height': '45px',
                     'display': 'inline-block',
                     'text-align': 'center',
-                    'line-height': '30px',
+                    'line-height': '45px',
                     'vertical-align': 'middle',
                     'cursor': 'pointer',
                     'transition': 'all 0.2s ease-in',

--- a/src/essence/Basics/ToolController_/ToolController_.js
+++ b/src/essence/Basics/ToolController_/ToolController_.js
@@ -362,6 +362,7 @@ let ToolController_ = {
                                 TimeUI.initialize()
                                 ToolController_.setToolHeight(TimeUI.height)
                                 ToolController_.setToolWidth()
+                                ToolController_.activeToolName = 'TimeUI'
                                 TimeUI.make()
                                 TimeUI.toggleExpanded()
                                 TimeUI.fina()
@@ -370,6 +371,7 @@ let ToolController_ = {
                                 ToolController_.setToolWidth()
                                 TimeUI.destroy()
                                 ToolController_.closeActiveTool()
+                                ToolController_.activeToolName = null
                             }
 
                             $('#topBar').css({
@@ -439,12 +441,14 @@ let ToolController_ = {
                                     L_.Coordinates.height
                                 )
                                 ToolController_.setToolWidth()
+                                ToolController_.activeToolName = 'CoordinatesTool'
                                 L_.Coordinates.make()
                             } else {
                                 ToolController_.setToolHeight(0)
                                 ToolController_.setToolWidth()
                                 L_.Coordinates.destroy()
                                 ToolController_.closeActiveTool()
+                                ToolController_.activeToolName = null
                             }
 
                             $('#topBar').css({

--- a/src/essence/Basics/UserInterface_/UserInterfaceMobile_.css
+++ b/src/essence/Basics/UserInterface_/UserInterfaceMobile_.css
@@ -246,6 +246,8 @@
 .toolButton {
     border-top: none !important;
     border-bottom: none !important;
+    width: 45px !important;
+    line-height: 45px !important;
 }
 
 /* Hide other misc items */
@@ -301,4 +303,8 @@
 }
 .leaflet-control-scalefactor {
     display: none !important;
+}
+/* Force the icons in the toolbar to be larger */
+.toolButton > .mdi-18.mdi-set, .toolButton > .mdi-18px.mdi:before {
+    font-size: 22px !important;
 }

--- a/src/essence/Basics/UserInterface_/UserInterfaceMobile_.css
+++ b/src/essence/Basics/UserInterface_/UserInterfaceMobile_.css
@@ -241,6 +241,9 @@
 #layersTool .LayersToolInfo:hover {
     background: transparent;
 }
+.locate {
+    display: none;
+}
 
 /* Overwrite InfoTool CSS */
 .toolButton {

--- a/src/essence/Basics/UserInterface_/UserInterfaceMobile_.js
+++ b/src/essence/Basics/UserInterface_/UserInterfaceMobile_.js
@@ -18,7 +18,7 @@ var mobileTools = ['Layers', 'Legend', 'Info']
 var UserInterface = {
     splitterSize: 0,
     splitterSizeHidden: 17,
-    topSize: 40,
+    topSize: 50,
     fullSizeViews: false, //Experimental!!!
     pxIsViewer: null,
     pxIsMap: null,

--- a/src/essence/Tools/Info/InfoTool.js
+++ b/src/essence/Tools/Info/InfoTool.js
@@ -96,8 +96,9 @@ var InfoTool = {
     MMGISInterface: null,
     initialize: function () {
         if (L_.UserInterface_.isMobile === true) {
+            const mapRect = document.getElementById('map').getBoundingClientRect()
             this.width = 'full'
-            this.height = 500
+            this.height = this.height = Math.round(mapRect.height * 0.5)
         }
     },
     make: function () {

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -143,8 +143,9 @@ var LayersTool = {
         }
 
         if (L_.UserInterface_.isMobile === true) {
+            const mapRect = document.getElementById('map').getBoundingClientRect()
             this.width = 'full'
-            this.height = 500
+            this.height = Math.round(mapRect.height * 0.70)
         }
     },
     finalize: function () {

--- a/src/essence/Tools/Legend/LegendTool.js
+++ b/src/essence/Tools/Legend/LegendTool.js
@@ -17,8 +17,9 @@ var LegendTool = {
     justification: 'left',
     initialize: function () {
         if (L_.UserInterface_.isMobile === true) {
+            const mapRect = document.getElementById('map').getBoundingClientRect()
             this.width = 'full'
-            this.height = 500
+            this.height = Math.round(mapRect.height * 0.25)
         }
 
         //Get tool variables


### PR DESCRIPTION
This fixes a few issues with the mobile version.

This fixes a toolbar bug where if clicking the LayerTool, InfoTool, or LegendTool, then clicking the TimeUI or Coordinates tool and then clicking the previous tool again, it would turn off the previous tool instead of switching to it.

This changes the height of the  LayerTool, InfoTool, and, LegendTool to be dynamic based on percentage of the height of the MMGIS page.

<img width="250"  alt="Screenshot 2026-02-26 at 12 37 45 PM_" src="https://github.com/user-attachments/assets/83004316-638b-472d-b1da-e953b7240d45" /> <img width="250" alt="Screenshot 2026-02-26 at 12 37 59 PM" src="https://github.com/user-attachments/assets/28eb1274-658d-403d-9f2a-02a2d05c0bbd" /> <img width="250"  alt="Screenshot 2026-02-26 at 12 37 56 PM_" src="https://github.com/user-attachments/assets/21908c1d-e4ce-4d4b-a13d-839cb64da824" />


Larger toolbar buttons before -> after

<img width="300" alt="Screenshot 2026-02-26 at 12 27 34 PM" src="https://github.com/user-attachments/assets/89ee2303-def8-4da4-95f1-7a7ae19c6b15" />
<img width="300" alt="Screenshot 2026-02-26 at 12 27 10 PM" src="https://github.com/user-attachments/assets/d3be5653-57ff-4301-9942-0f4ce3631f40" />



