### PR TITLE
Update time and timetype metaconfigs

### DIFF
--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.2.21-20260310",
+  "version": "4.2.22-20260310",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/configure/src/metaconfigs/layer-data-config.json
+++ b/configure/src/metaconfigs/layer-data-config.json
@@ -356,10 +356,10 @@
             {
               "field": "time.type",
               "name": "Time Type",
-              "description": "",
+              "description": "URL-based time filtering. Re-requests the data with {starttime} and {endtime} injected into the URL, expecting the server to filter by time. The data layer will refresh whenever the time window changes.",
               "type": "dropdown",
               "width": 3,
-              "options": ["requery", "local"]
+              "options": ["requery"]
             },
             {
               "field": "time.format",

--- a/configure/src/metaconfigs/layer-model-config.json
+++ b/configure/src/metaconfigs/layer-model-config.json
@@ -385,10 +385,10 @@
             {
               "field": "time.type",
               "name": "Time Type",
-              "description": "When the time changes, whether the layer should requery the source or filter the layer locally based on feature properties.",
+              "description": "URL-based time filtering for 3D model layers. Re-requests the model file with {starttime} and {endtime} injected into the URL if the model data varies by time.",
               "type": "dropdown",
               "width": 3,
-              "options": ["requery", "local"]
+              "options": ["requery"]
             }
           ]
         },

--- a/configure/src/metaconfigs/layer-query-config.json
+++ b/configure/src/metaconfigs/layer-query-config.json
@@ -501,10 +501,10 @@
             {
               "field": "time.type",
               "name": "Time Type",
-              "description": "When the time changes, whether the layer should requery the source or filter the layer locally based on feature properties.",
+              "description": "URL-based time filtering for query layers. Re-requests the query results with {starttime} and {endtime} injected into the URL, expecting the server to filter by time. Query layers do not support client-side time filtering.",
               "type": "dropdown",
               "width": 3,
-              "options": ["requery", "local"]
+              "options": ["requery"]
             }
           ]
         },

--- a/configure/src/metaconfigs/layer-tile-config.json
+++ b/configure/src/metaconfigs/layer-tile-config.json
@@ -370,10 +370,10 @@
             {
               "field": "time.type",
               "name": "Time Type",
-              "description": "Whether the layer should use global time values or function independently with its own time values.",
+              "description": "URL-based time filtering for tile layers. Re-requests tiles with {starttime} and {endtime} injected into the URL. For WMS layers, also sets WMS TIME parameters automatically. Note: Client-side filtering is not possible for raster tile layers.",
               "type": "dropdown",
               "width": 4,
-              "options": ["requery", "local"]
+              "options": ["requery"]
             }
           ]
         },

--- a/configure/src/metaconfigs/layer-vector-config.json
+++ b/configure/src/metaconfigs/layer-vector-config.json
@@ -446,7 +446,7 @@
             {
               "field": "time.type",
               "name": "Time Type",
-              "description": "When the time changes, whether the layer should requery the source or filter the layer locally based on feature properties.",
+              "description": "How time filtering is performed:\n\t<strong>• local</strong> - Downloads the entire file first, then filters features client-side based on their time properties (e.g., a timestamp field in the GeoJSON). If a refresh interval is set, the file will be re-downloaded periodically and then filtered locally.\n\t<strong>• requery</strong> - Re-requests the URL with {starttime} and {endtime} injected as parameters, expecting the server to do the time filtering. Does not filter client-side.",
               "type": "dropdown",
               "width": 3,
               "options": ["requery", "local"]

--- a/configure/src/metaconfigs/layer-vectortile-config.json
+++ b/configure/src/metaconfigs/layer-vectortile-config.json
@@ -407,10 +407,10 @@
             {
               "field": "time.type",
               "name": "Time Type",
-              "description": "When the time changes, whether the layer should requery the source or filter the layer locally based on feature properties.",
+              "description": "URL-based time filtering for vector tile layers. Re-requests tiles with {starttime} and {endtime} injected into the URL. Vector tiles are pre-rendered on the server, so filtering must happen server-side via URL parameters.",
               "type": "dropdown",
               "width": 3,
-              "options": ["requery", "local"]
+              "options": ["requery"]
             }
           ]
         },

--- a/configure/src/metaconfigs/layer-velocity-config.json
+++ b/configure/src/metaconfigs/layer-velocity-config.json
@@ -307,10 +307,10 @@
             {
               "field": "time.type",
               "name": "Time Type",
-              "description": "When the time changes, whether the layer should requery the source or filter the layer locally based on feature properties.",
+              "description": "URL-based time filtering for velocity layers. Re-requests velocity data with {starttime} and {endtime} injected into the URL. For WMS-backed velocity layers, also sets WMS TIME parameters. Velocity data must be filtered server-side.",
               "type": "dropdown",
               "width": 3,
-              "options": ["requery", "local"]
+              "options": ["requery"]
             }
           ]
         },

--- a/configure/src/metaconfigs/tab-time-config.json
+++ b/configure/src/metaconfigs/tab-time-config.json
@@ -81,7 +81,7 @@
         {
           "field": "time.initialstart",
           "name": "Initial Start Time",
-          "description": "The initial start time. It should be before the Initial End Time and it can be made relative by appending ' {+/-} {seconds}' - for instance: '2024-03-04T14:05:00Z + 864000'. Default: 1 month before Initial End Time",
+          "description": "The initial start time. It should be before the Initial End Time. You can use 'now' to have the start time be the present and you can make it relative by appending ' {+/-} {seconds}' - for instance: 'now - 864000' or '2024-03-04T14:05:00Z + 864000'. Default: 1 month before Initial End Time",
           "type": "text",
           "disableSwitch": "time.enabled",
           "width": 6
@@ -89,7 +89,7 @@
         {
           "field": "time.initialend",
           "name": "Initial End Time",
-          "description": "The initial end time. It should be after the Initial Start Time. You can use 'now' to have the end time be the present and you can make it relative by appending ' {+/-} {seconds}' - for instance: '2024-03-04T14:05:00Z + 864000'. Default: now",
+          "description": "The initial end time. It should be after the Initial Start Time. You can use 'now' to have the end time be the present and you can make it relative by appending ' {+/-} {seconds}' - for instance: 'now - 864000' or '2024-03-04T14:05:00Z + 864000'. Default: now",
           "type": "text",
           "disableSwitch": "time.enabled",
           "width": 6
@@ -101,7 +101,7 @@
         {
           "field": "time.initialwindowstart",
           "name": "Initial Timeline Window Start Time",
-          "description": "This does not control the time range for queries. This only allows the initial time window of the time line to differ from just being the Start Time to the End Time. A use-case for this would be to set the window times to fit the full extent of the temporal data but only set the Initial Start and End Times as a subset of that so as not to query everything on load. Can be made relative by appending ' {+/-} {seconds}' - for instance: '2024-03-04T14:05:00Z + 864000'. Default: Initial Start Time",
+          "description": "This does not control the time range for queries. This only allows the initial time window of the time line to differ from just being the Start Time to the End Time. A use-case for this would be to set the window times to fit the full extent of the temporal data but only set the Initial Start and End Times as a subset of that so as not to query everything on load. You can use 'now' to have the window start time be the present and you can make it relative by appending ' {+/-} {seconds}' - for instance: 'now - 864000' or '2024-03-04T14:05:00Z + 864000'. Default: Initial Start Time",
           "type": "text",
           "disableSwitch": "time.enabled",
           "width": 6
@@ -109,7 +109,7 @@
         {
           "field": "time.initialwindowend",
           "name": "Initial Timeline Window End Time",
-          "description": "This does not control the time range for queries. This only allows the initial time window of the time line to differ from just being the Start Time to the End Time. Should be after Initial Window End Time Use now to have the end time be the present. Can be made relative by appending ' {+/-} {seconds}' - for instance: '2024-03-04T14:05:00Z + 864000'. Default: Initial End Time",
+          "description": "This does not control the time range for queries. This only allows the initial time window of the time line to differ from just being the Start Time to the End Time. Should be after Initial Window Start Time. You can use 'now' to have the window end time be the present and you can make it relative by appending ' {+/-} {seconds}' - for instance: 'now - 864000' or '2024-03-04T14:05:00Z + 864000'. Default: Initial End Time",
           "type": "text",
           "disableSwitch": "time.enabled",
           "width": 6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.2.21-20260310",
+  "version": "4.2.22-20260310",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {


### PR DESCRIPTION
Updated time-related configuration page descriptions as well as remove time.type=local for layer types for which it does not make sense (which is pretty everything except for vector layers)