### PR TITLE
fix: add curl to runtime stage for healthcheck support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ FROM oraclelinux:8.9 AS runtime
 
 # Runtime dependencies only (smaller, more secure)
 RUN dnf -y update && \
-    dnf -y install ca-certificates && \
+    dnf -y install ca-certificates curl && \
     update-ca-trust enable && \
     update-ca-trust extract && \
     dnf module install -y nodejs:20 && \

--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.3.22-20260423",
+  "version": "4.3.23-20260423",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.3.22-20260423",
+  "version": "4.3.23-20260423",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {


### PR DESCRIPTION
_With Devin_

https://github.com/JPL-Devin/MMGIS/pull/42

The docker-compose.sample.yml healthcheck uses curl to probe http://mmgis:8888/api/utils/healthcheck, but curl was only installed in the builder stage of the Dockerfile, not the runtime stage. Without curl in the runtime image, the healthcheck always fails, the container is marked unhealthy, and dependent services refuse to start.