### PR TITLE
#898 Support TiTiler layers in Cesium Globe

### DIFF
--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.2.25-20260318",
+  "version": "4.2.26-20260318",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.2.25-20260318",
+  "version": "4.2.26-20260318",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/src/essence/Basics/Globe_/GlobeRenderer.js
+++ b/src/essence/Basics/Globe_/GlobeRenderer.js
@@ -2,6 +2,7 @@ import LithoSphere from 'lithosphere'
 import * as Cesium from 'cesium'
 import * as d3 from 'd3'
 import 'cesium/Source/Widgets/widgets.css'
+import LayerUtils from '../Layers_/LayerUtils'
 
 /**
  * GlobeRenderer - Abstraction wrapper for 3D globe rendering engines
@@ -416,9 +417,12 @@ class GlobeRenderer {
                 : null
 
             // Replace time parameters in URL if time is enabled
-            const processedUrl = timeConfig?.enabled
+            let processedUrl = timeConfig?.enabled
                 ? this._replaceTimeParameters(layerConfig.path, timeConfig)
                 : layerConfig.path
+
+            // Add TiTiler query parameters for COG/STAC layers
+            processedUrl = this._buildTiTilerUrl(processedUrl, layerConfig)
 
             let imageryProvider
 
@@ -481,7 +485,7 @@ class GlobeRenderer {
             layer.alpha =
                 layerConfig.opacity !== undefined ? layerConfig.opacity : 1.0
 
-            // Store layer metadata including time config
+            // Store layer metadata including time config and COG config
             this._layers[name] = {
                 type: 'tile',
                 layer: layer,
@@ -492,6 +496,19 @@ class GlobeRenderer {
                 minZoom: layerConfig.minZoom,
                 opacity: layerConfig.opacity,
                 order: layerConfig.order, // Store layer order for proper stacking
+                // Store COG configuration for dynamic updates
+                cogConfig: {
+                    splitColonType: layerConfig.splitColonType,
+                    cogTransform: layerConfig.cogTransform,
+                    cogMin: layerConfig.cogMin,
+                    cogMax: layerConfig.cogMax,
+                    currentCogMin: layerConfig.currentCogMin,
+                    currentCogMax: layerConfig.currentCogMax,
+                    cogColormap: layerConfig.cogColormap,
+                    cogExpression: layerConfig.cogExpression,
+                    currentCogExpression: layerConfig.currentCogExpression,
+                },
+                originalUrl: layerConfig.path, // Store template URL for rebuilding
             }
         } else if (type === 'vector' || type === 'clamped') {
             // Check if this layer is already being loaded (prevent duplicate async loads)
@@ -714,6 +731,46 @@ class GlobeRenderer {
     }
 
     /**
+     * Build complete TiTiler URL with query parameters for COG and STAC layers
+     * @private
+     * @param {string} baseUrl - Base URL template
+     * @param {Object} layerConfig - Layer configuration with COG parameters
+     * @returns {string} Complete URL with query parameters
+     */
+    _buildTiTilerUrl(baseUrl, layerConfig) {
+        // Only process COG or STAC collection layers
+        if (
+            layerConfig.splitColonType !== 'COG' &&
+            layerConfig.splitColonType !== 'stac-collection'
+        ) {
+            return baseUrl
+        }
+
+        // Build query parameters using shared function
+        const queryParams = LayerUtils.buildTiTilerQueryParams({
+            splitColonType: layerConfig.splitColonType,
+            starttime: layerConfig.time?.start,
+            endtime: layerConfig.time?.end,
+            cogTransform: layerConfig.cogTransform,
+            cogMin: layerConfig.cogMin,
+            cogMax: layerConfig.cogMax,
+            currentCogMin: layerConfig.currentCogMin,
+            currentCogMax: layerConfig.currentCogMax,
+            cogColormap: layerConfig.cogColormap,
+            cogExpression: layerConfig.cogExpression,
+            currentCogExpression: layerConfig.currentCogExpression,
+        })
+
+        // Append query parameters to URL
+        if (queryParams) {
+            const separator = baseUrl.indexOf('?') === -1 ? '?' : '&'
+            return baseUrl + separator + queryParams
+        }
+
+        return baseUrl
+    }
+
+    /**
      * Calculate the correct index for a tile layer in the imageryLayers collection
      * based on the global layer ordering (L_._layersOrdered)
      */
@@ -833,6 +890,104 @@ class GlobeRenderer {
     }
 
     /**
+     * Update COG parameters for a layer and refresh
+     * @param {string} layerName - Name of the layer to update
+     * @param {Object} cogParams - COG parameters to update (partial update supported)
+     */
+    updateLayerCogParameters(layerName, cogParams) {
+        const layerInfo = this._layers[layerName]
+
+        // Validate layer exists and has COG config
+        if (!layerInfo || layerInfo.type !== 'tile' || !layerInfo.cogConfig) {
+            return
+        }
+
+        // Update COG parameters (merge with existing)
+        Object.assign(layerInfo.cogConfig, cogParams)
+
+        // Refresh the layer with new parameters
+        this._refreshCogEnabledLayer(layerName)
+    }
+
+    /**
+     * Refresh a COG-enabled layer by recreating imagery provider with updated parameters
+     * @private
+     * @param {string} layerName - Name of the layer to refresh
+     */
+    _refreshCogEnabledLayer(layerName) {
+        const layerInfo = this._layers[layerName]
+
+        // Only refresh Cesium tile layers
+        if (
+            this.rendererType !== 'cesium' ||
+            !layerInfo ||
+            layerInfo.type !== 'tile'
+        ) {
+            return
+        }
+
+        // Store current state
+        const alpha = layerInfo.layer.alpha
+        const show = layerInfo.layer.show
+        const index = this.renderer.imageryLayers.indexOf(layerInfo.layer)
+
+        // Remove old imagery layer
+        this.renderer.imageryLayers.remove(layerInfo.layer)
+
+        // Build URL with updated COG parameters
+        let url = layerInfo.originalUrl
+
+        // Apply time parameters if enabled
+        if (layerInfo.timeConfig?.enabled) {
+            url = this._replaceTimeParameters(url, layerInfo.timeConfig)
+        }
+
+        // Build complete URL with COG query parameters
+        url = this._buildTiTilerUrl(url, {
+            ...layerInfo.cogConfig,
+            time: layerInfo.timeConfig,
+        })
+
+        // Create new imagery provider
+        let newProvider
+
+        if (layerInfo.format === 'wms') {
+            const { baseUrl, wmsParams } = this._parseWmsUrl(url)
+            newProvider = new Cesium.WebMapServiceImageryProvider({
+                url: baseUrl,
+                layers: wmsParams.LAYERS || '',
+                parameters: wmsParams,
+            })
+        } else {
+            newProvider = new Cesium.UrlTemplateImageryProvider({
+                url: this._convertTileUrl(url, layerInfo.format),
+                maximumLevel: layerInfo.maxZoom || 18,
+                minimumLevel: layerInfo.minZoom || 0,
+            })
+        }
+
+        // Add new imagery layer
+        const newLayer =
+            this.renderer.imageryLayers.addImageryProvider(newProvider)
+
+        // Restore state
+        newLayer.alpha = alpha
+        newLayer.show = show
+
+        // Restore layer order
+        if (index >= 0) {
+            const currentIndex = this.renderer.imageryLayers.indexOf(newLayer)
+            if (currentIndex !== index) {
+                this.renderer.imageryLayers.remove(newLayer, false)
+                this.renderer.imageryLayers.add(newLayer, index)
+            }
+        }
+
+        // Update reference
+        layerInfo.layer = newLayer
+    }
+
+    /**
      * Refresh a time-enabled layer by recreating its imagery provider
      */
     _refreshTimeEnabledLayer(layerName) {
@@ -855,10 +1010,18 @@ class GlobeRenderer {
         this.renderer.imageryLayers.remove(layerInfo.layer)
 
         // Create new URL with updated time parameters
-        const url = this._replaceTimeParameters(
+        let url = this._replaceTimeParameters(
             layerInfo.timeConfig.originalUrl,
             layerInfo.timeConfig
         )
+
+        // Add COG parameters to preserve rescale/colormap/expression when time changes
+        if (layerInfo.cogConfig) {
+            url = this._buildTiTilerUrl(url, {
+                ...layerInfo.cogConfig,
+                time: layerInfo.timeConfig,
+            })
+        }
 
         let newProvider
 

--- a/src/essence/Basics/Layers_/LayerUtils.js
+++ b/src/essence/Basics/Layers_/LayerUtils.js
@@ -157,7 +157,95 @@ export function transformStacUrl(url, layerData, type = 'tile', location = null)
     }
 }
 
+/**
+ * Build TiTiler query parameters for COG and STAC collection layers
+ * Extracted from leaflet-tilelayer-middleware.js for reusability in both Leaflet and Cesium
+ *
+ * @param {Object} options - Configuration options
+ * @param {string} options.splitColonType - 'COG' or 'stac-collection'
+ * @param {string} options.starttime - Start time for datetime parameter
+ * @param {string} options.endtime - End time for datetime parameter
+ * @param {boolean} options.cogTransform - Enable rescaling and coloring
+ * @param {number} options.cogMin - Minimum value for rescaling
+ * @param {number} options.cogMax - Maximum value for rescaling
+ * @param {number} options.currentCogMin - Runtime minimum value (overrides cogMin)
+ * @param {number} options.currentCogMax - Runtime maximum value (overrides cogMax)
+ * @param {string} options.cogColormap - Colormap name (e.g., 'viridis', 'cividis')
+ * @param {string} options.cogExpression - Band math expression
+ * @param {string} options.currentCogExpression - Runtime expression (overrides cogExpression)
+ * @returns {string} Query parameters string (without leading ? or &)
+ *
+ * @example
+ * // Returns 'datetime=2026-02-18/2026-03-18&exitwhenfull=false&skipcovered=false&rescale=[0,300]&colormap_name=cividis'
+ * buildTiTilerQueryParams({
+ *   splitColonType: 'stac-collection',
+ *   starttime: '2026-02-18',
+ *   endtime: '2026-03-18',
+ *   cogTransform: true,
+ *   cogMin: 0,
+ *   cogMax: 300,
+ *   cogColormap: 'cividis'
+ * })
+ */
+export function buildTiTilerQueryParams(options) {
+    const params = []
+
+    // datetime parameter
+    if (options.endtime != null) {
+        const datetime = options.starttime != null
+            ? `${options.starttime}/${options.endtime}`
+            : `../${options.endtime}`
+        params.push(`datetime=${datetime}`)
+    }
+
+    // STAC-specific parameters
+    if (options.splitColonType === 'stac-collection') {
+        params.push('exitwhenfull=false&skipcovered=false')
+    }
+
+    // rescale parameter
+    if (
+        options.cogTransform === true &&
+        options.cogMin != null &&
+        options.cogMax != null
+    ) {
+        const min = options.currentCogMin != null ? options.currentCogMin : options.cogMin
+        const max = options.currentCogMax != null ? options.currentCogMax : options.cogMax
+        params.push(`rescale=[${min},${max}]`)
+
+        // colormap parameter (only with rescale)
+        if (options.cogColormap != null) {
+            params.push(`colormap_name=${options.cogColormap}`)
+        }
+    }
+
+    // expression parameter
+    const expressionToUse = options.currentCogExpression || options.cogExpression
+    if (expressionToUse && expressionToUse.trim() !== '') {
+        // Replace bX or BX (where X is a number) with asset_bX or asset_BX
+        // Only replace if not already prefixed with an asset name (word_bX pattern)
+        const processedExpression = expressionToUse.replace(/(?<!\w)([bB])(\d+)/g, 'asset_$1$2')
+        params.push(`expression=${encodeURIComponent(processedExpression)}`)
+    }
+
+    // STAC mosaic limits from global config
+    if (typeof mmgisglobal !== 'undefined' && mmgisglobal.options?.stac) {
+        if (mmgisglobal.options.stac.mosaicItemLimit != null) {
+            params.push(`items_limit=${mmgisglobal.options.stac.mosaicItemLimit}`)
+        }
+        if (mmgisglobal.options.stac.mosaicScanLimit != null) {
+            params.push(`scan_limit=${mmgisglobal.options.stac.mosaicScanLimit}`)
+        }
+        if (mmgisglobal.options.stac.mosaicTimeLimit != null) {
+            params.push(`time_limit=${mmgisglobal.options.stac.mosaicTimeLimit}`)
+        }
+    }
+
+    return params.join('&')
+}
+
 export default {
     parseExternalStacUrl,
-    transformStacUrl
+    transformStacUrl,
+    buildTiTilerQueryParams
 }

--- a/src/essence/Basics/Layers_/Layers_.js
+++ b/src/essence/Basics/Layers_/Layers_.js
@@ -498,6 +498,18 @@ const L_ = {
                     let demUrl = L_.getUrl(s.type, s.demtileurl, s)
                     if (s.demtileurl == undefined || s.demtileurl.length == 0)
                         demUrl = undefined
+
+                    // Detect splitColonType from original URL
+                    let splitColonType = undefined
+                    if (s.url && typeof s.url === 'string') {
+                        const lowerUrl = s.url.toLowerCase()
+                        if (lowerUrl.startsWith('stac-collection:')) {
+                            splitColonType = 'stac-collection'
+                        } else if (lowerUrl.startsWith('cog:')) {
+                            splitColonType = 'COG'
+                        }
+                    }
+
                     L_.Globe_.litho.addLayer('tile', {
                         name: s.name,
                         order: L_._layersOrdered,
@@ -517,6 +529,16 @@ const L_ = {
                         maxZoom: s.maxNativeZoom,
                         //boundingBox: s.boundingBox,
                         time: s.time,
+                        // COG parameters for TiTiler layers
+                        splitColonType: splitColonType,
+                        cogTransform: s.cogTransform,
+                        cogMin: s.cogMin,
+                        cogMax: s.cogMax,
+                        currentCogMin: s.currentCogMin,
+                        currentCogMax: s.currentCogMax,
+                        cogColormap: s.cogColormap,
+                        cogExpression: s.cogExpression,
+                        currentCogExpression: s.currentCogExpression,
                     })
                 } else if (s.type === 'data') {
                 } else if (s.type === 'model') {
@@ -933,9 +955,8 @@ const L_ = {
 
                 // Add Globe layers
                 const s = L_.layers.dataFlat[i]
-                let layerUrl = s.url
-                if (!F_.isUrlAbsolute(layerUrl))
-                    layerUrl = L_.missionPath + layerUrl
+                // Use getUrl to properly transform STAC URLs and handle COG prefix
+                let layerUrl = L_.getUrl('tile', s.url, s)
                 if (
                     s.type === 'tile' ||
                     s.type === 'data' ||
@@ -952,6 +973,18 @@ const L_ = {
                     if (!F_.isUrlAbsolute(demUrl))
                         demUrl = L_.missionPath + demUrl
                     if (s.demtileurl == undefined) demUrl = undefined
+
+                    // Detect splitColonType from original URL
+                    let splitColonType = undefined
+                    if (s.url && typeof s.url === 'string') {
+                        const lowerUrl = s.url.toLowerCase()
+                        if (lowerUrl.startsWith('stac-collection:')) {
+                            splitColonType = 'stac-collection'
+                        } else if (lowerUrl.startsWith('cog:')) {
+                            splitColonType = 'COG'
+                        }
+                    }
+
                     if (s.type === 'tile')
                         L_.Globe_.litho.addLayer('tile', {
                             name: s.name,
@@ -972,6 +1005,16 @@ const L_ = {
                             maxZoom: s.maxNativeZoom,
                             //boundingBox: s.boundingBox,
                             time: s.time,
+                            // COG parameters for TiTiler layers
+                            splitColonType: splitColonType,
+                            cogTransform: s.cogTransform,
+                            cogMin: s.cogMin,
+                            cogMax: s.cogMax,
+                            currentCogMin: s.currentCogMin,
+                            currentCogMax: s.currentCogMax,
+                            cogColormap: s.cogColormap,
+                            cogExpression: s.cogExpression,
+                            currentCogExpression: s.currentCogExpression,
                         })
                 } else if (s.type === 'model') {
                     L_.Globe_.litho.addLayer('model', {

--- a/src/essence/Tools/Layers/LayersTool.js
+++ b/src/essence/Tools/Layers/LayersTool.js
@@ -2122,6 +2122,18 @@ function interfaceWithMMGIS(fromInit) {
                 currentCogMin: layer.currentCogMin,
                 currentCogMax: layer.currentCogMax,
             })
+
+            // Also update Cesium if Globe exists
+            if (
+                L_.Globe_ &&
+                L_.Globe_.litho &&
+                L_.Globe_.litho.updateLayerCogParameters
+            ) {
+                L_.Globe_.litho.updateLayerCogParameters(layer.name, {
+                    currentCogMin: layer.currentCogMin,
+                    currentCogMax: layer.currentCogMax,
+                })
+            }
         } else if (layer.type === 'image') {
             // TODO FIXME DOUBLE CHECK
             updateImageRange(
@@ -2166,6 +2178,17 @@ function interfaceWithMMGIS(fromInit) {
             L_.layers.layer[layer.name].refresh(null, true, {
                 currentCogExpression: newExpression,
             })
+
+            // Also update Cesium
+            if (
+                L_.Globe_ &&
+                L_.Globe_.litho &&
+                L_.Globe_.litho.updateLayerCogParameters
+            ) {
+                L_.Globe_.litho.updateLayerCogParameters(layer.name, {
+                    currentCogExpression: newExpression,
+                })
+            }
         } else if (layer.type === 'image') {
             L_.layers.layer[layer.name].refresh(null, true, {
                 currentCogExpression: newExpression,
@@ -2203,6 +2226,17 @@ function interfaceWithMMGIS(fromInit) {
             L_.layers.layer[layerData.name].refresh(null, true, {
                 currentCogExpression: null,
             })
+
+            // Also update Cesium
+            if (
+                L_.Globe_ &&
+                L_.Globe_.litho &&
+                L_.Globe_.litho.updateLayerCogParameters
+            ) {
+                L_.Globe_.litho.updateLayerCogParameters(layerData.name, {
+                    currentCogExpression: null,
+                })
+            }
         } else if (layerData.type === 'image') {
             L_.layers.layer[layerData.name].refresh(null, true, {
                 currentCogExpression: null,
@@ -2429,6 +2463,17 @@ function interfaceWithMMGIS(fromInit) {
             L_.layers.layer[layer.name].refresh(null, true, {
                 currentCogMin: layer.currentCogMin,
             })
+
+            // Also update Cesium
+            if (
+                L_.Globe_ &&
+                L_.Globe_.litho &&
+                L_.Globe_.litho.updateLayerCogParameters
+            ) {
+                L_.Globe_.litho.updateLayerCogParameters(layer.name, {
+                    currentCogMin: layer.currentCogMin,
+                })
+            }
         } else if (layer.type === 'image') {
             updateImageRange(
                 layer.name,
@@ -2466,6 +2511,17 @@ function interfaceWithMMGIS(fromInit) {
             L_.layers.layer[layer.name].refresh(null, true, {
                 currentCogMax: layer.currentCogMax,
             })
+
+            // Also update Cesium
+            if (
+                L_.Globe_ &&
+                L_.Globe_.litho &&
+                L_.Globe_.litho.updateLayerCogParameters
+            ) {
+                L_.Globe_.litho.updateLayerCogParameters(layer.name, {
+                    currentCogMax: layer.currentCogMax,
+                })
+            }
         } else if (layer.type === 'image') {
             updateImageRange(
                 layer.name,


### PR DESCRIPTION
Closes #898 

_With Claude_

# Support TiTiler Layers in Cesium Globe

   ## Summary

   Fixes #898 - TiTiler layers (COG and STAC collections) now render correctly in the 3D Cesium globe with proper color mapping, data rescaling, band math expressions, and time filtering. Previously, these layers appeared in grayscale without any query parameters, while the 2D Leaflet view displayed them correctly.

   ## Changes

   ### 1. Shared URL Building Logic (`LayerUtils.js`)
   - Added `buildTiTilerQueryParams()` function to construct TiTiler query parameters consistently across both Leaflet and Cesium
   - Handles datetime, STAC-specific parameters, rescale, colormap, band math expressions, and mosaic limits
   - Extracted from `leaflet-tilelayer-middleware.js` for reusability

   ### 2. Pass COG Parameters to GlobeRenderer (`Layers_.js`)
   - Modified layer URL construction to use `L_.getUrl()` for proper STAC URL transformation
   - Detects `splitColonType` from original URL ('COG' or 'stac-collection')
   - Passes all COG configuration parameters when adding tile layers to Globe:
     - `cogTransform`, `cogMin`, `cogMax`, `currentCogMin`, `currentCogMax`
     - `cogColormap`, `cogExpression`, `currentCogExpression`
   - Applied to both initial layer addition and layer toggle operations

   ### 3. Build Complete URLs in GlobeRenderer (`GlobeRenderer.js`)
   - Imported `LayerUtils` module for shared URL building
   - Added `_buildTiTilerUrl()` method to construct complete TiTiler URLs with query parameters
   - Modified `_addCesiumLayer()` to apply TiTiler parameters after time parameter replacement
   - Stored COG config and original URL in layer metadata for dynamic updates
   - Added `updateLayerCogParameters()` public method for runtime parameter updates
   - Added `_refreshCogEnabledLayer()` private method to recreate imagery providers with updated parameters
   - Updated `_refreshTimeEnabledLayer()` to preserve COG parameters when time changes

   ### 4. Synchronize UI Updates (`LayersTool.js`)
   - Added Cesium update calls alongside Leaflet refresh in 5 locations:
     - Rescale reset button
     - Band math expression apply button
     - Band math expression reset button
     - Rescale minimum value input change
     - Rescale maximum value input change
   - Ensures both 2D and 3D views update synchronously when users adjust COG parameters

   ## Technical Details

   **Before:**
   ```
   Cesium TiTiler-pgstac URL: .../tiles/10/176/410?assets=asset&bidx=1&resampling=nearest
   Result: Grayscale tiles, no time filtering, default contrast
   ```

   **After:**
   ```
   Cesium TiTiler-pgstac URL: .../tiles/10/176/410?assets=asset&bidx=1&resampling=nearest&datetime=2026-02-18/2026-03-18&exitwhenfull=false&skipcovered=false&rescale=[0,300]&colormap_name=cividis
   Result: Colored tiles matching 2D view, correct time filtering, proper contrast
   ```

   ## Testing

   Tested with STAC collection layers:
   - ✅ Initial layer rendering with correct colors and contrast
   - ✅ Dynamic rescale parameter updates (min/max sliders)
   - ✅ Band math expression apply and reset
   - ✅ Time filtering updates via TimeControl
   - ✅ Layer toggle (off/on) preserves all parameters
   - ✅ Multiple COG layers render independently
   - ✅ 2D Leaflet view continues to work correctly

   ## Files Changed

   - `src/essence/Basics/Layers_/LayerUtils.js` - Added shared URL building function
   - `src/essence/Basics/Layers_/Layers_.js` - Pass COG parameters to Globe, use `getUrl()` for proper URL transformation
   - `src/essence/Basics/Globe_/GlobeRenderer.js` - Build complete URLs with TiTiler parameters, handle dynamic updates
   - `src/essence/Tools/Layers/LayersTool.js` - Synchronize Cesium updates with Leaflet when COG parameters change

