### PR TITLE
fix: correct adjacent server URL rewriting when behind a reverse proxy/load balancer

### DIFF
--- a/adjacent-servers/adjacent-servers-proxy.js
+++ b/adjacent-servers/adjacent-servers-proxy.js
@@ -25,6 +25,10 @@ function initAdjacentServersProxy(app, isDocker, ensureAdmin, ensureUserForAdjac
         },
         selfHandleResponse: true,
         on: {
+          proxyReq: (proxyReq, req, res) => {
+            proxyReq.setHeader("X-Forwarded-Host", req.get("host"));
+            proxyReq.setHeader("X-Forwarded-Proto", req.headers["x-forwarded-proto"] || req.protocol);
+          },
           proxyRes: createSwaggerInterceptor("stac", stacTarget),
         },
       })
@@ -272,6 +276,10 @@ const createSwaggerInterceptor = (path, target) => {
         res.get("Content-Type").includes("html"))
     ) {
       newResponse = newResponse || responseBuffer.toString("utf8");
+      const serviceHost = new URL(target).hostname;
+      newResponse = newResponse.replaceAll(`https://${serviceHost}/`, `${req.protocol}://${req.get("host")}/${path}/`);
+      newResponse = newResponse.replaceAll(`https://${serviceHost}`, `${req.protocol}://${req.get("host")}/${path}`);
+      newResponse = newResponse.replaceAll(`http://${serviceHost}/`, `${req.protocol}://${req.get("host")}/${path}/`);
       newResponse = newResponse.replaceAll(
         target,
         `${req.protocol}://${req.get("host")}/${path}`

--- a/adjacent-servers/adjacent-servers-proxy.js
+++ b/adjacent-servers/adjacent-servers-proxy.js
@@ -51,6 +51,10 @@ function initAdjacentServersProxy(app, isDocker, ensureAdmin, ensureUserForAdjac
         },
         selfHandleResponse: true,
         on: {
+          proxyReq: (proxyReq, req, res) => {
+            proxyReq.setHeader("X-Forwarded-Host", req.get("host"));
+            proxyReq.setHeader("X-Forwarded-Proto", req.headers["x-forwarded-proto"] || req.protocol);
+          },
           proxyRes: createSwaggerInterceptor("tipg", tipgTarget),
         },
       })
@@ -89,6 +93,10 @@ function initAdjacentServersProxy(app, isDocker, ensureAdmin, ensureUserForAdjac
         },
         selfHandleResponse: true,
         on: {
+          proxyReq: (proxyReq, req, res) => {
+            proxyReq.setHeader("X-Forwarded-Host", req.get("host"));
+            proxyReq.setHeader("X-Forwarded-Proto", req.headers["x-forwarded-proto"] || req.protocol);
+          },
           proxyRes: createSwaggerInterceptor("titiler", titilerTarget),
         },
       })
@@ -113,6 +121,10 @@ function initAdjacentServersProxy(app, isDocker, ensureAdmin, ensureUserForAdjac
         },
         selfHandleResponse: true,
         on: {
+          proxyReq: (proxyReq, req, res) => {
+            proxyReq.setHeader("X-Forwarded-Host", req.get("host"));
+            proxyReq.setHeader("X-Forwarded-Proto", req.headers["x-forwarded-proto"] || req.protocol);
+          },
           proxyRes: createSwaggerInterceptor(
             "titilerpgstac",
             titilerpgstacTarget
@@ -276,14 +288,17 @@ const createSwaggerInterceptor = (path, target) => {
         res.get("Content-Type").includes("html"))
     ) {
       newResponse = newResponse || responseBuffer.toString("utf8");
-      const serviceHost = new URL(target).hostname;
-      newResponse = newResponse.replaceAll(`https://${serviceHost}/`, `${req.protocol}://${req.get("host")}/${path}/`);
-      newResponse = newResponse.replaceAll(`https://${serviceHost}`, `${req.protocol}://${req.get("host")}/${path}`);
-      newResponse = newResponse.replaceAll(`http://${serviceHost}/`, `${req.protocol}://${req.get("host")}/${path}/`);
-      newResponse = newResponse.replaceAll(
-        target,
-        `${req.protocol}://${req.get("host")}/${path}`
-      );
+      const { hostname: serviceHost, port: servicePort } = new URL(target);
+      const publicBase = `${req.protocol}://${req.get("host")}/${path}`;
+      // Replace port-qualified variants first to avoid partial matches on bare hostname
+      if (servicePort) {
+        newResponse = newResponse.replaceAll(`https://${serviceHost}:${servicePort}/`, `${publicBase}/`);
+        newResponse = newResponse.replaceAll(`https://${serviceHost}:${servicePort}`, publicBase);
+      }
+      newResponse = newResponse.replaceAll(`https://${serviceHost}/`, `${publicBase}/`);
+      newResponse = newResponse.replaceAll(`https://${serviceHost}`, publicBase);
+      newResponse = newResponse.replaceAll(`http://${serviceHost}/`, `${publicBase}/`);
+      newResponse = newResponse.replaceAll(target, publicBase);
     }
 
     return newResponse || finalReturn;


### PR DESCRIPTION
## Summary

Fixes #753

When MMGIS is deployed behind a load balancer that terminates SSL (e.g. AWS ALB), adjacent services like `stac-fastapi` receive proxied requests where `changeOrigin: true` rewrites the `Host` header to the internal Docker service name (e.g. `stac-fastapi`). The upstream service then builds self-referencing URLs using that internal hostname.

The existing `replaceAll` in `createSwaggerInterceptor` only matched the explicit `http://service:port` target string — but when the upstream service also picks up `X-Forwarded-Proto: https` from the ALB (passed through unchanged by the proxy), it generates URLs like `https://stac-fastapi/collections` instead of `http://stac-fastapi:8881/collections`. This variant was never matched, so internal hostnames leaked through to clients.

## Changes

- **`proxyReq` handler on the STAC proxy**: forwards `X-Forwarded-Host` (the real public hostname) and `X-Forwarded-Proto` to the upstream service, so it can natively build correct public URLs when configured with `--proxy-headers`
- **Broadened URL replacement in `createSwaggerInterceptor`**: extracts the service hostname from the target URL and replaces all variants (`http://`, `https://`, with and without port) as a reliable fallback for any upstream service

## Testing

Verified on a deployment behind an AWS ALB with `stac-fastapi-pgstac`. Before the fix, STAC catalog responses contained `https://stac-fastapi/collections`. After the fix, responses correctly contain `https://<public-domain>/stac/collections`.

For `stac-fastapi`, also add the following flags to the uvicorn command so it trusts the forwarded headers:
```
--proxy-headers --forwarded-allow-ips='*' --root-path /stac
```