### PR TITLE
#895 Fix DrawTool bugs, template field naming, not null adv filters

### DIFF
--- a/API/Backend/Draw/routes/aggregations.js
+++ b/API/Backend/Draw/routes/aggregations.js
@@ -98,10 +98,11 @@ router.post("/aggregations", function (req, res, next) {
           }
 
           if (bestHistory.length === 0) {
-            return res.send({
+            res.send({
               status: "success",
               aggregations: {},
             });
+            return Promise.resolve(null); // Stop the promise chain
           }
 
           // Build query for sampling features
@@ -142,7 +143,13 @@ router.post("/aggregations", function (req, res, next) {
             },
           });
         })
-        .then(([features]) => {
+        .then((result) => {
+          // If result is null, we already sent a response (empty history case)
+          if (result === null) {
+            return;
+          }
+
+          const [features] = result;
           // Build aggregations from sampled features
           const aggregations = {
             "geometry.type": {

--- a/API/Backend/Draw/routes/filesutils.js
+++ b/API/Backend/Draw/routes/filesutils.js
@@ -224,23 +224,38 @@ function getfile(req, res, next) {
               // Decode filters (following GeodatasetFilterer pattern)
               let filters = null;
               if (req.body.filters != null && req.body.filters !== '') {
-                const filterSplit = req.body.filters.split(',');
-                filters = [];
-                filterSplit.forEach((f) => {
-                  if (f === 'OR' || f === 'AND' || f === 'NOT_AND' || f === 'NOT_OR') {
-                    filters.push({ isGroup: true, op: f });
-                  } else {
-                    const fSplit = f.split('+');
-                    if (fSplit.length >= 4) {
-                      filters.push({
-                        key: Utils.forceAlphaNumUnder(fSplit[0]),
-                        op: fSplit[1] === 'in' ? ',' : fSplit[1],
-                        type: fSplit[2],
-                        value: fSplit[3].replaceAll('$', ',').replaceAll("'", "''")
-                      });
+                try {
+                  const filterSplit = req.body.filters.split(',');
+                  filters = [];
+                  filterSplit.forEach((f) => {
+                    if (f === 'OR' || f === 'AND' || f === 'NOT_AND' || f === 'NOT_OR') {
+                      filters.push({ isGroup: true, op: f });
+                    } else {
+                      const fSplit = f.split('+');
+                      if (fSplit.length >= 4) {
+                        // Validate field name format (alphanumeric, spaces, dash, underscore only)
+                        const fieldName = fSplit[0];
+                        if (!/^[a-zA-Z0-9 _\-\.]+$/.test(fieldName)) {
+                          throw new Error(`Invalid filter field name: ${fieldName}`);
+                        }
+
+                        filters.push({
+                          key: fieldName.trim(),  // Preserve spaces, just trim whitespace
+                          op: fSplit[1] === 'in' ? ',' : fSplit[1],
+                          type: fSplit[2],
+                          value: fSplit[3].replaceAll('$', ',').replaceAll("'", "''")
+                        });
+                      }
                     }
-                  }
-                });
+                  });
+                } catch (err) {
+                  logger("error", `Invalid filter format: ${err.message}`, req.originalUrl, req);
+                  return res.status(400).json({
+                    status: 'failure',
+                    message: `Invalid filter format: ${err.message}`,
+                    body: {}
+                  });
+                }
               }
 
               // Note: geometry.type filters are now handled inline within the filter loop
@@ -329,6 +344,10 @@ function getfile(req, res, next) {
                     } else if (op === 'endswith') {
                       sqlOp = 'LIKE';
                       sqlValue = `%${value}`;
+                    } else if (op === 'isnull') {
+                      sqlOp = 'IS NULL';
+                    } else if (op === 'isnotnull') {
+                      sqlOp = 'IS NOT NULL';
                     }
 
                     // Build SQL condition
@@ -350,14 +369,19 @@ function getfile(req, res, next) {
                     } else {
                       // Regular property access
                       // NOTE: properties is double-encoded JSON (stored as JSON string, not JSON object)
-                      const propAccess = `((properties#>>'{}')::json->>'${propKey}')`;
+                      // Escape single quotes to prevent SQL injection
+                      const escapedPropKey = propKey.replace(/'/g, "''");
+                      const propAccess = `((properties#>>'{}')::json->>'${escapedPropKey}')`;
 
                       // Cast to appropriate type if needed
                       const castPropAccess = filter.type === 'number'
                         ? `(${propAccess})::numeric`
                         : propAccess;
 
-                      if (sqlOp === 'IN') {
+                      if (sqlOp === 'IS NULL' || sqlOp === 'IS NOT NULL') {
+                        // Null checks don't need parameterized values
+                        condition = `${propAccess} ${sqlOp}`;
+                      } else if (sqlOp === 'IN') {
                         const placeholderKey = `filter_${idx}`;
                         condition = `${castPropAccess} IN (:${placeholderKey})`;
                         replacements[placeholderKey] = sqlValue;

--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.2.23-20260310",
+  "version": "4.2.24-20260311",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.2.23-20260310",
+  "version": "4.2.24-20260311",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/src/essence/Tools/Draw/DrawTool_Files.js
+++ b/src/essence/Tools/Draw/DrawTool_Files.js
@@ -2470,9 +2470,19 @@ var Files = {
             // Clean up any temporary point markers when toggling file off
             DrawTool_Templater.cleanupAllPointMarkers()
 
-            // Clear truncation state when file is turned off so notification shows again on next turn-on
-            if (DrawTool.dynamicExtent && DrawTool.dynamicExtent.truncated) {
-                delete DrawTool.dynamicExtent.truncated[id]
+            // Clear DynamicExtent state when file is turned off so it reloads fresh on next turn-on
+            if (DrawTool.dynamicExtent) {
+                // Clear truncation state so notification shows again on next turn-on
+                if (DrawTool.dynamicExtent.truncated) {
+                    delete DrawTool.dynamicExtent.truncated[id]
+                }
+                // Clear location/extent tracking to bypass moveThreshold check on next toggle ON
+                if (DrawTool.dynamicExtent.lastRequestedLocation) {
+                    delete DrawTool.dynamicExtent.lastRequestedLocation[id]
+                }
+                if (DrawTool.dynamicExtent.lastRequestedExtent) {
+                    delete DrawTool.dynamicExtent.lastRequestedExtent[id]
+                }
             }
 
             DrawTool.refreshMasterCheckbox()

--- a/src/essence/Tools/Draw/DrawTool_Shapes.js
+++ b/src/essence/Tools/Draw/DrawTool_Shapes.js
@@ -1964,13 +1964,14 @@ var Shapes = {
         })
 
         $(elmId).on('blur', function (event) {
-            const property = Shapes.filters.aggs[event.value || $(this).val()]
+            const inputValue = $(this).val()
+            const property = Shapes.filters.aggs[inputValue]
             if (property) {
                 if (
                     Shapes.filters.values[id] &&
-                    Shapes.filters.values[id].key !== event.value
+                    Shapes.filters.values[id].key !== inputValue
                 ) {
-                    Shapes.filters.values[id].key = event.value
+                    Shapes.filters.values[id].key = inputValue
                     Shapes.filters.values[id].type = property.type
                     Shapes.updateValuesAutoComplete(id)
                     Shapes.setSubmitButtonState(true)
@@ -1993,6 +1994,8 @@ var Shapes = {
             'contains',
             'beginswith',
             'endswith',
+            'isnull',
+            'isnotnull',
         ]
         const opId = Math.max(ops.indexOf(options.op), 0)
         $(elmId).html(
@@ -2008,6 +2011,8 @@ var Shapes = {
                     `<i class='mdi mdi-contain mdi-18px' title='Contains'></i>`,
                     `<i class='mdi mdi-contain-start mdi-18px' title='Begins With'></i>`,
                     `<i class='mdi mdi-contain-end mdi-18px' title='Ends With'></i>`,
+                    `<i class='mdi mdi-null mdi-18px' title='Is Null (No Value)'></i>`,
+                    `<i class='mdi mdi-check-circle-outline mdi-18px' title='Is Not Null (Has Value)'></i>`,
                 ],
                 'op',
                 opId,
@@ -2016,11 +2021,16 @@ var Shapes = {
         )
         Dropy.init($(elmId), function (idx) {
             Shapes.filters.values[id].op = ops[idx]
+            // Hide/show value input based on operator
+            Shapes.toggleValueInput(id, ops[idx])
             Shapes.setSubmitButtonState(true)
         })
 
         // Value AutoComplete
         Shapes.updateValuesAutoComplete(id)
+
+        // Initialize value input visibility based on operator
+        Shapes.toggleValueInput(id, ops[opId])
     },
     refreshValueAutocomplete: function (id) {
         // Refresh the property (key) autocomplete with updated aggregations
@@ -2141,6 +2151,21 @@ var Shapes = {
                 $(numberElmId).css('display', 'none')
                 $(stringElmId).css('display', 'none')
                 break
+        }
+    },
+    toggleValueInput: function (id, operator) {
+        // Hide value input for null operators (they don't need a value)
+        const valueInputId = `#drawToolShapes_filtering_value_value_input_${id}`
+        const valueContainerId = `#drawToolShapes_filtering_value_value_${id}`
+
+        if (operator === 'isnull' || operator === 'isnotnull') {
+            // Hide value input for null checks
+            $(valueInputId).prop('disabled', true).css('opacity', '0.3')
+            $(valueInputId).val('') // Clear any existing value
+            Shapes.filters.values[id].value = '' // Clear stored value
+        } else {
+            // Show value input for other operators
+            $(valueInputId).prop('disabled', false).css('opacity', '1')
         }
     },
     attachGroupEvents: function (id, options) {

--- a/src/essence/Tools/Draw/DrawTool_Templater.js
+++ b/src/essence/Tools/Draw/DrawTool_Templater.js
@@ -1864,9 +1864,9 @@ const DrawTool_Templater = {
         if (
             isReadOnly ||
             featureToMakeTemplateFrom != null ||
-            Array.isArray(templateObj.template)
+            Array.isArray(templateObj?.template)
         ) {
-            if (Array.isArray(templateObj.template))
+            if (Array.isArray(templateObj?.template))
                 templateObj.template.forEach((t) => {
                     add(t)
                 })
@@ -2230,6 +2230,18 @@ const DrawTool_Templater = {
             if (t.field == 'uuid') {
                 CursorInfo.update(
                     `Template cannot contain the field name 'uuid'`,
+                    6000,
+                    true,
+                    { x: 305, y: 6 },
+                    '#e9ff26',
+                    'black'
+                )
+                return false
+            }
+            // Validate field name format (alphanumeric, spaces, dash, underscore, dot only)
+            if (!/^[a-zA-Z0-9 _\-\.]+$/.test(t.field)) {
+                CursorInfo.update(
+                    `Template field name '${t.field}' contains invalid characters. Only letters, numbers, spaces, dashes, underscores, and dots are allowed.`,
                     6000,
                     true,
                     { x: 305, y: 6 },

--- a/src/external/Dropy/dropy.css
+++ b/src/external/Dropy/dropy.css
@@ -130,7 +130,7 @@ dd {
 }
 
 .dropy.open .dropy__content ul {
-    max-height: 20em;
+    max-height: 24em;
     overflow-y: auto;
     opacity: 1;
     padding-left: 0;


### PR DESCRIPTION
Closes #895

_With Claude_

#### Fix DrawTool bugs, template field naming, and null advanced filters
                                                                                                       
  This PR addresses several critical bugs in the DrawTool feature and adds support for null/not-null
  filtering operations.

  🐛 Bug Fixes

  Backend (API/Backend/Draw/)
  - aggregations.js: Fixed promise chain issue where response was sent but the promise continued
  executing, causing potential errors when history is empty
  - filesutils.js:
    - Fixed field name validation to allow spaces, dashes, dots in addition to alphanumeric and        
  underscores (previously was too restrictive)
    - Added SQL injection protection by escaping single quotes in property keys
    - Improved error handling for malformed filter formats with proper 400 status responses

  Frontend (src/essence/Tools/Draw/)
  - DrawTool_Files.js: Fixed DynamicExtent state not resetting properly when toggling files off, which 
  prevented proper reload on next toggle. Now clears:
    - Truncation state
    - Last requested location
    - Last requested extent
  - DrawTool_Shapes.js: Fixed blur event handler to properly read input value from DOM element
  - DrawTool_Templater.js: Added null safety checks using optional chaining (?.) to prevent errors when
   templateObj is undefined

  ✨ New Features

  Advanced Filtering
  - Added "Is Null" and "Is Not Null" operators to the Draw Tool advanced filter system
  - Automatically hides value input field when null operators are selected (they don't require a value)
  - Includes appropriate icons and tooltips for the new operators
  - Backend support for isnull and isnotnull SQL operations

  Template Field Validation
  - Added validation for template field names to ensure they only contain safe characters: [a-zA-Z0-9  
  _\-\.]
  - Displays clear error message when invalid characters are used
  - Prevents potential issues with field name handling in filters and queries

  🎨 UI Improvements

  - dropy.css: Increased dropdown max-height from 20em to 24em for better visibility of filter options 

  📝 Files Changed

  - API/Backend/Draw/routes/aggregations.js
  - API/Backend/Draw/routes/filesutils.js
  - src/essence/Tools/Draw/DrawTool_Files.js
  - src/essence/Tools/Draw/DrawTool_Shapes.js
  - src/essence/Tools/Draw/DrawTool_Templater.js
  - src/external/Dropy/dropy.css