### PR TITLE
fix: db volume mount path for postgres 18

### DIFF
--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -245,6 +245,6 @@ services:
       timeout: 8s
     restart: on-failure
     volumes:
-      - mmgis-db:/var/lib/postgresql/data
+      - mmgis-db:/var/lib/postgresql
 volumes:
   mmgis-db:


### PR DESCRIPTION
postgis:18 stores data in a version specific subdir and expects the volume at /var/lib/postgresql, not /var/lib/postgresql/data. On a fresh install the old path makes the db container crash-loop, so mmgis never starts (container mmgis-db-1 is unhealthy).

Left over from the postgres16 to 18 upgrade (#935). 
Tested with down -v then up -d on a clean volume.
