### PR TITLE
#966 Poor configure/upsert SQL and websocket body causes memory spike.

### DIFF
--- a/API/Backend/Config/routes/configs.js
+++ b/API/Backend/Config/routes/configs.js
@@ -518,23 +518,23 @@ function upsert(req, res, next, cb, info) {
 
   const forceClientUpdate = req.body?.forceClientUpdate || false;
 
-  Config.findAll({
+  Config.max("version", {
     where: {
       mission: req.body.mission,
     },
-    order: [["id", "DESC"]],
   })
-    .then((missions) => {
-      missions.every(function (mission, i) {
-        if (hasVersion && missions[i].version == req.body.version) {
-          versionConfig = missions[i].config;
-          return false;
-        }
-        return true;
-      });
+    .then((maxVersion) => {
+      const currentVersion = maxVersion == null || isNaN(maxVersion) ? -1 : maxVersion;
 
-      if (missions && missions.length > 0) return missions[0].version;
-      return -1;
+      if (hasVersion) {
+        return Config.findOne({
+          where: { mission: req.body.mission, version: req.body.version },
+        }).then((match) => {
+          if (match) versionConfig = match.config;
+          return currentVersion;
+        });
+      }
+      return currentVersion;
     })
     .then((version) => {
       let configJSON;
@@ -658,7 +658,10 @@ function upsert(req, res, next, cb, info) {
           }
 
           openWebSocket(
-            req.body,
+            {
+              mission: req.body.mission,
+              config: true,
+            },
             {
               status: "success",
               mission: created.mission,

--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "4.3.30-20260507",
+  "version": "4.3.31-20260511",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "4.3.30-20260507",
+  "version": "4.3.31-20260511",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {


### PR DESCRIPTION
Closes #966 

_With Claude_

Fix config upsert memory spike on save (#966)               
   
  The upsert function was causing significant memory pressure 
  when saving large mission configs (~1.5MB), particularly for
   missions with many historical versions.

  Changes to API/Backend/Config/routes/configs.js:

  1. Replace Config.findAll with targeted queries — the old
  code loaded every historical config row (full blobs) just to
   find the latest version number. Replaced with
  Config.max("version", ...) to fetch only the version number,
   plus a single Config.findOne only when a specific
  historical version is requested. Eliminates N×1.5MB of
  unnecessary data being loaded into memory.
  2. Strip config blob from WebSocket broadcast —
  openWebSocket was called with the full req.body (including
  the ~1.5MB config), broadcasting it to every connected
  client. Replaced with a minimal { mission, config: true }
  object. Frontend consumers only need body.mission for
  mission filtering and body.config as a truthy signal — they
  never use the actual config content from the WebSocket
  message.
