### PR TITLE
#960 Fix DrawTool - Templated point type points do not respect time filtering

### DIFF
--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.3.29-20260505",
+  "version": "4.3.30-20260507",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.3.29-20260505",
+  "version": "4.3.30-20260507",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/src/essence/Tools/Draw/DrawTool.js
+++ b/src/essence/Tools/Draw/DrawTool.js
@@ -1642,6 +1642,68 @@ var DrawTool = {
                                 }
                             }
                         })
+                    } else if (l._isAssociatedPoint) {
+                        const parentLayer = L_.layers.layer[
+                            `DrawTool_${fileId}`
+                        ].find((pl) => {
+                            if (pl == null) return false
+                            // Direct feature on layer (Point, annotation)
+                            if (
+                                pl.feature?.properties?._?.id ===
+                                l._parentFeatureId
+                            )
+                                return true
+                            // Feature nested inside _layers (LineString, Polygon via L.geoJson)
+                            if (pl._layers) {
+                                return Object.values(pl._layers).some(
+                                    (sl) =>
+                                        sl.feature?.properties?._?.id ===
+                                        l._parentFeatureId
+                                )
+                            }
+                            return false
+                        })
+
+                        // Default visible if parent not found or time filtering is off
+                        let isVisible = true
+                        if (parentLayer) {
+                            const parentFeature =
+                                parentLayer.feature ||
+                                (parentLayer._layers &&
+                                    Object.values(parentLayer._layers).find(
+                                        (sl) =>
+                                            sl.feature?.properties?._?.id ===
+                                            l._parentFeatureId
+                                    )?.feature)
+                            if (parentFeature) {
+                                isVisible =
+                                    DrawTool._isFeatureTemporallyVisible(
+                                        parentFeature,
+                                        startField,
+                                        endField
+                                    )
+                            }
+                        }
+
+                        if (l.savedOptions == null)
+                            l.savedOptions = {
+                                opacity: l.options.opacity,
+                                fillOpacity: l.options.fillOpacity,
+                            }
+
+                        l.temporallyHidden = !isVisible
+                        if (l.temporallyHidden) {
+                            l.setStyle({ opacity: 0, fillOpacity: 0 })
+                            if (l._path?.style)
+                                l._path.style.pointerEvents = 'none'
+                        } else if (l.savedOptions) {
+                            l.setStyle({
+                                opacity: l.savedOptions.opacity,
+                                fillOpacity: l.savedOptions.fillOpacity,
+                            })
+                            if (l._path?.style)
+                                l._path.style.pointerEvents = 'all'
+                        }
                     }
                 } else {
                     const isVisible = DrawTool._isFeatureTemporallyVisible(

--- a/src/essence/Tools/Draw/DrawTool_Editing.js
+++ b/src/essence/Tools/Draw/DrawTool_Editing.js
@@ -149,6 +149,14 @@ var Editing = {
                 }
             }
         } else if (DrawTool.contextMenuLayer) {
+            const departingFeatureId =
+                DrawTool.contextMenuLayer?.feature?.properties?._?.id
+            if (departingFeatureId && DrawTool.showAssociatedPoints) {
+                DrawTool.showAssociatedPoints(
+                    departingFeatureId,
+                    DrawTool.lastContextLayerIndexFileId?.layer
+                )
+            }
             resetShape()
         }
 


### PR DESCRIPTION
_With Claude_

Closes #960

Fixes two bugs with type: 'point' templated points in DrawTool files:

  1. Templated points not hidden by Temporal Drawings
  When "Temporal Drawings" is enabled and a parent feature is filtered out by time, its
  associated L.circleMarker points remained visible. The timeFilterDrawingLayer loop had
  two branches (arrow layer groups and regular features) but no branch for associated
  point markers, which carry _isAssociatedPoint = true and no .feature or ._layers. Added
  a third branch that looks up the parent feature (searching both direct .feature and
  nested ._layers for LineString/Polygon types) and applies the same opacity-0/restore
  logic. Defaults to visible when no parent is found or time filtering is off, to avoid
  breaking non-temporal use.

  2. Templated points disappearing when switching selected features
  When clicking a second polygon while one was already selected for editing,
  hideAssociatedPoints was called for the new feature but showAssociatedPoints was never
  called for the departing one. Its marker sat removed from the Leaflet map (flagged
  _wasHidden) with no restore path until the next DynamicExtent reload (pan/zoom). Fixed
  in showContextMenu by calling showAssociatedPoints for the departing feature before
  resetShape().