### PR TITLE
Add option to display Latitude/Longitude in coordinates display

### DIFF
--- a/configure/README.md
+++ b/configure/README.md
@@ -79,7 +79,7 @@ The structure of these meta-configuration is as follows:
           "description": "",
           "type": "dropdown",
           "width": 2,
-          "options": ["ll", "en", "cproj", "sproj", "rxy", "site"]
+          "options": ["ll", "ll_r", "en", "cproj", "sproj", "rxy", "site"]
         },
 
         {

--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.2.29-20260320",
+  "version": "4.2.30-20260323",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.2.27-20260319",
+  "version": "4.2.30-20260323",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/configure/src/metaconfigs/tab-coordinates-config.json
+++ b/configure/src/metaconfigs/tab-coordinates-config.json
@@ -188,10 +188,10 @@
         {
           "field": "coordinates.coordmain",
           "name": "Main Coordinate Type",
-          "description": "Sets which coordinates are shown by default in the bottom-right of the map.\n\t<strong>• LL</strong>: Longitude, Latitude\n\t<strong>• EN</strong>: Easting, Northing\n\t<strong>• CPROJ</strong>: Custom Projected (uses Projection tab)\n\t<strong>• SPROJ</strong>: Secondary Projected\n\t<strong>• RXY</strong>: Relative X, Y, (Z) in meters\n\t<strong>• SITE</strong>: Local Level Y, X, -Z",
+          "description": "Sets which coordinates are shown by default in the bottom-right of the map.\n\t<strong>• LL</strong>: Longitude, Latitude\n\t<strong>• LL_R</strong>: Latitude, Longitude\n\t<strong>• EN</strong>: Easting, Northing\n\t<strong>• CPROJ</strong>: Custom Projected (uses Projection tab)\n\t<strong>• SPROJ</strong>: Secondary Projected\n\t<strong>• RXY</strong>: Relative X, Y, (Z) in meters\n\t<strong>• SITE</strong>: Local Level Y, X, -Z",
           "type": "dropdown",
           "width": 4,
-          "options": ["ll", "en", "cproj", "sproj", "rxy", "site"]
+          "options": ["ll", "ll_r", "en", "cproj", "sproj", "rxy", "site"]
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.2.27-20260319",
+  "version": "4.2.30-20260323",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.2.29-20260320",
+  "version": "4.2.30-20260323",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/src/essence/Ancillary/Coordinates.js
+++ b/src/essence/Ancillary/Coordinates.js
@@ -62,6 +62,14 @@ const Coordinates = {
             available: true,
             coordOffset: [0, 0],
         },
+        ll_r: {
+            ancillaryTitle: 'lat/lon',
+            names: ['Latitude', 'Longitude', 'Elevation'],
+            units: ['°', '°', 'm'],
+            precision: [8, 8, 3],
+            available: true,
+            coordOffset: [0, 0],
+        },
         en: {
             ancillaryTitle: 'east/north',
             names: ['Easting', 'Northing', 'Elevation'],
@@ -184,6 +192,22 @@ const Coordinates = {
             )
                 Coordinates.states.ll.coordOffset[1] = parseFloat(
                     L_.configData.coordinates.coordlatoffset || 0
+                )
+
+            // ll_r
+            if (
+                L_.configData.coordinates.coordlatoffset != null &&
+                !isNaN(L_.configData.coordinates.coordlatoffset)
+            )
+                Coordinates.states.ll_r.coordOffset[0] = parseFloat(
+                    L_.configData.coordinates.coordlatoffset || 0
+                )
+            if (
+                L_.configData.coordinates.coordlngoffset != null &&
+                !isNaN(L_.configData.coordinates.coordlngoffset)
+            )
+                Coordinates.states.ll_r.coordOffset[1] = parseFloat(
+                    L_.configData.coordinates.coordlngoffset || 0
                 )
 
             // en
@@ -432,6 +456,12 @@ const Coordinates = {
             case 'll':
                 newCoords[0] = lng + currentState.coordOffset[0]
                 newCoords[1] = lat + currentState.coordOffset[1]
+                if (Coordinates.elevation != null)
+                    newCoords[2] = Coordinates.elevation
+                break
+            case 'll_r':
+                newCoords[0] = lat + currentState.coordOffset[0]
+                newCoords[1] = lng + currentState.coordOffset[1]
                 if (Coordinates.elevation != null)
                     newCoords[2] = Coordinates.elevation
                 break
@@ -729,6 +759,10 @@ function pickLngLatGo() {
         case 'll': //00 lnglat
             finalLng = valA - currentState.coordOffset[0]
             finalLat = valB - currentState.coordOffset[1]
+            break
+        case 'll_r':
+            finalLat = valA - currentState.coordOffset[0]
+            finalLng = valB - currentState.coordOffset[1]
             break
         case 'en': //01 easting northing
             const valALng =


### PR DESCRIPTION
This adds an option in the Coordinates tab in the configure page to display coordinates as "Latitude, Longitude" instead. 

<img width="650" height="1454" alt="Screenshot 2026-03-19 at 3 53 03 PM" src="https://github.com/user-attachments/assets/b6979e94-af09-40f9-8951-5ae9c1fbcc97" />

