### PR TITLE
Fix mock litho missing addLayerFor/onLayerToggle for globe-less missions

### DIFF
--- a/configure/package.json
+++ b/configure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configure",
-  "version": "5.3.5-20260813",
+  "version": "5.3.6-20260814",
   "homepage": "./configure/build",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmgis",
-  "version": "5.3.5-20260813",
+  "version": "5.3.6-20260814",
   "description": "A web-based mapping and localization solution for science operation on planetary missions.",
   "homepage": "build",
   "repository": {

--- a/src/essence/Basics/Globe_/Globe_.js
+++ b/src/essence/Basics/Globe_/Globe_.js
@@ -267,6 +267,12 @@ let Globe_ = {
             addLayer: function () {
                 return Promise.resolve()
             },
+             // Mirror GlobeRenderer.addLayerFor's async contract so callers that
+            // chain .then()/.catch() work when there is no globe panel.
+            addLayerFor: function () {
+                return Promise.resolve()
+            },
+            onLayerToggle: function () {},
             toggleLayer: function () {},
             hasLayer: function () {},
             getCenter: function () {},


### PR DESCRIPTION
## Purpose
- `getMockLitho` was missing `addLayerFor` and `onLayerToggle`, so errors were printed in the console when running a mission without the globe.
## Proposed Changes
- [FIX] Add `addLayerFor` and `onLayerToggle` to `getMockLitho`
