### PR TITLE
fix: preserve development startup logs in terminal scrollback

### DIFF
--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "5.2.25-20260804",
+  "version": "5.2.26-20260805",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "5.2.25-20260804",
+  "version": "5.2.26-20260805",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -885,7 +885,6 @@ function setupDevServer() {
   const HOST = "localhost";
   const config = configFactory("development");
   const protocol = process.env.HTTPS === "true" ? "https" : "http";
-  const isInteractive = process.stdout.isTTY;
   const { URL } = require("url");
   const lanUrl = new URL(`${protocol}://${HOST}:${port}${paths.publicUrlOrPath.slice(0, -1)}`);
   const urls = {
@@ -958,10 +957,6 @@ function setupDevServer() {
     if (err) {
       return console.log(err);
     }
-    if (isInteractive) {
-      console.clear();
-    }
-
     // We used to support resolving modules according to `NODE_PATH`.
     // This now has been deprecated in favor of jsconfig/tsconfig.json
     // This lets you use absolute paths in imports inside large monorepos:

--- a/tests/unit/server-startup-logs.spec.js
+++ b/tests/unit/server-startup-logs.spec.js
@@ -1,0 +1,30 @@
+/**
+ * Regression coverage for development-server startup logging.
+ *
+ * Startup output must remain in an interactive terminal's scrollback after
+ * the delayed Webpack development server starts.
+ */
+
+import { test, expect } from '@playwright/test';
+const fs = require('fs');
+const path = require('path');
+
+test.describe('Development server startup logs', () => {
+  let serverContent;
+
+  test.beforeAll(() => {
+    serverContent = fs.readFileSync(
+      path.join(__dirname, '..', '..', 'scripts', 'server.js'),
+      'utf-8'
+    );
+  });
+
+  test('does not clear interactive terminal scrollback', () => {
+    const callbackStart = serverContent.indexOf('devServer.startCallback');
+    const callbackEnd = serverContent.indexOf('\n  });', callbackStart);
+    const startupCallback = serverContent.slice(callbackStart, callbackEnd);
+
+    expect(callbackStart).toBeGreaterThan(-1);
+    expect(startupCallback).not.toContain('console.clear()');
+  });
+});


### PR DESCRIPTION
This change removes the interactive-terminal `console.clear()` from the development-server startup callback and adds regression coverage. Startup logs now remain available in terminal scrollback while preserving the existing development-server startup message.

Verified with the focused startup-log test, all 907 unit tests, a Node syntax check, and diff validation. The original clearing behavior was reproduced before the fix.

Fixes #144