### PR TITLE
Implement /rename configure endpoint (#962)

### DIFF
--- a/docs/mmgis-openapi.json
+++ b/docs/mmgis-openapi.json
@@ -559,6 +559,66 @@
         }
       }
     },
+    "/api/configure/rename": {
+      "post": {
+        "summary": "Rename a mission configuration",
+        "tags": ["Configure"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mission": {
+                    "type": "string"
+                  },
+                  "newName": {
+                    "type": "string"
+                  }
+                },
+                "required": ["mission", "newName"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Rename mission config response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "success": {
+                    "summary": "Success",
+                    "value": {
+                      "status": "success",
+                      "message": "Successfully renamed mission to example_mission_renamed"
+                    }
+                  },
+                  "successWithWarnings": {
+                    "summary": "Success with warnings",
+                    "value": {
+                      "status": "success",
+                      "message": "Successfully renamed mission to example_mission_renamed",
+                      "warnings": [
+                        "These missions contain relative paths to example_mission that will need updating: other_mission"
+                      ]
+                    }
+                  },
+                  "failure": {
+                    "summary": "Failure",
+                    "value": {
+                      "status": "failure",
+                      "message": "A mission named example_mission_renamed already exists."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/configure/validate": {
       "post": {
         "summary": "Validate a mission configuration",

--- a/plugins/core/backend/Config/routes/configs.js
+++ b/plugins/core/backend/Config/routes/configs.js
@@ -894,7 +894,130 @@ if (fullAccess)
     }, { full: true, mission: req.body.existingMission });
   });
 
-if (fullAccess) router.post("/rename", function (req, res, next) {});
+if (fullAccess)
+  router.post("/rename", checkMissionPermission, function (req, res, next) {
+    const missionName = req.body.mission;
+    const newName = req.body.newName;
+
+    const nameRegex = /^[A-Za-z0-9_ -]+$/;
+    if (
+      !missionName ||
+      !nameRegex.test(missionName) ||
+      !newName ||
+      !nameRegex.test(newName)
+    ) {
+      logger("error", "Invalid mission name in rename request.", req.originalUrl, req);
+      res.send({ status: "failure", message: "Invalid mission name." });
+      return;
+    }
+    if (missionName === newName) {
+      res.send({
+        status: "failure",
+        message: "New mission name must differ from the current name.",
+      });
+      return;
+    }
+    const missionsBase = path.resolve("./Missions");
+    const resolvedSrc = path.resolve("./Missions/" + missionName);
+    const resolvedDest = path.resolve("./Missions/" + newName);
+    if (
+      (!resolvedSrc.startsWith(missionsBase + path.sep) &&
+        resolvedSrc !== missionsBase) ||
+      (!resolvedDest.startsWith(missionsBase + path.sep) &&
+        resolvedDest !== missionsBase)
+    ) {
+      logger("error", "Path traversal attempt in rename request.", req.originalUrl, req);
+      res.send({ status: "failure", message: "Invalid mission name." });
+      return;
+    }
+
+    Config.findAll({ where: { mission: newName } })
+      .then((existing) => {
+        if ((existing && existing.length > 0) || fs.existsSync(resolvedDest)) {
+          res.send({
+            status: "failure",
+            message: "A mission named " + newName + " already exists.",
+          });
+          return null;
+        }
+        return Config.findAll({ where: { mission: missionName } }).then(
+          (rows) => {
+            if (!rows || rows.length === 0) {
+              res.send({
+                status: "failure",
+                message: "Mission " + missionName + " not found.",
+              });
+              return null;
+            }
+            return sequelize
+              .transaction((t) => {
+                return Promise.all(
+                  rows.map((row) => {
+                    // Deep copy so Sequelize detects the JSON change
+                    const cfg = JSON.parse(JSON.stringify(row.config || {}));
+                    if (cfg.msv) {
+                      cfg.msv.mission = newName;
+                      cfg.msv.missionFolderName = newName;
+                    }
+                    return row.update(
+                      { mission: newName, config: cfg },
+                      { transaction: t }
+                    );
+                  })
+                );
+              })
+              .then(() => {
+                logger(
+                  "info",
+                  "Renamed Mission: " + missionName + " to " + newName,
+                  req.originalUrl,
+                  req
+                );
+                const srcDir = "./Missions/" + missionName;
+                const destDir = "./Missions/" + newName;
+                if (fs.existsSync(srcDir)) {
+                  fs.rename(srcDir, destDir, (err) => {
+                    if (err)
+                      res.send({
+                        status: "success",
+                        message:
+                          "Successfully renamed mission to " +
+                          newName +
+                          " but couldn't rename its Missions directory.",
+                      });
+                    else
+                      res.send({
+                        status: "success",
+                        message: "Successfully renamed mission to " + newName,
+                      });
+                  });
+                } else {
+                  res.send({
+                    status: "success",
+                    message: "Successfully renamed mission to " + newName,
+                  });
+                }
+                return null;
+              });
+          }
+        );
+      })
+      .catch((err) => {
+        logger(
+          "error",
+          "Failed to rename mission: " + missionName,
+          req.originalUrl,
+          req,
+          err
+        );
+        res.send({
+          status: "failure",
+          message: "Failed to rename mission " + missionName + ".",
+        });
+        return null;
+      });
+    return null;
+  });
 
 if (fullAccess)
   router.post("/destroy", checkMissionPermission, function (req, res, next) {

--- a/plugins/core/backend/Config/routes/configs.js
+++ b/plugins/core/backend/Config/routes/configs.js
@@ -7,6 +7,7 @@ const express = require("express");
 const router = express.Router();
 const execFile = require("child_process").execFile;
 const Sequelize = require("sequelize");
+const crypto = require("crypto");
 const { sequelize } = require("../../../../../API/connection");
 
 const logger = require("../../../../../API/logger");
@@ -894,6 +895,16 @@ if (fullAccess)
     }, { full: true, mission: req.body.existingMission });
   });
 
+// pg_advisory_xact_lock takes two 32 bit keys. Derive them from the target
+// name so concurrent renames into the same name serialize on the same lock.
+const renameLockKeys = (name) => {
+  const digest = crypto
+    .createHash("sha1")
+    .update("mission_rename:" + name)
+    .digest();
+  return [digest.readInt32BE(0), digest.readInt32BE(4)];
+};
+
 if (fullAccess)
   router.post("/rename", checkMissionPermission, function (req, res, next) {
     const missionName = req.body.mission;
@@ -908,6 +919,17 @@ if (fullAccess)
     ) {
       logger("error", "Invalid mission name in rename request.", req.originalUrl, req);
       res.send({ status: "failure", message: "Invalid mission name." });
+      return;
+    }
+    // Rename must be at least as strict as /add: a name you cannot create
+    // should not be reachable by renaming into it.
+    if (
+      newName !== newName.trim() ||
+      newName.trim().length === 0 ||
+      !isNaN(newName[0])
+    ) {
+      logger("error", "Bad new mission name in rename request.", req.originalUrl, req);
+      res.send({ status: "failure", message: "Bad mission name." });
       return;
     }
     if (missionName === newName) {
@@ -965,8 +987,27 @@ if (fullAccess)
               latestFolder === "" ||
               latestFolder === missionName;
 
+            const lockKeys = renameLockKeys(newName);
             return sequelize
-              .transaction((t) => {
+              .transaction(async (t) => {
+                // The check above is outside the transaction, so two callers
+                // can both see the name as free. A row lock cannot close that
+                // window because there are no rows to lock when the name is
+                // absent. Take a transaction scoped advisory lock on the target
+                // name instead, then re-check inside the transaction.
+                await sequelize.query(
+                  "SELECT pg_advisory_xact_lock($1, $2)",
+                  { bind: lockKeys, transaction: t }
+                );
+                const taken = await Config.findAll({
+                  where: { mission: newName },
+                  transaction: t,
+                });
+                if (taken && taken.length > 0) {
+                  const collision = new Error("mission name taken");
+                  collision.missionNameTaken = true;
+                  throw collision;
+                }
                 const configUpdates = rows.map((row) => {
                   // Deep copy so Sequelize detects the JSON change
                   const cfg = JSON.parse(JSON.stringify(row.config || {}));
@@ -1073,6 +1114,13 @@ if (fullAccess)
         );
       })
       .catch((err) => {
+        if (err && err.missionNameTaken) {
+          res.send({
+            status: "failure",
+            message: "A mission named " + newName + " already exists.",
+          });
+          return null;
+        }
         logger(
           "error",
           "Failed to rename mission: " + missionName,

--- a/plugins/core/backend/Config/routes/configs.js
+++ b/plugins/core/backend/Config/routes/configs.js
@@ -949,22 +949,64 @@ if (fullAccess)
               });
               return null;
             }
+
+            // The folder name is intentionally separable from the mission name.
+            // Only follow the rename when the mission currently points at its
+            // own folder; if it points elsewhere, leave the folder alone.
+            const latest = rows.reduce((a, b) =>
+              (b.version || 0) > (a.version || 0) ? b : a
+            );
+            const latestFolder =
+              latest.config && latest.config.msv
+                ? latest.config.msv.missionFolderName
+                : undefined;
+            const followFolder =
+              !latestFolder ||
+              latestFolder === "" ||
+              latestFolder === missionName;
+
             return sequelize
               .transaction((t) => {
-                return Promise.all(
-                  rows.map((row) => {
-                    // Deep copy so Sequelize detects the JSON change
-                    const cfg = JSON.parse(JSON.stringify(row.config || {}));
-                    if (cfg.msv) {
-                      cfg.msv.mission = newName;
+                const configUpdates = rows.map((row) => {
+                  // Deep copy so Sequelize detects the JSON change
+                  const cfg = JSON.parse(JSON.stringify(row.config || {}));
+                  if (cfg.msv) {
+                    cfg.msv.mission = newName;
+                    if (followFolder) {
                       cfg.msv.missionFolderName = newName;
                     }
-                    return row.update(
-                      { mission: newName, config: cfg },
-                      { transaction: t }
-                    );
-                  })
-                );
+                  }
+                  return row.update(
+                    { mission: newName, config: cfg },
+                    { transaction: t }
+                  );
+                });
+
+                // Mission-manager permissions are stored as mission names, so
+                // they must follow the rename or the manager loses access.
+                const permissionUpdate = User.findAll({
+                  transaction: t,
+                }).then((users) => {
+                  const affected = (users || []).filter(
+                    (u) =>
+                      Array.isArray(u.missions_managing) &&
+                      u.missions_managing.includes(missionName)
+                  );
+                  return Promise.all(
+                    affected.map((u) =>
+                      u.update(
+                        {
+                          missions_managing: u.missions_managing.map((m) =>
+                            m === missionName ? newName : m
+                          ),
+                        },
+                        { transaction: t }
+                      )
+                    )
+                  );
+                });
+
+                return Promise.all([...configUpdates, permissionUpdate]);
               })
               .then(() => {
                 logger(
@@ -973,31 +1015,59 @@ if (fullAccess)
                   req.originalUrl,
                   req
                 );
-                const srcDir = "./Missions/" + missionName;
-                const destDir = "./Missions/" + newName;
-                if (fs.existsSync(srcDir)) {
-                  fs.rename(srcDir, destDir, (err) => {
-                    if (err)
-                      res.send({
-                        status: "success",
-                        message:
+
+                // Other missions may embed ../OldName/ relative paths (written
+                // by clone/relativizePaths). Those silently break, so report them.
+                return Config.findAll().then((allRows) => {
+                  const needle = "../" + missionName + "/";
+                  const warnings = [];
+                  (allRows || []).forEach((row) => {
+                    if (row.mission === newName) {
+                      return;
+                    }
+                    try {
+                      if (JSON.stringify(row.config || {}).indexOf(needle) !== -1) {
+                        if (warnings.indexOf(row.mission) === -1) {
+                          warnings.push(row.mission);
+                        }
+                      }
+                    } catch (e) {
+                      // ignore unparsable configs
+                    }
+                  });
+
+                  const respond = (message) => {
+                    const payload = { status: "success", message: message };
+                    if (warnings.length > 0) {
+                      payload.warnings = [
+                        "These missions contain relative paths to " +
+                          missionName +
+                          " that will need updating: " +
+                          warnings.join(", "),
+                      ];
+                    }
+                    res.send(payload);
+                  };
+
+                  const srcDir = "./Missions/" + missionName;
+                  const destDir = "./Missions/" + newName;
+                  if (followFolder && fs.existsSync(srcDir)) {
+                    fs.rename(srcDir, destDir, (err) => {
+                      if (err) {
+                        respond(
                           "Successfully renamed mission to " +
-                          newName +
-                          " but couldn't rename its Missions directory.",
-                      });
-                    else
-                      res.send({
-                        status: "success",
-                        message: "Successfully renamed mission to " + newName,
-                      });
-                  });
-                } else {
-                  res.send({
-                    status: "success",
-                    message: "Successfully renamed mission to " + newName,
-                  });
-                }
-                return null;
+                            newName +
+                            " but couldn't rename its Missions directory."
+                        );
+                      } else {
+                        respond("Successfully renamed mission to " + newName);
+                      }
+                    });
+                  } else {
+                    respond("Successfully renamed mission to " + newName);
+                  }
+                  return null;
+                });
               });
           }
         );

--- a/plugins/core/backend/Config/tests/config.spec.js
+++ b/plugins/core/backend/Config/tests/config.spec.js
@@ -262,6 +262,81 @@ test.describe('Config API', () => {
     expect(renameBody.message).toMatch(/already exists/i);
   });
 
+  // POST /api/configure/rename — rejects names that /add would refuse
+  test('POST /api/configure/rename rejects names /add refuses', async ({ request }) => {
+    const mission = `RenameStrict-${Date.now()}`;
+
+    const add = await request.post(`${baseURL}/api/configure/add`, {
+      data: { mission: mission },
+    });
+    const addBody = await add.json();
+    if (addBody.status !== 'success') {
+      test.skip(true, 'Config add requires SuperAdmin — skipping strict name test');
+      return;
+    }
+    testMissionsCreated.push(mission);
+
+    // All whitespace, leading whitespace and a leading digit are rejected by
+    // /add, so renaming into them must be rejected too.
+    for (const badName of ['   ', ' Padded ', '9lives']) {
+      const response = await request.post(`${baseURL}/api/configure/rename`, {
+        data: { mission: mission, newName: badName },
+      });
+      expect(response.status()).toBeLessThan(500);
+      const body = await response.json();
+      expect(body.status).toBe('failure');
+      expect(body.message).toMatch(/bad mission name/i);
+    }
+  });
+
+  // POST /api/configure/rename — concurrent renames into one name, only one wins
+  test('POST /api/configure/rename serializes concurrent renames', async ({ request }) => {
+    const stamp = Date.now();
+    const missionA = `RaceSrcA-${stamp}`;
+    const missionB = `RaceSrcB-${stamp}`;
+    const target = `RaceTarget-${stamp}`;
+
+    const addA = await request.post(`${baseURL}/api/configure/add`, {
+      data: { mission: missionA },
+    });
+    const addABody = await addA.json();
+    if (addABody.status !== 'success') {
+      test.skip(true, 'Config add requires SuperAdmin — skipping concurrency test');
+      return;
+    }
+    testMissionsCreated.push(missionA);
+
+    const addB = await request.post(`${baseURL}/api/configure/add`, {
+      data: { mission: missionB },
+    });
+    expect((await addB.json()).status).toBe('success');
+    testMissionsCreated.push(missionB);
+    testMissionsCreated.push(target);
+
+    const [resA, resB] = await Promise.all([
+      request.post(`${baseURL}/api/configure/rename`, {
+        data: { mission: missionA, newName: target },
+      }),
+      request.post(`${baseURL}/api/configure/rename`, {
+        data: { mission: missionB, newName: target },
+      }),
+    ]);
+
+    const bodies = [await resA.json(), await resB.json()];
+    const succeeded = bodies.filter((b) => b.status === 'success');
+    const failed = bodies.filter((b) => b.status === 'failure');
+    expect(succeeded).toHaveLength(1);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].message).toMatch(/already exists/i);
+
+    // The loser must be untouched rather than merged into the target.
+    const list = await request.get(`${baseURL}/api/configure/missions`);
+    const missions = (await list.json()).missions || [];
+    expect(missions).toContain(target);
+    const survivors = [missionA, missionB].filter((m) => missions.includes(m));
+    expect(survivors).toHaveLength(1);
+  });
+
   // POST /api/configure/rename — rejects renaming a mission that does not exist
   test('POST /api/configure/rename rejects an unknown mission', async ({ request }) => {
     const response = await request.post(`${baseURL}/api/configure/rename`, {

--- a/plugins/core/backend/Config/tests/config.spec.js
+++ b/plugins/core/backend/Config/tests/config.spec.js
@@ -183,6 +183,95 @@ test.describe('Config API', () => {
     if (idx > -1) testMissionsCreated.splice(idx, 1);
   });
 
+  // POST /api/configure/rename — rename a mission and verify the new name
+  test('POST /api/configure/rename renames a mission', async ({ request }) => {
+    const testMission = `RenameMission-${Date.now()}`;
+    const renamedMission = `${testMission}-Renamed`;
+
+    const addRes = await request.post(`${baseURL}/api/configure/add`, {
+      data: { mission: testMission },
+    });
+    const addBody = await addRes.json();
+
+    if (addBody.status !== 'success') {
+      test.skip(true, 'Config add requires SuperAdmin — skipping rename test');
+      return;
+    }
+    testMissionsCreated.push(testMission);
+
+    const renameRes = await request.post(`${baseURL}/api/configure/rename`, {
+      data: { mission: testMission, newName: renamedMission },
+    });
+    expect(renameRes.status()).toBeLessThan(500);
+    const renameBody = await renameRes.json();
+    expect(renameBody.status).toBe('success');
+
+    // Old name gone, new name present
+    const listRes = await request.get(`${baseURL}/api/configure/missions`);
+    const listBody = await listRes.json();
+    expect(listBody.missions).not.toContain(testMission);
+    expect(listBody.missions).toContain(renamedMission);
+
+    // Clean up
+    await request.post(`${baseURL}/api/configure/destroy`, {
+      data: { mission: renamedMission },
+    });
+    const idx = testMissionsCreated.indexOf(testMission);
+    if (idx > -1) testMissionsCreated.splice(idx, 1);
+  });
+
+  // POST /api/configure/rename — rejects invalid names and path traversal
+  test('POST /api/configure/rename rejects invalid names', async ({ request }) => {
+    const response = await request.post(`${baseURL}/api/configure/rename`, {
+      data: { mission: 'SomeMission', newName: '../evil' },
+    });
+    expect(response.status()).toBeLessThan(500);
+    const body = await response.json();
+    expect(body.status).toBe('failure');
+    expect(body.message).toMatch(/invalid mission name/i);
+  });
+
+  // POST /api/configure/rename — rejects a rename to an existing mission name
+  test('POST /api/configure/rename rejects an existing target name', async ({ request }) => {
+    const missionA = `RenameSrc-${Date.now()}`;
+    const missionB = `RenameDst-${Date.now()}`;
+
+    const addA = await request.post(`${baseURL}/api/configure/add`, {
+      data: { mission: missionA },
+    });
+    const addABody = await addA.json();
+    if (addABody.status !== 'success') {
+      test.skip(true, 'Config add requires SuperAdmin — skipping collision test');
+      return;
+    }
+    testMissionsCreated.push(missionA);
+
+    const addB = await request.post(`${baseURL}/api/configure/add`, {
+      data: { mission: missionB },
+    });
+    const addBBody = await addB.json();
+    expect(addBBody.status).toBe('success');
+    testMissionsCreated.push(missionB);
+
+    const renameRes = await request.post(`${baseURL}/api/configure/rename`, {
+      data: { mission: missionA, newName: missionB },
+    });
+    expect(renameRes.status()).toBeLessThan(500);
+    const renameBody = await renameRes.json();
+    expect(renameBody.status).toBe('failure');
+    expect(renameBody.message).toMatch(/already exists/i);
+  });
+
+  // POST /api/configure/rename — rejects renaming a mission that does not exist
+  test('POST /api/configure/rename rejects an unknown mission', async ({ request }) => {
+    const response = await request.post(`${baseURL}/api/configure/rename`, {
+      data: { mission: `NoSuchMission-${Date.now()}`, newName: `Target-${Date.now()}` },
+    });
+    expect(response.status()).toBeLessThan(500);
+    const body = await response.json();
+    expect(body.status).toBe('failure');
+  });
+
   // Authorization: non-admin rejected (skip if AUTH=off)
   test('rejects non-admin config changes', async ({ request }) => {
     test.skip(


### PR DESCRIPTION
## Description
Implements the previously-empty `/api/configure/rename` route (fixes #962), following the existing `/destroy` and `/clone` patterns:
- Validates both `mission` and `newName` with the same name regex and path-traversal guards as `/destroy`
- Rejects renaming to a name that already exists (in the DB or as a `Missions/` directory)
- Updates the `mission` column across all config versions in a single transaction, including the embedded `msv.mission` / `msv.missionFolderName` fields inside each stored config (deep-copied so Sequelize detects the JSON change)
- Renames the `./Missions` directory afterwards, with a partial-success message if the directory move fails (matching `/destroy` behavior)
- Adds the `checkMissionPermission` middleware for consistency with `/upsert` and `/destroy`

Backend-only per the issue; happy to wire up the Configure UI in a follow-up.

## Testing
Verified locally (macOS, Node + Postgres 16, AUTH=none, admin session):
- Happy path: `{"mission":"RenameTest","newName":"RenameTestNew"}` → success; DB shows renamed rows with updated embedded config JSON, unrelated missions untouched
- Path traversal `../evil` → "Invalid mission name."
- Nonexistent mission → "Mission ... not found."
- Existing target name → "A mission named ... already exists."
- Same name → "New mission name must differ from the current name."