### PR TITLE
Improve login page for smaller screens

### DIFF
--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.2.17-20260305",
+  "version": "4.2.18-20260305",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.2.16-20260302",
+  "version": "4.2.17-20260304",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.2.16-20260302",
+  "version": "4.2.17-20260304",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.2.17-20260305",
+  "version": "4.2.18-20260305",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/public/login.css
+++ b/public/login.css
@@ -208,3 +208,25 @@ img {
   background: #08aeea;
   color: white;
 }
+@media (max-width: 480px) {
+  .header {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  .header > img {
+    left: auto !important;
+  }
+  .footer {
+    padding: 22px !important;
+  }
+  .box input[type="text"],
+  .box input[type="password"] {
+    font-size: 16px;
+  }
+}
+@media (max-width: 420px) {
+  #container {
+    transform: translateX(-50%) translateY(-50%) scale(0.8);
+  }
+}

--- a/views/login.pug
+++ b/views/login.pug
@@ -2,6 +2,7 @@ doctype html
 html(lang='en')
   head
     title MMGIS / Login
+    meta(name='viewport' content='width=device-width, initial-scale=1.0')
     link(rel='shortcut icon' href='public/images/logos/logo.png')
     link(type='text/css' rel='stylesheet' href='public/login.css')
     script.


### PR DESCRIPTION
This closes #877. This should work well for screens that are at least 330 pixels wide. Some improvements could be made for screens that are less than 330 pixels wide.

Before -> After
<img width="350" alt="Screenshot 2026-03-04 at 2 16 20 PM" src="https://github.com/user-attachments/assets/56392bb8-3461-49f5-a879-fd987d6ff34d" /> <img width="350" height="1336" alt="Screenshot 2026-03-04 at 2 33 48 PM" src="https://github.com/user-attachments/assets/68415374-cb0a-4903-84a8-ed624450774c" />
