### PR TITLE
docs(specs): add Offline-Support spec and plan for discussion

### DIFF
--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.3.27-20260428",
+  "version": "4.3.28-20260505",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.3.27-20260428",
+  "version": "4.3.28-20260505",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/specs/Offline-Support/Tariq-Feedback.md
+++ b/specs/Offline-Support/Tariq-Feedback.md
@@ -72,12 +72,12 @@ The app imports ~30 vendored libraries (Leaflet plugins, THREE.js, OpenSeadragon
 Multiple tools make server-side API calls at runtime and will fail offline with no graceful degradation:
 
 | Tool                   | Server Dependency                                   | Offline Feasibility          |
-| ---------------------- | --------------------------------------------------- | ---------------------------- | --------------------- |
+| ---------------------- | --------------------------------------------------- | ---------------------------- |
 | **Measure** (profiles) | `api/utils/getprofile` — server-side GDAL           | Not possible                 |
 | **Identifier**         | `api/utils/getbands` — server-side GDAL             | Not possible                 |
 | **Shade**              | `api/utils/getbands` + `api/utils/ll2aerll` (SPICE) | Not possible                 |
 | **Viewshed**           | Client-side DEM tile fetch via `PNG.load()`         | Possible if DEM tiles cached |
-| **Isochrone**          | Client-side DEM/slope tile fetch                    | Possible if tiles cached     | [7-cite-9](#7-cite-9) |
+| **Isochrone**          | Client-side DEM/slope tile fetch                    | Possible if tiles cached     |
 
 The plan should document which tools work offline, disable server-dependent tools with clear UI when offline, and optionally include DEM tile URLs in the Phase 2 AOI cache for tools that do client-side DEM processing.
 
@@ -151,7 +151,7 @@ The plan says `src/index.js:80`. The actual line is 79. [7-cite-15](#7-cite-15)
 
 ### 24. `Map_.js` line reference is misleading
 
-The plan says _"Modify `Map_.js` (~1272–1452) — add `Map_.getActiveTileLayers()`."_ Those lines are the `makeTileLayer()` function body. The plan is adding a _new_ method, not modifying code at those lines. [7-cite-16](#7-cite-16)
+The plan says _"Modify `Map_.js`(~1272–1452) — add`Map*.getActiveTileLayers()`."* Those lines are the `makeTileLayer()` function body. The plan is adding a _new_ method, not modifying code at those lines. [7-cite-16](#7-cite-16)
 
 ### 25. `leaflet.draw` is vendored, not an npm package
 
@@ -220,3 +220,120 @@ The current `manifest.json` references `logo192.png` and `logo512.png` which are
 8. **Create `config.json` files** for `OfflineTool` and `GPSPathTool` and decide feature flag placement.
 9. **Decide time-dependent tile caching strategy** — lock time slider offline, or cache multiple time steps.
 10. **Add server-side throttling** for TiTiler-routed bulk tile requests.
+
+---
+
+# Is a PWA the right choice?
+
+A PWA is a defensible choice for Phases 1–3, but it's the wrong tool for Phase 4 (GPS tracking), and the plan significantly understates how much of MMGIS's value evaporates offline regardless of approach. Here's the full analysis:
+
+## The Core Problem: What Actually Works Offline?
+
+Before evaluating the delivery mechanism, consider what MMGIS can actually do without its server:
+
+| Capability                        | Server Dependency     | Offline?          |
+| --------------------------------- | --------------------- | ----------------- |
+| View pre-cached raster tiles      | None (if cached)      | Yes               |
+| Draw features with form data      | Write queue           | Yes (deferred)    |
+| Record GPS path                   | None                  | Yes               |
+| Elevation profiles (Measure)      | GDAL on server        | No                |
+| Raster value queries (Identifier) | GDAL / TiTiler        | No                |
+| Viewshed computation              | Client-side DEM tiles | Maybe (if cached) |
+| Shade / sun position              | SPICE on server       | No                |
+| Geodataset queries                | PostGIS               | No                |
+| Dataset links (on-click)          | Express API           | No                |
+| Geodataset filtering              | PostGIS               | No                |
+| 3D Globe (Cesium)                 | Terrain server        | No                |
+| STAC catalog browsing             | STAC API              | No                |
+
+The offline feature set reduces to: **view a cached map, take notes on it, and record where you walked**. That's a legitimate field workflow, but it's a thin slice of MMGIS. The question is whether the complexity of retrofitting a full PWA onto a 100+ dependency SPA is proportionate to that slice.
+
+## PWA Limitations Specific to MMGIS
+
+### 1. The app shell is too heavy to precache
+
+The `src/index.js` entry point eagerly imports vendored THREE.js (14 modules), OpenSeadragon (3 modules), ~20 Leaflet plugins, jQuery, React 18, and more — all before the app even renders: [8-cite-0](#8-cite-0)
+
+On top of that, webpack copies **four directories** of Cesium static assets (Workers, ThirdParty, Assets, Widgets) into the build output. Cesium's static assets alone are typically 30–50 MB: [8-cite-1](#8-cite-1)
+
+A Workbox `InjectManifest` precache of the full MMGIS shell — JS chunks, CSS, Cesium assets, fonts, images — will likely exceed **60–80 MB**. On iOS, where PWA storage can be evicted after ~7 days of non-use, this is a significant concern. The plan doesn't estimate total precache size anywhere.
+
+### 2. Background GPS tracking doesn't work on iOS
+
+This is the most critical issue. The plan's Phase 4 proposes `navigator.geolocation.watchPosition()` for GPS path capture. On iOS:
+
+- **Screen lock** → `watchPosition` callbacks stop firing
+- **App backgrounded** (user switches to another app) → callbacks stop
+- **Wake Lock API** → not supported on iOS Safari / WKWebView
+- **Page Visibility API** → the plan says "pause + visible 'paused' UI" but this means the GPS track has gaps every time the user checks a text message
+
+The plan's risk register lists this as "Cert. / Med" with mitigation "Document; advise device sleep-disable; show banner." That's not a mitigation — it's telling field scientists they can never lock their screen or switch apps during a multi-hour traverse. For a tool targeting iPad/iPhone field use, this is a fundamental capability gap. [8-cite-2](#8-cite-2)
+
+### 3. iOS Safari PWA storage is unreliable
+
+- `navigator.storage.estimate()` returns inflated/inaccurate values on iOS
+- No `navigator.storage.persist()` support in iOS PWAs — storage is always "best effort"
+- Standalone PWAs on iOS use WKWebView, which has different storage behavior than Safari tabs
+- After ~7 days of non-use, iOS can evict all PWA storage (Cache API + IDB)
+
+For a "1–2 day field shift" use case, the 7-day eviction window is probably fine. But if a user installs the PWA, pre-caches tiles on Monday, and doesn't go to the field until the following Monday, their cache may be gone.
+
+### 4. No Background Sync API on iOS
+
+The plan's Phase 3 sync queue relies on detecting `online` events and draining the queue. On Android, the Background Sync API can drain the queue even when the app isn't open. On iOS, there is no Background Sync — the queue only drains when the user has the app open and in the foreground. This is workable but means the user must manually open the app after returning to connectivity.
+
+## Alternatives
+
+### Option A: Capacitor wrapper
+
+[Capacitor](https://capacitorjs.com/) wraps the existing web app in a native iOS/Android shell. It reuses 99% of the codebase and adds native plugin access:
+
+| Capability             | PWA            | Capacitor                     |
+| ---------------------- | -------------- | ----------------------------- |
+| Background GPS         | No (iOS)       | Yes (native plugin)           |
+| Storage eviction       | Yes (iOS, ~7d) | No (native filesystem)        |
+| Background Sync        | No (iOS)       | Yes (native background fetch) |
+| App Store distribution | No             | Yes (optional)                |
+| `beforeinstallprompt`  | No (iOS)       | N/A (native install)          |
+| Wake Lock              | No (iOS)       | Yes (native)                  |
+| Build complexity       | Low            | Medium (Xcode/Android Studio) |
+| Desktop support        | Yes            | No (separate Electron needed) |
+
+Capacitor solves the GPS problem definitively. The `capacitor-background-geolocation` plugin provides continuous tracking even with the screen locked. Storage is native and not subject to browser eviction.
+
+**Downside**: Requires Xcode and Android Studio in the build pipeline, app store review (or enterprise distribution), and a team member who can troubleshoot native build issues. For a NASA/JPL internal tool, enterprise distribution (no App Store review) is likely available.
+
+### Option B: Lightweight companion PWA
+
+Instead of retrofitting the full MMGIS SPA for offline use, build a **separate, lightweight field data collection PWA** that:
+
+- Has its own minimal UI (map viewer + form + GPS)
+- Precaches only what it needs (~2 MB shell, not 60+ MB)
+- Syncs collected data back to the main MMGIS instance via API
+- Doesn't try to replicate MMGIS's full tool suite offline
+
+This sidesteps the precache size problem, the Cesium asset problem, the tool degradation problem, and the configure-app-needs-updates problem. The GPS limitation on iOS remains, but the app is small enough that Capacitor wrapping is trivial if needed later.
+
+### Option C: PWA for Phases 1–3, defer Phase 4
+
+Accept that GPS tracking in a PWA is foreground-only on iOS. Ship Phases 1–3 as a PWA. For Phase 4, either:
+
+- Accept the foreground-only limitation and document it
+- Add Capacitor later specifically for GPS-heavy field deployments
+- Build GPS capture as a separate native/Capacitor micro-app
+
+## Recommendation
+
+**A PWA is the right strategy for Phases 1–3 if and only if:**
+
+1. The precache is scoped aggressively (exclude Cesium assets, exclude vendored THREE.js modules, use runtime caching for non-critical chunks)
+2. The plan acknowledges that most tools are disabled offline and provides clear degradation UI
+3. iOS storage limitations are accepted as a known constraint
+
+**A PWA is the wrong strategy for Phase 4 (GPS tracking) on iOS.** The plan should either:
+
+- Scope Phase 4 to Android-only and desktop (where Wake Lock and background tabs work better)
+- Use Capacitor for Phase 4's mobile delivery
+- Accept foreground-only GPS and document the limitation honestly (not as "advise device sleep-disable")
+
+**The plan should also seriously consider Option B** — a lightweight companion app for field collection. The full MMGIS SPA was never designed for offline use, and the number of deficiencies identified in our review (28 issues, 8 critical) reflects the fundamental mismatch between "make this desktop GIS app work offline" and "build a field data collection tool." A purpose-built companion app would be simpler, more reliable, and easier to maintain.

--- a/specs/Offline-Support/Tariq-Feedback.md
+++ b/specs/Offline-Support/Tariq-Feedback.md
@@ -1,0 +1,222 @@
+_With Devin_
+
+# Deficiency Report: Offline Support (PWA) spec.md and plan.md
+
+This report consolidates all deficiencies identified through codebase verification across our full review. Issues are organized by severity and category.
+
+---
+
+## Critical: Factual Errors and Misrepresentations
+
+### 1. `extant_start` / `extant_end` columns do not exist
+
+The plan states: _"Existing `extant_start` / `extant_end` columns are sufficient for conflict detection — no new columns."_
+
+This is **false**. The `user_features` model defines only `file_id`, `level`, `intent`, `properties`, and `geom` — with `timestamps: false`, meaning there are no `createdAt`/`updatedAt` columns either. There are 4 references to `extant_start` in `draw.js` routes, but these are not backed by a persisted column in the Sequelize model. The entire Phase 3 conflict detection strategy (`baseline_extant_start`) is built on a column that doesn't exist in the schema. [7-cite-0](#7-cite-0)
+
+**Impact**: Phase 3's conflict detection design needs to be reworked. Either `extant_start`/`extant_end` columns must be added via a migration, or an alternative conflict detection mechanism (e.g., a version counter or hash) must be used.
+
+### 2. `public/index.html` has no `<link rel="manifest">` — needs adding, not modifying
+
+The plan says to modify the manifest link to resolve against `ROOT_PATH`. There is **no manifest link** in `index.html` at all. It needs to be _added_, not modified. Similarly, there are no `apple-touch-icon`, `apple-mobile-web-app-capable`, or `apple-mobile-web-app-title` meta tags. [7-cite-1](#7-cite-1)
+
+### 3. `RefreshAuth.js` is CSSO-only, not a general CSRF/auth refresh mechanism
+
+The plan's Open Question #3 asks _"does `src/pre/RefreshAuth.js` issue a token that needs refreshing per drain?"_ — implying it might be a general auth refresh mechanism. It is **exclusively a CSSO (SSO) auth refresh** that checks SSO token expiry and refreshes the inactivity timeout. It only activates when `mmgisglobal.AUTH == 'csso'`. For local auth or other auth backends, this file does nothing. The plan's Phase 3 queue drain auth strategy needs to account for the full auth backend matrix (local, CSSO, off), not just CSSO. [7-cite-2](#7-cite-2)
+
+### 4. The `calls.js` `api()` function already exists — plan mischaracterizes the integration
+
+The plan says _"wrap `$.ajax` in `api()`"_ — but `api()` already exists and already wraps `$.ajax`. The plan should say "intercept the existing `api()` function" or "add offline-aware logic to the existing `api()` call path." The existing `api()` function is the sole entry point for all API calls. [7-cite-3](#7-cite-3)
+
+---
+
+## Critical: Missing Technical Considerations
+
+### 5. Mission config is not explicitly pre-cached
+
+The mission config (`GET /api/configure/get?mission=X`) is **the single most critical data dependency** for offline. Without it, the app is a blank shell — no layers, no tools, no UI structure. The plan mentions `StaleWhileRevalidate` for this endpoint, which is insufficient for cold-start offline. If the cache was evicted (iPadOS can evict after ~7 days), the app is dead. The config must be **explicitly pinned** during the Phase 2 AOI download flow. [7-cite-4](#7-cite-4)
+
+### 6. Geodatasets are completely unaddressed
+
+Geodataset-backed vector layers (`url: "geodatasets:layer_name"`) query PostGIS via `/api/geodatasets/get` on every load. There are two modes:
+
+- **Static geodatasets**: fetched once as GeoJSON. Could be SW-cached but the plan doesn't mention `/api/geodatasets/get` in its caching strategy.
+- **Dynamic extent geodatasets**: re-query the server on every pan/zoom with viewport bounds. Fundamentally incompatible with offline without pre-fetching the full dataset for the AOI.
+- **Geodataset MVT**: served as vector tiles via `/api/geodatasets/get?type=mvt&x={x}&y={y}&z={z}`. Dynamically generated from PostGIS — not addressed by the tile cache.
+
+The plan treats offline as a tiles + Draw mutations problem but ignores this entire data category. [7-cite-5](#7-cite-5)
+
+### 7. Datasets (CSV tabular data) are unaddressed
+
+Dataset links (`variables.datasetLinks`) lazy-load tabular data on feature click via `/api/datasets/get`. Offline, clicking any feature with dataset links will fail silently. The plan doesn't mention datasets at all.
+
+### 8. WebSocket interaction with offline mode is unaddressed
+
+MMGIS has WebSocket support (`ENABLE_MMGIS_WEBSOCKETS`) for real-time collaboration. The spec says _"No offline collaboration (one user offline at a time per file)"_ but neither document addresses:
+
+- What happens to active WebSocket connections when going offline
+- Whether the Draw tool's real-time collaboration conflicts with the offline queue
+- How to enforce "one user offline at a time per file"
+- Whether WebSocket reconnection on network restore could race with the sync queue drain [7-cite-6](#7-cite-6)
+
+### 9. Cesium static assets must be excluded from SW precache
+
+The webpack config copies 4 directories of Cesium assets (Workers, ThirdParty, Assets, Widgets) into the build output. These are large and will bloat the precache manifest if not explicitly excluded in the Workbox `InjectManifest` config. The plan doesn't mention this. [7-cite-7](#7-cite-7)
+
+### 10. Vendored libraries in `src/index.js` inflate precache size
+
+The app imports ~30 vendored libraries (Leaflet plugins, THREE.js, OpenSeadragon, etc.) from `src/external/`. These are bundled into the webpack output and will be part of the precache manifest. The plan doesn't estimate the total precache size or set a budget for the app shell. [7-cite-8](#7-cite-8)
+
+### 11. Server-dependent tools are not addressed for offline degradation
+
+Multiple tools make server-side API calls at runtime and will fail offline with no graceful degradation:
+
+| Tool                   | Server Dependency                                   | Offline Feasibility          |
+| ---------------------- | --------------------------------------------------- | ---------------------------- | --------------------- |
+| **Measure** (profiles) | `api/utils/getprofile` — server-side GDAL           | Not possible                 |
+| **Identifier**         | `api/utils/getbands` — server-side GDAL             | Not possible                 |
+| **Shade**              | `api/utils/getbands` + `api/utils/ll2aerll` (SPICE) | Not possible                 |
+| **Viewshed**           | Client-side DEM tile fetch via `PNG.load()`         | Possible if DEM tiles cached |
+| **Isochrone**          | Client-side DEM/slope tile fetch                    | Possible if tiles cached     | [7-cite-9](#7-cite-9) |
+
+The plan should document which tools work offline, disable server-dependent tools with clear UI when offline, and optionally include DEM tile URLs in the Phase 2 AOI cache for tools that do client-side DEM processing.
+
+### 12. Client-side DEM tile fetching bypasses Leaflet's tile pipeline
+
+The Viewshed and Isochrone tools fetch DEM tiles via `PNG.load()` — a vendored PNG decoder that makes its own HTTP requests, not through Leaflet's tile layer. The SW tile interception from Phase 2 would need to also match these URLs, and `PNG.load()` would need to be able to find cached responses. This is not addressed. [7-cite-10](#7-cite-10)
+
+### 13. Layer Tool advanced filters have two code paths — one breaks offline
+
+- **`LocalFilterer`**: filters already-loaded GeoJSON client-side. Works offline.
+- **`GeodatasetFilterer`**: encodes filters into URL params and triggers a server re-query. Fails offline.
+- **`ESFilterer`**: queries Elasticsearch. Fails offline.
+- **Draw Tool aggregations**: fetches from server for filter autocomplete. Fails offline.
+
+The plan doesn't document which filter paths work offline or provide graceful degradation for server-dependent filtering.
+
+### 14. WMS tiles use BBOX-based URLs, not z/x/y
+
+WMS tiles construct URLs with bounding-box coordinates, not `{z}/{x}/{y}`. The `TileCacheManager`'s tile enumeration logic can't simply iterate z/x/y for WMS layers. The cache key canonicalizer would need to handle BBOX-based URLs differently. The plan lists WMS as a supported format but doesn't address this structural difference. [7-cite-11](#7-cite-11)
+
+### 15. DEM tiles are 32×32 pixels — 64× more tiles per area
+
+MMGIS supports 32×32 pixel DEM tiles (not just 256×256). If DEM/data layers are included in the AOI selector, the tile count explodes by a factor of 64. The plan doesn't distinguish between standard raster tiles and DEM tiles.
+
+### 16. Sync queue error handling is incomplete
+
+The existing `calls.js` error handler passes **no HTTP status code or response body** to the error callback — just `console.warn('error')`. The Phase 3 interceptor needs to parse the actual XHR response to distinguish 401/409/5xx, but the current error handler doesn't expose this. The interceptor will need to replace the error handler entirely. [7-cite-12](#7-cite-12)
+
+### 17. Network failure recovery has multiple unaddressed edge cases
+
+**After max retries**: The plan says "exponential backoff, max 10 attempts" for 5xx but doesn't define a terminal state. Items would be stuck — not in the conflict tray, not discarded, not retrying.
+
+**Lost responses**: Server processes a request but the network drops before the client receives the 200. The plan adds `correlation_uuid` idempotency for `/add`, but `/edit`, `/remove`, `/merge`, and `/split` have no idempotency mechanism. Replaying these after a lost response could cause duplicates or errors.
+
+**Dependent items**: If item 3 (`/add`) fails with 5xx and item 4 is an `/edit` of that same feature, item 4 will fail because the feature doesn't exist. The plan should pause the entire queue on any non-terminal failure, not just on 401.
+
+**Network flapping**: If the network drops mid-drain, some items may have been sent but their responses lost. The plan doesn't specify whether the drain aborts immediately or continues trying remaining items.
+
+### 18. Configure app needs changes — not just "out of scope"
+
+The plan conflates "the configure app doesn't need to become a PWA" (correct) with "the configure app doesn't need any changes" (incorrect). Required changes include:
+
+- **`config.json` files** for `OfflineTool` and `GPSPathTool` — without these, the tools are invisible in the configure page's Tools tab and admins can't enable or configure them.
+- **Feature flag placement** — `mmgisglobal.options.offline` flags need to be settable somewhere (ENV, GeneralOptions, or mission config). The plan doesn't specify which.
+- **GPS target Draw file** configuration in the GPSPathTool config.
+- **Optional per-layer offline eligibility** fields in layer metaconfigs.
+
+### 19. STAC/COG tile URL canonicalization complexity is understated
+
+The `leaflet-tilelayer-middleware.js` constructs STAC/COG tile URLs with many optional parameters: `datetime`, `exitwhenfull`, `skipcovered`, `rescale`, `colormap_name`, `expression`, `items_limit`, `scan_limit`, `time_limit`, `bidx`, `resampling`. The `cacheKey.js` canonicalizer must handle all of these. The plan mentions this as a risk but doesn't enumerate the full parameter set. [7-cite-13](#7-cite-13)
+
+### 20. COG tile URLs include deployment path — cache key must account for it
+
+COG tiles are constructed with `window.location.origin` and `window.location.pathname` baked in. The cache key must account for the deployment path, and the SW's tile route matching must handle this proxied path pattern.
+
+### 21. Time-dependent tile URLs are not addressed
+
+The tile middleware injects `{time}`, `{starttime}`, `{endtime}`, and `{customtime.N}` into tile URLs. If a user changes the time slider while offline, the tile URLs change and won't match cached entries. The plan doesn't address whether time-dependent tiles should be cached at multiple time steps, or whether the time slider should be locked to the cached time range while offline. [7-cite-14](#7-cite-14)
+
+### 22. TiTiler server load from bulk pre-caching
+
+COG and STAC mosaic tiles are dynamically rendered by TiTiler, which runs with `WEB_CONCURRENCY=1`. Bulk-fetching 750+ tiles through TiTiler with a concurrency pool of 6 could saturate or crash the tile server. The plan mentions the concurrency pool but doesn't address server-side rate limiting or differentiated throttling for TiTiler-routed tiles.
+
+---
+
+## Medium: Minor Reference Errors
+
+### 23. Line number off-by-one for `serviceWorker.unregister()`
+
+The plan says `src/index.js:80`. The actual line is 79. [7-cite-15](#7-cite-15)
+
+### 24. `Map_.js` line reference is misleading
+
+The plan says _"Modify `Map_.js` (~1272–1452) — add `Map_.getActiveTileLayers()`."_ Those lines are the `makeTileLayer()` function body. The plan is adding a _new_ method, not modifying code at those lines. [7-cite-16](#7-cite-16)
+
+### 25. `leaflet.draw` is vendored, not an npm package
+
+The plan references `leaflet.draw` as if it's a standard dependency. It's a vendored copy at `src/external/Leaflet/leaflet.draw`. For the AOI rectangle drawing in Phase 2, this works, but the plan should note this to avoid confusion. [7-cite-17](#7-cite-17)
+
+### 26. `manifest.json` references non-existent icons
+
+The current `manifest.json` references `logo192.png` and `logo512.png` which are CRA defaults. The plan says to replace the manifest but doesn't note that MMGIS-branded icons need to be created. [7-cite-18](#7-cite-18)
+
+---
+
+## Medium: Open Questions That Can Be Closed
+
+### 27. Open Question #4 (attachments) can be answered definitively
+
+`DrawTool_Templater.js` does **not** support photo/file attachments. The supported template types are: `checkbox`, `number`, `text`, `textarea`, `range`/`slider`, `dropdown`, `date`, `incrementer`, `point`. No `file`, `image`, or `attachment` type exists. This should be moved from "open question" to "confirmed: not supported, defer to follow-up." [7-cite-19](#7-cite-19)
+
+### 28. Open Question #3 (CSRF refresh) can be partially answered
+
+`RefreshAuth.js` is CSSO-only. For local auth, the session cookie is the only auth state — there is no CSRF token mechanism. The question should be reframed as: "For CSSO deployments, does the SSO token need refreshing before each drain? For local auth, does the session cookie expire during a 1–2 day offline window?" [7-cite-20](#7-cite-20)
+
+---
+
+## Summary Table
+
+| #     | Category                                         | Severity | Phase Affected |
+| ----- | ------------------------------------------------ | -------- | -------------- |
+| 1     | `extant_start`/`extant_end` don't exist in model | Critical | P3             |
+| 2     | No `<link rel="manifest">` in index.html         | Critical | P1             |
+| 3     | `RefreshAuth.js` is CSSO-only                    | Critical | P3             |
+| 4     | `api()` already exists — mischaracterized        | Medium   | P3             |
+| 5     | Mission config not explicitly pre-cached         | Critical | P2             |
+| 6     | Geodatasets unaddressed                          | Critical | P2             |
+| 7     | Datasets unaddressed                             | Medium   | P2             |
+| 8     | WebSocket interaction unaddressed                | Critical | P3             |
+| 9     | Cesium assets bloat precache                     | Medium   | P1             |
+| 10    | Vendored libraries inflate precache              | Medium   | P1             |
+| 11    | Server-dependent tools not degraded              | Critical | P1–P4          |
+| 12    | DEM tile fetch bypasses Leaflet pipeline         | Medium   | P2/P4          |
+| 13    | Filter paths partially break offline             | Medium   | P2             |
+| 14    | WMS tiles use BBOX, not z/x/y                    | Medium   | P2             |
+| 15    | 32px DEM tiles explode tile count                | Medium   | P2             |
+| 16    | Error handler exposes no HTTP status             | Medium   | P3             |
+| 17    | Sync queue recovery edge cases                   | Critical | P3             |
+| 18    | Configure app needs tool configs                 | Critical | P1–P4          |
+| 19    | STAC/COG URL canonicalization understated        | Medium   | P2             |
+| 20    | COG URLs include deployment path                 | Medium   | P2             |
+| 21    | Time-dependent tile URLs unaddressed             | Medium   | P2             |
+| 22    | TiTiler server load from bulk caching            | Medium   | P2             |
+| 23–26 | Minor reference errors                           | Low      | Various        |
+| 27–28 | Closeable open questions                         | Low      | P3             |
+
+**Totals**: 8 Critical, 14 Medium, 6 Low across 28 distinct deficiencies.
+
+---
+
+## Recommended Actions Before Implementation
+
+1. **Verify and add `extant_start`/`extant_end`** to the `user_features` Sequelize model via a migration, or redesign conflict detection around a version counter. This is a P3 blocker.
+2. **Add an "Offline Data Scope" section** to the plan categorizing every data source (config, geodatasets, datasets, tiles, Draw files) with its offline strategy or explicit "out of scope with graceful degradation."
+3. **Add a "Tool Availability Matrix"** documenting which tools work offline, which degrade, and which are disabled.
+4. **Close Open Questions #3 and #4** — the answers are in the codebase.
+5. **Add Cesium asset exclusion** to Phase 1's Workbox config and estimate total precache size.
+6. **Address WebSocket state** during offline periods and on reconnection.
+7. **Add idempotency to `/edit`, `/remove`, `/merge`, `/split`** — not just `/add`.
+8. **Create `config.json` files** for `OfflineTool` and `GPSPathTool` and decide feature flag placement.
+9. **Decide time-dependent tile caching strategy** — lock time slider offline, or cache multiple time steps.
+10. **Add server-side throttling** for TiTiler-routed bulk tile requests.

--- a/specs/Offline-Support/plan.md
+++ b/specs/Offline-Support/plan.md
@@ -1,0 +1,530 @@
+# Offline Support (PWA / Mobile Field Workflow) - Technical Plan
+
+**Spec Reference**: [spec.md](./spec.md)
+**Status**: 📋 Draft (for discussion)
+**Created**: 2026-05-05
+**Last Updated**: 2026-05-05
+
+## Technical Context
+
+MMGIS is a desktop-first SPA on a CRA-derived webpack 5 setup. The codebase already has the right hooks for offline work:
+
+- **`src/serviceWorker.js`** is CRA boilerplate currently `unregister()`-ed at `src/index.js:80` — a clean slate to replace with a Workbox-driven SW.
+- **`src/essence/Basics/Layers_/leaflet-tilelayer-middleware.js`** is the canonical tile-request shaping point and the natural place to integrate cache-aware tile loading.
+- **`src/pre/calls.js`** is a single chokepoint for nearly every mutating API call.
+- **Draw features** already carry server-issued v4 UUIDs in `properties.uuid` (e.g., `API/Backend/Draw/routes/draw.js:732`), and the `/edit` route already accepts `addIfNotFound` and `reassignUUID` flags — adjacent prior art for the new client-supplied identity and conflict fields.
+- **Mobile detection** (`src/essence/Basics/UserInterface_/UserInterface_.js:2-6`) and a mobile CSS file are already in place.
+- **No existing GPS feature** — Phase 4 is greenfield.
+
+### Related Systems
+- Service Worker / browser caches (`Cache API`, `IndexedDB`, `navigator.storage`)
+- Leaflet 2D map and tile pipeline
+- Cesium 3D engine (Phase 2 tile cache only addresses 2D layers in initial scope)
+- Draw tool (collaborative vector editing)
+- Express API for Draw mutations and configuration
+- Reference Mission used as integration sandbox
+
+### Dependencies (new)
+- `workbox-webpack-plugin` (build-time SW injection)
+- `workbox-precaching`, `workbox-routing`, `workbox-strategies`, `workbox-expiration`, `workbox-background-sync`
+
+### Existing Dependencies Reused
+- Leaflet, `leaflet.draw` (already imported in `src/index.js`)
+- Turf.js (Douglas-Peucker simplification)
+- `crypto.randomUUID()` (with `uuid` package fallback)
+- `mmgisglobal.ROOT_PATH` pattern from `src/pre/calls.js:184-188`
+
+### Technology Stack
+- Service Worker generated via Workbox `InjectManifest` (we own the SW source).
+- Tile cache in Cache API; metadata + queues + GPS raw points in IndexedDB.
+- No new server framework — additive Express route changes only.
+
+## Constitution Check
+
+Evaluating against `.specify/memory/constitution.md`:
+
+### I. Documentation-First Development
+**Compliance**: ✅
+**Notes**: This spec + plan exist before any code. Each phase will gain `tasks.md` before implementation.
+
+### II. Clear Requirements
+**Compliance**: ✅
+**Notes**: 16 functional + 7 non-functional requirements with acceptance criteria. 4 user scenarios with measurable outcomes.
+
+### III. Incremental Delivery
+**Compliance**: ✅
+**Notes**: Four independently shippable phases, each behind its own server-side feature flag.
+
+### IV. Quality Standards
+**Compliance**: ✅ (target)
+**Notes**: ESLint clean; ≥80% unit-test coverage on new pure modules (`cacheKey.js`, `SyncQueue.js`, `GpsRecorder.js`); Playwright suite for user-visible behaviors per phase; Lighthouse CI for PWA score.
+
+### V. Node.js & Web-Mapping Best Practices
+**Compliance**: ✅
+**Notes**: Async/await throughout; proper error handling on SW message ports and IDB transactions; Leaflet for 2D, no Cesium changes; GeoJSON LineString for GPS save.
+
+### VI. Geospatial Data Integrity
+**Compliance**: ✅
+**Notes**: Cached tiles are byte-identical to upstream (no transcoding). GPS points stored raw; decimation is reversible (raw retained until save/discard). CRS unchanged — XYZ tiles use existing layer projection.
+
+### VII. Real-time Collaboration Safety
+**Compliance**: ⚠️ (intentional narrow exception)
+**Notes**: One user offline at a time per file. Conflicts are surfaced via server-wins + manual review (NOT silently merged), preserving the integrity guarantee.
+
+## Architecture & Design
+
+### High-Level Architecture
+
+```
+                         ┌──────────────────────────────────────┐
+                         │   MMGIS Browser Tab (Main App)       │
+                         │                                      │
+                         │  ┌──────────────────────────────┐    │
+                         │  │ src/essence/offline/         │    │
+                         │  │  - OfflineStatus             │    │
+                         │  │  - InstallPrompt             │    │
+                         │  │  - TileCacheManager          │    │
+                         │  │  - cacheKey  (shared w/ SW)  │────┼──┐
+                         │  │  - SyncQueue                 │    │  │
+                         │  │  - ConflictTray              │    │  │
+                         │  │  - GpsRecorder               │    │  │
+                         │  │  - idb (schema versions)     │    │  │
+                         │  └──────────────┬───────────────┘    │  │
+                         │                 │                    │  │
+                         │  ┌──────────────▼───────────────┐    │  │
+                         │  │ src/pre/calls.js (api wrap)  │    │  │
+                         │  └──────────────┬───────────────┘    │  │
+                         │                 │ fetch / xhr        │  │
+                         └─────────────────┼────────────────────┘  │
+                                           │                       │
+                         ┌─────────────────▼────────────────────┐  │
+                         │ Service Worker (src/sw/)             │◀─┘
+                         │  - Workbox routes                    │
+                         │  - Tile NetworkFirst→CacheFirst      │
+                         │  - App shell precache                │
+                         │  - StaleWhileRevalidate (read-only)  │
+                         │  - NetworkOnly for write paths       │
+                         └─────────────────┬────────────────────┘
+                                           │ network
+                         ┌─────────────────▼────────────────────┐
+                         │  Express API                         │
+                         │   /api/draw/{add,edit,remove,...}    │
+                         │     ＋ correlation_uuid               │
+                         │     ＋ baseline_extant_start          │
+                         └──────────────────────────────────────┘
+```
+
+### Component Breakdown (cumulative across phases)
+
+**`src/sw/service-worker.js`** *(new)*
+- Workbox-injected SW. Defines precache (`self.__WB_MANIFEST`), runtime caches.
+- Tile route: `CacheFirst` against `mmgis-tiles-v1`, `NetworkFirst` only when missing AND online.
+- Read-side: `StaleWhileRevalidate` for `api/configure/get`, `api/configure/missions`, etc., with user-id-prefixed namespace.
+- Write paths: `NetworkOnly` (denylist) — SW never queues; client owns the queue.
+- Versioned cache namespace `mmgis-shell-v{version}`.
+
+**`src/sw/registration.js`** *(new)*
+- Replaces `src/serviceWorker.js`.
+- Handles `register`, `updatefound`/`waiting`, opt-in `skipWaiting`, online/offline event bus.
+
+**`src/essence/offline/OfflineStatus.js`** *(new)* — UI pill bound to SW event bus.
+**`src/essence/offline/InstallPrompt.js`** *(new)* — `beforeinstallprompt` listener; iOS instructional fallback.
+
+**`src/essence/offline/cacheKey.js`** *(new)*
+- URL canonicalization shared verbatim by SW and client.
+- Normalizes COG / TiTiler param order so `?url=X&bidx=1` and `?bidx=1&url=X` share a cache key.
+- Strips known-volatile params (cache-busters, signed-URL nonces).
+
+**`src/essence/offline/TileCacheManager.js`** *(new)*
+- Pure JS module owning region creation: Leaflet bounds + `{minZoom, maxZoom}` + tile-layer list → ordered tile list.
+- Bounded concurrency pool (~6).
+- Stores in Cache API namespace `mmgis-tiles-v1`.
+- Sidecar `tileMeta` IDB store for size accounting (Cache API has none).
+- `navigator.storage.estimate()` quota enforcement.
+- Manual delete by region.
+
+**`src/essence/Tools/Offline/OfflineTool.js`** *(new)* (`.css`, `config.json`)
+- New tool plugin. Mirrors `src/essence/Tools/Measure/MeasureTool.js`.
+- Region selector (rectangle on map via `leaflet.draw` or "current viewport").
+- Zoom-range slider (default `currentZoom..currentZoom+2`).
+- Layer multi-select.
+- Progress UI; cached regions list with size, age, delete.
+
+**`src/essence/offline/SyncQueue.js`** *(new)*
+- IDB store `mmgisSyncQueue` rows: `{queueId (auto), correlationUuid, endpoint, method, payload, createdAt, attempts, lastError, status}`.
+- Statuses: `pending` | `in_flight` | `conflict` | `done`.
+- API: `enqueue`, `drain`, `peekConflicts`, `discardConflict`, `replayConflict`.
+- FIFO across all endpoints (cross-feature ordering matters).
+- Resolved conflicts go to **head of FIFO**, not tail.
+
+**`src/essence/offline/ConflictTray.js`** *(new)*
+- Sidebar surface in Draw tool.
+- Side-by-side diff (queued payload vs. server-current state, fetched on demand).
+- Discard / Force-replay-with-fresh-baseline.
+
+**`src/essence/Tools/GPSPath/GPSPathTool.js`** *(new)* (`.css`, `config.json`)
+- Tool plugin (`MeasureTool.js` shape).
+- Start / Stop / Pause / Discard buttons.
+- Target Draw file selector (defaults to mission-configured "GPS Tracks").
+- Live stats: duration, distance, accuracy, point count.
+- Wake-lock acquisition (`navigator.wakeLock.request('screen')`); banner when unsupported (iOS).
+
+**`src/essence/offline/GpsRecorder.js`** *(new)*
+- Wraps `navigator.geolocation.watchPosition({enableHighAccuracy: true, maximumAge: 0, timeout: 30000})`.
+- Streams `{lat, lon, alt, accuracy, heading, speed, timestamp}` into IDB store `gpsTracks` keyed by `trackId`.
+- Page Visibility API: pauses ingestion when `document.hidden`.
+- On save: Douglas-Peucker via Turf.js, configurable epsilon (default ~2m); raw retained.
+
+**`src/essence/offline/idb.js`** *(new)*
+- Centralized IDB schema versions: `mmgisSyncQueue` v1, `tileMeta` v1, `gpsTracks` v1, `mmgisOfflineEvents` v1.
+- Coordinated version bumps; clear-error on mismatch rather than silent drop.
+
+### Data Flow
+
+**Tile pre-cache (Phase 2)**:
+```
+User → OfflineTool → TileCacheManager → fetch tiles in pool →
+  → Cache API (mmgis-tiles-v1) + tileMeta IDB → "Region cached" UI
+Render path (offline):
+  Leaflet getTileUrl → SW intercept → cacheKey() → caches.match() → tile
+```
+
+**Mutation sync (Phase 3)**:
+```
+DrawTool action → calls.api('draw_add', ...) →
+  online?  → fetch → response → UI confirm
+  offline? → SyncQueue.enqueue (IDB) → optimistic UI ("pending" badge)
+window.online → SyncQueue.drain →
+  fetch each → 200 OK: status=done; 401: pause + re-auth modal;
+  409: status=conflict (move to tray); 5xx: backoff retry
+```
+
+**GPS capture (Phase 4)**:
+```
+watchPosition tick → GpsRecorder → gpsTracks IDB + live polyline
+Stop & Save → simplify (Turf) + compute metadata →
+  calls.api('draw_add', LineString, correlation_uuid) → Phase-3 path
+```
+
+### Database Changes
+
+**No schema migrations**. All changes are additive at the API layer.
+
+`API/Backend/Draw/routes/draw.js`:
+1. `/add` accepts optional `correlation_uuid` in body. Before insert, look up existing row with same `correlation_uuid` in the file. If found, return existing id/uuid as success (replay-safe).
+2. `/add` does **not** overwrite `req.body.properties.uuid` when set (currently unconditional `newFeature.properties.uuid = uuidv4()` at line 732).
+3. `/edit` accepts optional `baseline_extant_start` timestamp. If current row's `extant_start > baseline_extant_start`, return 409 with current server state.
+
+Existing `extant_start` / `extant_end` columns are sufficient for conflict detection — no new columns.
+
+## API Contracts
+
+### Modified: `POST /api/draw/add`
+
+**New request fields (optional)**:
+```json
+{
+  "...existing fields...": "...",
+  "correlation_uuid": "client-generated v4 UUID for idempotency",
+  "feature": {
+    "properties": {
+      "uuid": "client-generated v4 UUID — server preserves when set"
+    }
+  }
+}
+```
+
+**Response (200, replay)**: when `correlation_uuid` matches an existing row, returns the existing row's id/uuid as if it were a fresh insert.
+
+**Response (200, new)**: same shape as today.
+
+### Modified: `POST /api/draw/edit`
+
+**New request field (optional)**:
+```json
+{
+  "...existing fields...": "...",
+  "baseline_extant_start": "ISO-8601 timestamp of the row's extant_start when the client took its baseline"
+}
+```
+
+**Response (409)**:
+```json
+{
+  "error": "conflict",
+  "server_state": { "...current row payload..." }
+}
+```
+
+### New: `GET /api/configure/get`, `/api/configure/missions` (cache-side only)
+
+No API change. SW caches with `StaleWhileRevalidate` and user-id-prefixed namespace.
+
+## Phased Implementation
+
+Each phase below maps to the spec's user scenarios P1–P4 respectively.
+
+---
+
+### Phase 1 — PWA Shell (P1)
+
+**Deliverable**: Installable PWA with Workbox SW that precaches the app shell, runtime-caches static assets and select read-only API calls, surfaces online/offline state, and exposes an event bus for later phases.
+
+**Files to Create / Modify**:
+- *Create* `src/sw/service-worker.js`, `src/sw/registration.js`.
+- *Create* `src/essence/offline/OfflineStatus.js`, `src/essence/offline/InstallPrompt.js`.
+- *Modify* `public/manifest.json` — replace CRA boilerplate. Real `name`, `short_name="MMGIS"`, `id="/"`, `start_url="./?source=pwa"`, `scope="./"`, `display="standalone"`, `display_override`, `theme_color`, `background_color`, multi-resolution icons (192/256/384/512 + maskable), iOS `apple-touch-icon` set, `screenshots[]`.
+- *Modify* `public/index.html` — `<link rel="apple-touch-icon">`, `<meta name="apple-mobile-web-app-capable">`, status-bar style, `apple-mobile-web-app-title`, `<link rel="manifest">` resolved against `mmgisglobal.ROOT_PATH`.
+- *Modify* `src/index.js:80` — remove `serviceWorker.unregister()`; call new `registration.register({ onUpdate, onSuccess })`.
+- *Modify* `configuration/webpack.config.js` — add `workbox-webpack-plugin`'s `InjectManifest` (not `GenerateSW`). Production-only by default; gate dev with `WORKBOX_DEV=true`.
+- *Modify* `package.json` — add Workbox deps.
+- *Modify* `configure/public/index.html` — explicitly do NOT register a SW; ensure Workbox `exclude` rule prevents precaching.
+
+**Key Decisions**:
+- **`InjectManifest` over `GenerateSW`** — Phase 2 tile cache and Phase 3 queue-replay logic require a custom SW we own.
+- **Dynamic SW scope from `mmgisglobal.ROOT_PATH`** — MMGIS can be served from a sub-path; an incorrect scope makes the SW silently inactive.
+- **Don't precache the templated `index.html`** — it's server-rendered with auth/user/permissions. Use `NetworkFirst` with 3s timeout; fall back to a precached `offline.html` shell.
+- **Skip-waiting opt-in** — show "New version ready, refresh" toast rather than auto-activating; in-flight Draw or GPS work would be lost on a forced reload.
+
+**Reuse**: `mmgisglobal.ROOT_PATH` pattern from `src/pre/calls.js:184-188`; mobile UA detect from `UserInterface_.js:4`; existing top-bar slot for status pill.
+
+**Risks**:
+- iOS Safari `beforeinstallprompt` does not fire — manual instructional modal required.
+- iOS standalone resets storage every ~7 days of non-use — document; show "last sync" warning when older than 5d.
+- Cookie-based `withCredentials` SW interception can break in cross-origin reverse-proxy setups — flag for ops.
+- Sub-path deployments require dynamic scope — test on `/mmgis/` route.
+- Configure-app coexistence — verify Workbox exclude rule on a deployed `/configure`.
+
+**Verification**:
+- Manual: install on iPad Safari, Android Chrome, desktop Chrome; force offline (DevTools), reload, shell renders with "Offline" pill.
+- Manual: deploy to `/mmgis/` sub-path; SW registers correctly.
+- Automated: Playwright test loads app, asserts SW `activated`, goes offline, reloads, asserts shell renders.
+- Lighthouse CI step for PWA score (≥ 90).
+
+---
+
+### Phase 2 — Offline Tile Cache (P2)
+
+**Deliverable**: User pans/zooms to AOI, taps "Make available offline," and MMGIS computes the {z,x,y} tile set for currently-visible tile layers across a chosen zoom range, fetches them, and stores them so they render seamlessly with no network. A "Cached Regions" panel lists regions with size, age, and delete actions.
+
+**Files to Create / Modify**:
+- *Create* `src/essence/offline/TileCacheManager.js`, `src/essence/offline/cacheKey.js`.
+- *Create* `src/essence/Tools/Offline/OfflineTool.js` (`.css`, `config.json`).
+- *Modify* `src/essence/Basics/Layers_/leaflet-tilelayer-middleware.js` — extend `colorFilterExtension.getTileUrl` so that when the layer is in "offline" mode and SW isn't controlling (e.g., dev), `_loadTile` consults `caches.match()` directly. Defense-in-depth fallback when SW is uninstalled or stale.
+- *Modify* `src/sw/service-worker.js` — Workbox route matching tile URL patterns (XYZ/TMS/MVT/TiTiler proxied paths). `CacheFirst` against `mmgis-tiles-v1`, `NetworkFirst` only when missing AND online. Match logic uses `cacheKey.js`.
+- *Modify* `src/essence/Basics/Map_/Map_.js` (~1272–1452) — add `Map_.getActiveTileLayers()` returning layer descriptors `{id, urlTemplate, options, type}` for `TileCacheManager`. No layer construction changes.
+
+**Key Decisions**:
+- **Cache API for tiles, IDB for metadata.** Cache API handles opaque cross-origin responses cleanly and matches the SW's natural primitive. IDB carries byte accounting and region grouping.
+- **User-driven, not predictive.** "Make available offline" is a button. No auto-eviction beyond manual delete; stale regions get a badge but are not auto-purged.
+- **Cache-key canonicalization is the load-bearing piece.** TiTiler URLs carry `?url=&bidx=&rescale=&colormap_name=&expression=` and order/encoding can drift. One canonicalizer between SW and client is the only way they agree.
+- **iPad quota is the binding constraint.** Pre-flight estimate samples 5 tiles, projects total bytes, shows percentage of `navigator.storage.estimate()`'s available budget. Cap regions at 50% of remaining to leave room for Draw + GPS.
+- **No MBTiles/PMTiles import.** Out of scope.
+
+**Reuse**: `leaflet-tilelayer-middleware.js` (existing tile interception point); `leaflet.draw` (already in `src/index.js`) for AOI rectangle; `MeasureTool.js` shape for tool plugin lifecycle; mission `config.json` `data.layers[]` schema for layer enumeration.
+
+**Risks**:
+- Cross-origin opaque responses charged ~7MB each on Safari historically — warn on cross-origin layers; recommend MMGIS proxy.
+- iPadOS quota is small for non-installed PWAs; installation unlocks the larger budget — document.
+- Vector tile renderers need style JSON; ensure styles are precached or included in region downloads.
+- TiTiler dynamic params (`cogMin/cogMax/colormap`) — cache only currently-rendered styling; warn on style change while offline.
+- STAC mosaic params (`items_limit`/`scan_limit`/`time_limit`) need canonicalizer normalization.
+
+**Verification**:
+- Manual: cache viewport over Reference-Mission AOI at z10–14 with 2 layers; go offline; pan/zoom within AOI renders; outside AOI shows transparent placeholder.
+- Manual: storage estimate matches actual usage within 10%.
+- Automated: unit tests for `cacheKey.js` covering TiTiler, MVT, WMS variants. Playwright test for download/delete flow.
+- Reference Mission: add a "Sample Field AOI" preset region in `blueprints/Missions/Reference-Mission/config.reference-mission.json`.
+
+---
+
+### Phase 3 — Offline Data Sync (P3)
+
+**Deliverable**: While offline, a user can add/edit/delete Draw features and submit form data; mutations are queued durably. On reconnect, the queue drains in order. Server-rejected items land in a "Sync Conflicts" tray for manual resolve/discard. Feature creation uses **client-generated UUIDs** so optimistic UI never has to renumber a feature on confirmation.
+
+**Files to Create / Modify**:
+- *Create* `src/essence/offline/SyncQueue.js`, `src/essence/offline/ConflictTray.js`.
+- *Modify* `src/pre/calls.js` — wrap `$.ajax` in `api()`:
+  - GETs pass through (SW handles caching).
+  - POSTs to mutation endpoints (`draw_add`, `draw_edit`, `draw_remove`, `draw_undo`, `draw_merge`, `draw_split`): if `navigator.onLine === false` OR a recent network error to that endpoint, enqueue with `correlationUuid`, return synthesized optimistic success, emit `mmgis:queued` event.
+  - On reconnect (`window.online`), call `SyncQueue.drain()`.
+  - 401 during drain: pause queue, fire re-auth modal, do NOT discard items.
+  - 409 during drain: move to conflict tray with server payload attached.
+  - Other 4xx: conflict tray. 5xx: exponential backoff (cap 5 min, max 10 attempts).
+- *Modify* `src/essence/Tools/Draw/DrawTool_Drawing.js`, `src/essence/Tools/Draw/DrawTool_Editing.js` — pass explicit client-generated `properties.uuid` and a new `correlation_uuid` field to `calls.api('draw_add', ...)`.
+- *Modify* `API/Backend/Draw/routes/draw.js`:
+  1. **Idempotency**: accept optional `correlation_uuid` on `/add`. Before insert, check if a feature with that `correlation_uuid` already exists in the file; if yes, return existing row's id/uuid as success.
+  2. **Client UUID**: when `req.body.properties.uuid` is set, do NOT overwrite at line 732.
+  3. **Conflict detection on /edit**: accept `baseline_extant_start`. If current row's `extant_start > baseline_extant_start`, return 409 with current server state.
+- *Modify* `src/essence/Tools/Draw/DrawTool_Templater.js` — render features with queued mutations using a dashed outline + "pending sync" badge.
+- *Modify* toolbar (locate via `UserInterfaceBridge`) — add sync-status indicator: green (synced), amber (queued, online, draining), red (queued, offline), purple (conflicts).
+
+**Key Decisions**:
+- **Server-wins. Always.** Conflict tray is the only path back. No automatic merge.
+- **Don't depend on Background Sync API.** iOS Safari doesn't implement it. Replay is foreground-only on `window.online`. Use Background Sync as best-effort secondary trigger on Chromium.
+- **Client-generated UUIDs are the keystone.** Without them, optimistic UI must reconcile a server-assigned id later, complicating Phase 4's GPS append-during-tracking flow. Server already round-trips `uuid` in responses; this is a small additive change.
+- **Single FIFO across all endpoints.** Cross-feature ordering matters (an `/edit` of a queued `/add` must run after the add). FIFO + idempotency keys handle this; per-feature subqueues unnecessary.
+- **No Workbox `BackgroundSync` plugin for the queue.** It replays opaquely and gives no hook for 409 → conflict tray routing. We own the queue.
+- **SW does NOT intercept mutating POSTs.** `NetworkOnly` for `/api/draw/*` and other write paths. Queue lives in JS; SW intercepting would duplicate logic.
+
+**Reuse**: existing `properties.uuid` field on every feature; `extant_start`/`extant_end` schema for conflict detection; `addIfNotFound` / `reassignUUID` in `/edit` (adjacent prior art); `triggerWebhooks("drawFileChange", ...)` (line 99 in `draw.js`) — fire after queue drain just as if mutations had been online.
+
+**Risks**:
+- **Auth session expiry mid-offline** — most common 1–2 day failure mode. Catch 401 explicitly, surface re-auth, don't drop queue.
+- **CSRF tokens** may have expired by replay — refresh via `src/pre/RefreshAuth.js` before each drain if applicable.
+- **Photo / file attachments** in Draw forms — store as Blob in IDB, not data URLs, to avoid quota explosion. Verify whether `DrawTool_Templater.js` supports attachments today.
+- **Out-of-order conflict resolution** — resolved items go to **head of FIFO**, not tail, to preserve original chain.
+- **UUID collisions** — require `crypto.randomUUID()`; feature-check, fall back to `uuid` package.
+- **IDB schema drift across deployed clients** — centralized version table; clear-error on mismatch rather than silent drop.
+
+**Verification**:
+- Manual: offline, draw 3 features, edit 1, delete 1; reload (queue persists); go online; verify drain and server state.
+- Manual: while user A is offline, user B edits one of A's features; A reconnects → conflict tray; both Discard and Replay work.
+- Manual: offline, server-side-expire session, go online → drain pauses with re-auth modal; resume after re-auth.
+- Automated: `tests/` integration coverage per mutation type. Unit tests for `SyncQueue` (FIFO, idempotency replay, conflict transitions). Server-side unit tests for new `/add` `correlation_uuid` and `/edit` `baseline_extant_start`.
+- Reference Mission: "Field Observations" Draw file with template using all `DrawTool_Templater.js` field types.
+
+---
+
+### Phase 4 — GPS Path Capture Tool (P4)
+
+**Deliverable**: User opens GPS Path tool, taps "Start," and a live polyline grows on the map as they move. Tap "Stop & Save" emits a LineString feature into a configured Draw file with auto-computed metadata. Offline saves route through Phase 3's sync queue.
+
+**Files to Create / Modify**:
+- *Create* `src/essence/Tools/GPSPath/GPSPathTool.js` (`.css`, `config.json`) — follows `MeasureTool.js` `make:`/`destroy:` lifecycle.
+- *Create* `src/essence/offline/GpsRecorder.js`.
+- *Modify* `src/essence/Basics/Map_/Map_.js` — register a Leaflet polyline for the live track. Subscribe to `GpsRecorder` events for incremental polyline extension. No new layer schema.
+- *Reuse* Phase 3 path on save: `calls.api('draw_add', ...)` with client-generated `properties.uuid`, `correlation_uuid`, and the LineString geometry. Offline → queue. Online → immediate.
+- *Modify* `blueprints/Missions/Reference-Mission/config.reference-mission.json` — add a "GPS Tracks" Draw file with template covering `start_ts`, `end_ts`, `distance_m`, `point_count`, `accuracy_avg_m`, `device_label`.
+
+**Key Decisions**:
+- **Foreground only.** iOS Safari doesn't run JS reliably with screen locked or tab backgrounded. Wake-lock + "keep tab visible" is the user contract.
+- **Save as one LineString**, not many points. Compute stats on save; store as properties.
+- **Decimation on save.** Douglas-Peucker via Turf.js (already in deps) at configurable epsilon (default ~2m). Always retain raw points in `gpsTracks` IDB for forensic export.
+- **Crash recovery.** On tool open, if a `gpsTracks` row is `inProgress`, prompt: "Resume previous track from {time}? (Save / Discard)."
+- **Independent of Phases 2 and 3.** Tool can save online without Phase 3; works without Phase 2's tile cache. Shippable on its own once Phase 1 lands.
+- **Decoration filtering.** Drop first 1–2 points or any with `accuracy > 50m` by default (configurable) to suppress initial-fix drift.
+
+**Reuse**: `MeasureTool.js` shape for tool plugin; Phase 3 sync queue for offline saves (no new persistence path); `DrawTool_Templater.js` template engine for GPS metadata schema (text/number/date already supported); existing Leaflet polyline rendering; Turf.js for Douglas-Peucker.
+
+**Risks**:
+- **HTTPS required** for geolocation — most deployments OK; document for HTTP dev.
+- **Permissions UX**: first-time prompt may be dismissed. Provide "Enable location" empty state with re-prompt button.
+- **Battery drain**: surface a "Battery saver" mode dropping `enableHighAccuracy=false`.
+- **Wake-lock unsupported on iOS Safari** — display tooltip; advise device sleep-disable.
+- **Backgrounded tab silently drops points** — visible "paused" UI; never claim points captured while backgrounded.
+- **Long tracks blow IDB** — cap raw retention at 50k points or 24h and rotate; saved decimated feature is the durable record.
+
+**Verification**:
+- Manual: walk a known route on phone with tool active; live polyline; save; verify LineString matches GPX baseline within accuracy expectations.
+- Manual: offline track → save (queues) → reconnect → confirms in Draw file with correct geometry/metadata.
+- Manual: backgrounding test — track, switch tabs 30s, return; "paused" was visible; resume works.
+- Manual: kill tab mid-track, reopen; "Resume?" prompt; track recoverable.
+- Automated: Playwright with `navigator.geolocation` overrides simulating `watchPosition` callbacks; verify resulting LineString and simplification at various epsilons.
+
+---
+
+## Cross-Cutting Concerns
+
+### Auth / sessions while offline
+- Cookie sessions are existing (`xhrFields: { withCredentials: true }` at `src/pre/calls.js:190-191`). They survive offline as long as the browser keeps the cookie and the server doesn't rotate the session.
+- Three failure modes: (a) cookie expired between offline and online, (b) server restart invalidated session, (c) admin force-logout. All surface as 401 on first replay. Treatment is identical: pause queue, surface re-auth modal, resume on success. **Never embed credentials in the queue.**
+- CSRF: confirm whether `src/pre/RefreshAuth.js` issues a token; if so, refresh before each drain.
+
+### Telemetry
+- IDB `mmgisOfflineEvents` ring buffer (size 500): `{type, timestamp, detail}` for `sw:install`, `sw:activate`, `tile:cached`, `tile:hit`, `tile:miss`, `queue:enqueue`, `queue:drain_start`, `queue:drain_complete`, `queue:conflict`, `gps:start`, `gps:save`.
+- "Download diagnostic log" button in Offline tool.
+- Plumb same events through the existing logger when online.
+
+### Feature flagging
+- Each phase ships behind a server-side flag in `mmgisglobal`:
+  ```
+  mmgisglobal.options.offline = {
+    pwa: true,
+    tileCache: false,
+    syncQueue: false,
+    gpsTrack: false
+  }
+  ```
+- Module-init checks. Operators set via mission/server config; UI toggles can wait.
+
+### Security review of caching mutating responses
+- Mutating endpoints are NEVER cached by the SW. Explicit `NetworkOnly` denylist for `/api/draw/*` and any other write paths.
+- Read-side caching of `/api/files/getfile` and `/api/draw` aggregations: short-TTL `StaleWhileRevalidate`. **Include user identity in cache key** (e.g., `mmgis-data-{user}-v1`) so revoked permissions don't surface stale protected data.
+- Geodatasets MVT responses: cache by URL only; ACL enforced server-side at fetch time. Acceptable for the 1–2 day window.
+- All caches must be cleared on logout — hook the existing logout flow in `src/pre/calls.js:24` to call `caches.keys().then(...delete)` and IDB wipe.
+
+### Versioning & migrations
+- Bump SW cache namespace on any breaking change to cache shape or canonicalizer.
+- IDB schema versions: `mmgisSyncQueue` v1, `tileMeta` v1, `gpsTracks` v1, `mmgisOfflineEvents` v1 — centralized in `src/essence/offline/idb.js` so version bumps coordinate.
+
+---
+
+## Verification Plan (cumulative)
+
+**Manual device matrix**: iPad Safari (current iPadOS), iPhone Safari, Android Chrome, desktop Chrome, desktop Firefox. Each device exercises: install, offline reload, AOI cache + offline pan, queued draw, queue drain, GPS short walk, conflict provoke + resolve.
+
+**Automated**:
+- `tests/offline/` Playwright suite covering each phase's user-visible behaviors.
+- Unit tests in `src/essence/offline/__tests__/` for `cacheKey.js`, `SyncQueue.js`, `GpsRecorder.js` (deterministic, no browser).
+- Server-side unit tests for new `/add` `correlation_uuid` idempotency and `/edit` `baseline_extant_start` conflict detection.
+- Lighthouse CI for PWA score post-Phase-1.
+
+**Reference Mission integration**: each phase adds artifacts to `blueprints/Missions/Reference-Mission/` so a developer can `FORCE_CONFIG_PATH=blueprints/Missions/Reference-Mission/config.reference-mission.json npm start` and exercise the full feature without external services.
+- Phase 1: nothing required.
+- Phase 2: "Sample Field AOI" preset region.
+- Phase 3: "Field Observations" Draw file with full-template coverage.
+- Phase 4: "GPS Tracks" Draw file with metadata template.
+
+---
+
+## Risk Register
+
+| #  | Risk                                                                  | Phase | Likelihood | Impact | Mitigation                                                                                       |
+|----|-----------------------------------------------------------------------|-------|------------|--------|--------------------------------------------------------------------------------------------------|
+| 1  | iOS Safari standalone storage eviction after ~7d unused               | 1     | Med        | High   | Document; "last sync" warning when older than 5d                                                 |
+| 2  | SW scope wrong on sub-path deployments                                | 1     | Med        | High   | Dynamic scope from `mmgisglobal.ROOT_PATH`; deploy test under `/mmgis/`                          |
+| 3  | Configure app accidentally precached / offline-broken                 | 1     | Med        | Med    | Explicit Workbox exclude rule; smoke test deploys                                                |
+| 4  | Tile cache canonicalization bug → cache misses on every render        | 2     | High       | High   | Shared `cacheKey.js` between SW and client; unit tests for every URL family                      |
+| 5  | iPadOS quota smaller than expected for installed PWA                  | 2     | Med        | Med    | Pre-flight estimate; cap region at 50% of available; honest error UI                             |
+| 6  | Cross-origin opaque tile responses charge ~7MB each                   | 2     | Low        | High   | Warn on cross-origin; recommend MMGIS proxy                                                      |
+| 7  | Auth session expires mid-replay → drain blocked                       | 3     | High       | Med    | Detect 401, pause queue, prompt re-auth, resume                                                  |
+| 8  | CSRF token expired by replay                                          | 3     | Med        | Med    | Refresh token at start of each drain                                                             |
+| 9  | Server overwrites client UUID at `draw.js:732`                        | 3     | Cert.      | High   | Explicit code change with idempotency tests                                                      |
+| 10 | Conflict tray accumulates and no user resolves                        | 3     | Med        | Low    | Surface count in toolbar; daily reminder while items present                                     |
+| 11 | Out-of-order conflict resolution corrupts later replays               | 3     | Med        | High   | Resolved items go to head of FIFO, not tail                                                      |
+| 12 | GPS drift on first fixes pollutes track                               | 4     | High       | Low    | Drop first 1–2 points + accuracy filter                                                          |
+| 13 | Wake-lock missing on iOS → screen sleeps mid-track                    | 4     | Cert.      | Med    | Document; advise device sleep-disable; show banner                                               |
+| 14 | Backgrounded tab silently drops points                                | 4     | Cert.      | Med    | Page Visibility pause + visible "paused" UI                                                      |
+| 15 | IDB schema version drift between deployed clients                     | All   | Med        | Med    | Centralized version table in `idb.js`; clear-error on mismatch                                   |
+| 16 | Caches retain protected data after logout                             | All   | Med        | High   | Hook logout to clear caches + IDB; user-id-prefix cache namespaces                               |
+| 17 | Workbox dev-mode caching makes development painful                    | 1     | High       | Low    | Production-only by default; explicit `WORKBOX_DEV=true` opt-in                                   |
+
+---
+
+## Top-of-Stack Critical Files (across phases)
+- `configuration/webpack.config.js`
+- `src/sw/service-worker.js` *(new)*
+- `src/sw/registration.js` *(new)*
+- `src/pre/calls.js`
+- `API/Backend/Draw/routes/draw.js`
+- `src/essence/Basics/Layers_/leaflet-tilelayer-middleware.js`
+- `src/essence/Basics/Map_/Map_.js`
+- `public/manifest.json`
+- `public/index.html`
+- `blueprints/Missions/Reference-Mission/config.reference-mission.json`
+
+---
+
+## Discussion Points (for review)
+
+This plan is intentionally surfacing the following for team feedback before any tasks.md / implementation work:
+
+1. **Phase release strategy** — gate all phases behind flags and release each as it's ready, or hold for a single "Offline Support" GA?
+2. **Auth model for long-offline windows** — is the existing cookie session adequate, or do we want a refresh-token mechanism specifically for installed PWAs?
+3. **Tile-cache scope for 3D / Cesium** — initial scope is 2D Leaflet only. When/if Cesium AOI caching is needed, that's a follow-up.
+4. **Attachment handling** — confirm current `DrawTool_Templater.js` attachment support, and the IDB-Blob path before Phase 3 begins.
+5. **Cross-origin layer policy** — hard-block in AOI selector or warn-and-allow?
+6. **Conflict tray retention policy** — indefinite vs. auto-archive after N days.
+7. **Telemetry sink** — local-only ring buffer or pipe to existing logger?
+8. **Reference-Mission GPS Tracks template** — final field set ownership.

--- a/specs/Offline-Support/spec.md
+++ b/specs/Offline-Support/spec.md
@@ -1,0 +1,298 @@
+# Offline Support (PWA / Mobile Field Workflow) - Specification
+
+**Status**: 📋 Draft (for discussion)
+**Created**: 2026-05-05
+**Last Updated**: 2026-05-05
+
+## Overview
+
+MMGIS today is a desktop-first single-page app. Field users on iPad/phone can authenticate and use the app while online, but cannot install it, lose all map content the moment connectivity drops, and have no durable buffer for in-flight Draw mutations. There is no GPS path capture today.
+
+This feature adds **single-shift (1–2 day) offline support** for a small AOI:
+
+1. Install MMGIS as a PWA on iOS / Android / desktop.
+2. Pre-cache map tiles for a chosen viewport so the map renders offline.
+3. Capture form-driven Draw observations offline; sync when connectivity returns.
+4. Record a GPS path live and save it as a LineString feature (online or offline).
+
+Delivery is split into **four independently-shippable phases**. Phase 1 (PWA shell) is the foundation. Phase 2 (tile cache), Phase 3 (data sync), and Phase 4 (GPS path) each layer on Phase 1 but are independent of each other.
+
+**Configure app (`configure/`) is explicitly out of scope** — only the main MMGIS app becomes a PWA.
+
+## User Scenarios
+
+### P1 - Field User Installs MMGIS and Survives Connectivity Loss
+
+**As a** field scientist on a mission deployment
+**I want to** install MMGIS to my home screen and have the app shell continue to function during brief connectivity gaps
+**So that** I am not blocked when network drops mid-task
+
+**Acceptance Criteria**:
+- [ ] App is installable from iOS Safari, Android Chrome, and desktop Chrome via the standard browser install affordance.
+- [ ] Installed app launches from home screen with custom icon, splash, and `display: standalone`.
+- [ ] When offline, opening the installed app loads the shell (no blank page, no browser error chrome).
+- [ ] Online/offline status is visible in the UI at all times.
+- [ ] On iOS (where `beforeinstallprompt` does not fire), an "Add to Home Screen" instructional modal is available.
+- [ ] App update flow is non-destructive (user is prompted to refresh; in-flight work is not auto-killed).
+
+**User Flow**:
+1. User opens MMGIS in mobile Safari / Chrome.
+2. User taps the in-app "Install" affordance (or follows instructional modal on iOS).
+3. App installs to home screen.
+4. User launches the app, signs in, uses it as normal.
+5. Connectivity drops mid-session — UI surfaces an "Offline" pill; shell remains usable.
+6. Connectivity returns — pill flips to "Online".
+
+### P2 - Field User Pre-Caches an AOI for Offline Map Rendering
+
+**As a** field user about to leave network coverage
+**I want to** select an area of interest and a zoom range and download those tiles to my device
+**So that** the map renders correctly while I'm in the field
+
+**Acceptance Criteria**:
+- [ ] User can select an AOI by drawing a rectangle or by using the current viewport.
+- [ ] User can choose a zoom range (default: current zoom .. current zoom + 2).
+- [ ] User can choose which active layers to include (tile / vectortile / COG / STAC mosaic layers visible on the map).
+- [ ] Pre-flight estimate of total bytes is shown before download begins, expressed both absolutely and as a percentage of available device storage.
+- [ ] Download progress is visible (tiles fetched / total / bytes / failures) and cancellable.
+- [ ] After download, panning and zooming within the AOI renders cached tiles offline; outside the AOI shows a transparent placeholder.
+- [ ] Cached regions appear in a "Cached Regions" panel showing name, size, age, and a delete button.
+- [ ] Storage usage is bounded — by default, a single region is capped at 50% of remaining device quota to leave room for Draw + GPS data.
+
+**User Flow**:
+1. User opens the Offline tool.
+2. User pans / zooms to the AOI and chooses "Use current viewport" (or draws a rectangle).
+3. User picks a zoom range and the layers to include.
+4. User reviews the size estimate, names the region, taps "Download".
+5. Progress UI updates as tiles are fetched.
+6. User goes offline; map continues to render within the AOI.
+7. User returns from the field and deletes the region from the Cached Regions panel.
+
+### P3 - Field User Captures Observations Offline and Syncs Later
+
+**As a** field user collecting observations
+**I want to** add, edit, and delete Draw features (with form data) while offline, and have them sync automatically when I reconnect
+**So that** I do not lose work due to connectivity gaps and do not need to retype data
+
+**Acceptance Criteria**:
+- [ ] While offline, all Draw mutations (add / edit / delete / undo / merge / split) appear to succeed with optimistic UI feedback.
+- [ ] Features created offline display a visual "pending sync" treatment (e.g., dashed outline + badge) until confirmed.
+- [ ] The pending queue persists across page reloads and app restarts.
+- [ ] On reconnect, the queue drains in FIFO order automatically; visible status indicator shows progress.
+- [ ] Server-rejected items (conflicts, validation errors) land in a "Sync Conflicts" tray for manual review.
+- [ ] In the Conflicts tray, the user can see a side-by-side diff of their queued payload vs. current server state and choose **Discard** or **Force replay with fresh baseline**.
+- [ ] If the auth session has expired by the time the queue drains, the user is prompted to re-authenticate; queue is paused (not dropped) and resumes after re-auth.
+- [ ] Conflict resolution is **server-wins** by default — no automatic merge.
+- [ ] Form attachments (photos / files) survive offline persistence without exhausting storage quota.
+
+**User Flow**:
+1. User opens the Draw tool while online; selects a Draw file with a form template.
+2. User loses connectivity; user adds 3 features, edits 1, deletes 1.
+3. Sync indicator shows "queued, offline" (red); features display with "pending" styling.
+4. User force-quits and reopens the app — queued mutations persist.
+5. Connectivity returns; sync indicator flips to "queued, online, draining" (amber); queue drains.
+6. One feature is rejected because another user edited it in the interim — it appears in the Conflicts tray.
+7. User opens the tray, reviews the diff, chooses Discard.
+8. Indicator returns to green ("synced").
+
+### P4 - Field User Captures a GPS Path
+
+**As a** field user walking a transect
+**I want to** record my GPS path live and save it as a LineString feature with metadata
+**So that** I have a durable, georeferenced record of where I went
+
+**Acceptance Criteria**:
+- [ ] User can Start, Pause, Resume, Stop & Save, and Discard a track from the GPS Path tool.
+- [ ] A live polyline grows on the map as the user moves.
+- [ ] On Stop & Save, a LineString feature is written to a configured Draw file with auto-computed metadata: `start_ts`, `end_ts`, `distance_m`, `point_count`, `accuracy_avg_m`, `device_label`.
+- [ ] If saved while offline, the save routes through the Phase 3 sync queue (not lost).
+- [ ] Track is decimated on save (Douglas-Peucker, configurable epsilon, default ~2m); raw points retained in local storage for forensic export.
+- [ ] If the user kills / crashes the tab mid-track, on next open the user is prompted: "Resume previous track from {time}? (Save / Discard)".
+- [ ] On iOS where wake-lock is unsupported, a banner advises the user to disable device sleep.
+- [ ] When the tab is backgrounded, ingestion is paused and a visible "paused" notice is shown — points captured while backgrounded are never silently claimed.
+- [ ] First few points or any with `accuracy > 50m` are dropped by default to suppress initial-fix drift (configurable).
+
+**User Flow**:
+1. User opens the GPS Path tool, selects target Draw file (defaults to mission-configured "GPS Tracks").
+2. User taps Start; permission prompt accepted; wake-lock acquired (where supported).
+3. Live polyline draws on the map; live stats update (duration, distance, accuracy, point count).
+4. User backgrounds the tab briefly to take a photo — "paused" notice appears; track resumes on return.
+5. User taps Stop & Save; LineString feature is written to the Draw file.
+6. If offline, save queues; on reconnect, it drains and the feature appears for collaborators.
+
+## Requirements
+
+### Functional Requirements
+
+**FR-001**: PWA installability across iOS Safari, Android Chrome, and desktop Chrome / Edge.
+- **Priority**: P1
+- **User Scenarios**: P1
+- **Acceptance Criteria**: Standard browser install flow succeeds; installed app launches standalone with custom icon; iOS instructional fallback present.
+
+**FR-002**: Service Worker app-shell precaching with non-destructive update flow.
+- **Priority**: P1
+- **User Scenarios**: P1
+- **Acceptance Criteria**: Cold-cache-miss reload of installed app renders shell offline; update prompts user; in-flight Draw / GPS work is not killed by SW activation.
+
+**FR-003**: Online / offline status indicator in the UI.
+- **Priority**: P1
+- **User Scenarios**: P1, P3
+- **Acceptance Criteria**: Visible status pill in the existing top bar; flips on `online`/`offline` events.
+
+**FR-004**: User-driven AOI tile pre-caching (XYZ, MVT, COG/TiTiler, STAC mosaic).
+- **Priority**: P2
+- **User Scenarios**: P2
+- **Acceptance Criteria**: Region selector (rectangle or current viewport), zoom range, layer multi-select, pre-flight byte estimate, progress UI, cancel.
+
+**FR-005**: Cached Regions management panel.
+- **Priority**: P2
+- **User Scenarios**: P2
+- **Acceptance Criteria**: List of named regions with size, age, delete action.
+
+**FR-006**: SW-based tile fetch interception with shared canonicalization between SW and client.
+- **Priority**: P2
+- **User Scenarios**: P2
+- **Acceptance Criteria**: Cached tiles render offline; cache keys are stable across param ordering / encoding variation; defense-in-depth fallback when SW is missing.
+
+**FR-007**: Durable, ordered offline mutation queue for Draw endpoints.
+- **Priority**: P3
+- **User Scenarios**: P3
+- **Acceptance Criteria**: Queue persists in IndexedDB across reloads; FIFO drain on reconnect; statuses `pending`, `in_flight`, `conflict`, `done`.
+
+**FR-008**: Client-generated UUIDs and idempotent `/draw/add` (via `correlation_uuid`).
+- **Priority**: P3
+- **User Scenarios**: P3
+- **Acceptance Criteria**: Server preserves client-set `properties.uuid`; replays of the same `correlation_uuid` return the existing row's identity (replay-safe).
+
+**FR-009**: Server-wins conflict detection on `/draw/edit` via `baseline_extant_start`.
+- **Priority**: P3
+- **User Scenarios**: P3
+- **Acceptance Criteria**: If current row's `extant_start > baseline_extant_start`, server returns 409 with current state; client moves item to Conflicts tray.
+
+**FR-010**: Sync Conflicts tray with diff, discard, and force-replay.
+- **Priority**: P3
+- **User Scenarios**: P3
+- **Acceptance Criteria**: Tray surfaces all `conflict`-status items; resolved replays go to head of FIFO (not tail); discarded items are removed.
+
+**FR-011**: Auth-aware queue drain (pause on 401, resume after re-auth).
+- **Priority**: P3
+- **User Scenarios**: P3
+- **Acceptance Criteria**: 401 during drain pauses queue, prompts re-auth modal, never discards items; CSRF token refreshed before each drain if applicable.
+
+**FR-012**: GPS Path tool with Start / Pause / Resume / Stop & Save / Discard lifecycle.
+- **Priority**: P4
+- **User Scenarios**: P4
+- **Acceptance Criteria**: Live polyline; live stats; wake-lock on supported platforms; configurable target Draw file.
+
+**FR-013**: Crash-recoverable raw-point storage and on-save Douglas-Peucker decimation.
+- **Priority**: P4
+- **User Scenarios**: P4
+- **Acceptance Criteria**: Raw points retained in IDB until explicit save/discard; saved feature is the decimated LineString with computed metadata; "Resume previous track?" prompt on tool re-open.
+
+**FR-014**: Backgrounded-tab pause with visible UI; never claim points captured while hidden.
+- **Priority**: P4
+- **User Scenarios**: P4
+- **Acceptance Criteria**: Page Visibility API drives pause; "paused" banner is visible; resume on return to foreground.
+
+**FR-015**: Cache and IDB clear on logout.
+- **Priority**: P1 (security)
+- **User Scenarios**: All
+- **Acceptance Criteria**: Logout flow purges SW caches and offline IDB stores; user-id-prefixed cache namespaces ensure no cross-user leakage.
+
+**FR-016**: Per-phase server-side feature flags in `mmgisglobal.options.offline`.
+- **Priority**: P1
+- **User Scenarios**: All
+- **Acceptance Criteria**: `{ pwa, tileCache, syncQueue, gpsTrack }` flags gate module init; operators control rollout.
+
+### Non-Functional Requirements
+
+**NFR-001**: Offline duration target.
+- **Category**: Usability
+- **Metric**: Single shift, up to 1–2 days, on a small AOI with small data payloads (form submissions + GPS paths).
+
+**NFR-002**: Tile cache storage budget.
+- **Category**: Storage
+- **Metric**: A single region is capped at 50% of `navigator.storage.estimate()` available budget; pre-flight estimate accurate within 10% of actual.
+
+**NFR-003**: Mutating endpoints are never SW-cached.
+- **Category**: Security
+- **Metric**: Explicit `NetworkOnly` denylist for `/api/draw/*` and all write paths.
+
+**NFR-004**: Read-side caches include user identity in cache key.
+- **Category**: Security
+- **Metric**: `mmgis-data-{user}-v1` style namespacing prevents revoked-permission stale data leakage.
+
+**NFR-005**: Sub-path deployments must work.
+- **Category**: Compatibility
+- **Metric**: SW scope derived from `mmgisglobal.ROOT_PATH`; deploy test passes under `/mmgis/`.
+
+**NFR-006**: PWA Lighthouse score.
+- **Category**: Quality
+- **Metric**: Lighthouse PWA score ≥ 90 post-Phase-1, enforced in CI.
+
+**NFR-007**: Configure app coexistence.
+- **Category**: Compatibility
+- **Metric**: SW does not register on `/configure`; Workbox `exclude` rule prevents precaching of `configure/public/index.html`.
+
+## Scope & Constraints
+
+### In Scope
+- Main MMGIS app PWA shell (Phase 1).
+- User-driven AOI tile pre-caching (Phase 2).
+- Draw mutation sync queue with conflict tray (Phase 3).
+- GPS path capture tool (Phase 4).
+- Reference Mission updates to exercise each phase end-to-end.
+
+### Out of Scope
+- No native iOS / Android shells.
+- No mobile UX redesign — Phase 1 just makes existing UI installable and offline-resilient.
+- No offline collaboration (one user offline at a time per file).
+- No MBTiles / PMTiles import.
+- Configure app is **not** made into a PWA.
+- No automatic merge of conflicting edits — server-wins, manual review only.
+
+### User-Confirmed Product Decisions
+- Offline duration target: single shift, 1–2 days, small AOI, small data payloads.
+- Tile bundles: user-driven viewport download.
+- Conflicts: **server-wins** with manual conflict tray resolution.
+- Plan shape: one phased plan, each phase ships independently.
+
+## Success Criteria
+
+**Definition of Done (per phase)**:
+- [ ] All in-phase functional requirements implemented.
+- [ ] Acceptance criteria for the phase's user scenario(s) verified manually on the device matrix (iPad Safari, iPhone Safari, Android Chrome, desktop Chrome, desktop Firefox).
+- [ ] Automated tests added per phase (Playwright for user-visible behaviors; unit tests for pure modules; server-side tests for new endpoint behaviors).
+- [ ] Reference Mission artifact added for the phase (where applicable).
+- [ ] Feature flag wired and defaults to **off** at merge.
+- [ ] Constitution compliance reviewed.
+
+**Cumulative Metrics**:
+- Lighthouse PWA score ≥ 90 after Phase 1.
+- AOI cache pre-flight estimate within 10% of actual usage after Phase 2.
+- 100% of Draw mutations replay-safe (idempotent on `correlation_uuid`) after Phase 3.
+- GPS save round-trip works offline → online with metadata intact after Phase 4.
+
+## Open Questions
+
+These are explicitly raised for discussion. None block starting Phase 1.
+
+1. **Phase ordering and interleaving** — Phases 2/3/4 are independent of each other. Do we want them all to land before any goes GA, or release each behind its flag as it ripens?
+2. **Auth strategy across long offline windows** — current cookie sessions may rotate or expire over 1–2 days. Is a longer-lived session acceptable for installed PWAs, or do we want to issue a refresh-token mechanism specifically for offline use?
+3. **CSRF refresh path** — does `src/pre/RefreshAuth.js` issue a token that needs refreshing per drain, or is the cookie session the only auth state? (Confirm before Phase 3 implementation.)
+4. **Photo / file attachments in Draw forms** — does `DrawTool_Templater.js` currently support attachments? If yes, IDB Blob storage is required; if no, defer to a follow-up.
+5. **Telemetry destination** — is the IDB ring-buffer + "Download diagnostic log" enough, or do we want to plumb to an existing logger / Splunk-style destination when online?
+6. **Cross-origin tile providers** — Safari's historical 7MB-per-opaque-response charge may make cross-origin pre-caching untenable. Do we hard-block cross-origin layers in the AOI selector or just warn?
+7. **Conflict tray retention** — do conflict items persist forever until user resolves, or auto-archive after N days?
+8. **Reference-Mission GPS Tracks template** — exact field set TBD with the science / ops stakeholders.
+9. **Storage quota messaging** — what's the right UX when iPadOS evicts standalone storage after ~7 days unused? Banner? Pre-emptive nudge after 5 days?
+10. **Configure-page coexistence test** — should we add a CI smoke test that hits `/configure` after deploy and confirms no SW registration?
+
+## References
+
+- Source plan: `/Users/jleach/.claude/plans/we-re-running-into-a-cheeky-crayon.md`
+- Technical Plan: [plan.md](./plan.md)
+- Constitution: `.specify/memory/constitution.md`
+- Existing tile interception: `src/essence/Basics/Layers_/leaflet-tilelayer-middleware.js`
+- Existing API call chokepoint: `src/pre/calls.js`
+- Existing Draw API: `API/Backend/Draw/routes/draw.js`


### PR DESCRIPTION
Adds specs/Offline-Support/{spec.md,plan.md} drafting a phased PWA / offline mobile field workflow:
  Phase 1 — PWA shell (installable, app-shell SW, status pill)
  Phase 2 — User-driven AOI tile pre-cache
  Phase 3 — Durable Draw mutation queue with server-wins conflict tray
  Phase 4 — GPS path capture tool (LineString save via sync queue)

Each phase is independently shippable behind a server-side feature flag. Documents are intended as a discussion starting point and call out open questions on auth, attachments, cross-origin layers, and release strategy.

Using this PR as a method to do some discussions on the plan and see what we think