### PR TITLE
Use L_.missionPath in three mission data path call sites (#1038)

### DIFF
--- a/plugins/core/tools/Identifier/IdentifierTool.js
+++ b/plugins/core/tools/Identifier/IdentifierTool.js
@@ -830,7 +830,7 @@ function queryDataValue(url, lng, lat, numBands, layerUUID, callback) {
     } else if (url.startsWith('/vsicurl/') || url.startsWith('Missions/')) {
         dataPath = url
     } else {
-        dataPath = 'Missions/' + L_.mission + '/' + url
+        dataPath = L_.missionPath + url
     }
 
     dataPath = IdentifierTool.fillURLParameters(dataPath, layerUUID)

--- a/plugins/core/tools/Measure/MeasureTool.js
+++ b/plugins/core/tools/Measure/MeasureTool.js
@@ -1465,7 +1465,7 @@ function makeProfile() {
         // enable remote access via GDAL Virtual File Systems /vsi* prefix
         let pathDEM
         if (path.startsWith('/vsi')) pathDEM = path
-        else pathDEM = 'Missions/' + L_.mission + '/' + path
+        else pathDEM = L_.missionPath + path
 
         //elevPoints.push([{"x": clickedLatLngs[numOfPts - 2].x, "y": clickedLatLngs[numOfPts - 2].y}, {"x": clickedLatLngs[numOfPts - 1].x, "y": clickedLatLngs[numOfPts - 1].y}]);
         elevPoints = [

--- a/src/essence/Basics/Viewer_/Viewer_.js
+++ b/src/essence/Basics/Viewer_/Viewer_.js
@@ -183,8 +183,7 @@ var Viewer_ = {
             .html('To begin, select any imagery-enabled feature.')
         this.imageIntro.append(introMessage)
 
-        this.lookupPath =
-            'Missions/' + L_.mission + '/' + 'Data/mosaic_parameters.csv'
+        this.lookupPath = L_.missionPath + 'Data/mosaic_parameters.csv'
 
         buildToolBar()
 


### PR DESCRIPTION
Fixes #1038.

Three call sites built mission data paths from the mission display name rather than the configured mission folder:

- `Viewer_.js` mosaic parameters lookup path
- `IdentifierTool.js` layer data paths
- `MeasureTool.js` DEM paths

All three now use `L_.missionPath`, which is set to `'Missions/' + L_.missionFolderName + '/'` in `Layers_/lifecycle/config.js` and already carries the trailing slash, so the concatenations lose their separate `'/'`.

This matches the 30 other call sites that already resolve through `L_.missionPath`, including two in `Viewer_.js` itself. #772 introduced `missionFolderName` and converted `Layers_.js`, `LandingPage.js` and `essence.js`, but these three were missed.

Raised during review of #1030 and split out as a follow up, as suggested there.

## Testing

Change is a substitution of an equivalent expression: for a mission whose folder name matches its name, `L_.missionPath` produces the same string the old concatenation did, so existing behaviour is unchanged. For a mission whose folder name differs, the paths now resolve against the folder instead of the display name, which is the fix.

I did not exercise the three code paths end to end locally, since each needs mission data in place (a mosaic parameters CSV, a layer with a relative data URL, a DEM). Happy to set that up if you would like it verified that way before merging.
