### PR TITLE
#889 Fix Time Type = Local and Refresh Interval don't work together

### DIFF
--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -1034,6 +1034,11 @@ async function makeVectorLayer(
                 )
             }
 
+            // Clear local time filter cache on refresh so new data is used
+            if (isRefresh && L_._localTimeFilterCache) {
+                delete L_._localTimeFilterCache[layerObj.name]
+            }
+
             ctx.layerRegistry.attachments[layerObj.name] = vl.sublayers
             ctx.layerRegistry.layer[layerObj.name] = vl.layer
 


### PR DESCRIPTION
Closes #889

Simply clears the local feature cache when using the refresh interval so that the latest features can get cached as well later.