### PR TITLE
Added leaflet wraparound for lat/lon display

### DIFF
--- a/src/essence/Basics/UserInterface_/components/Coordinates/Coordinates.js
+++ b/src/essence/Basics/UserInterface_/components/Coordinates/Coordinates.js
@@ -702,8 +702,10 @@ function changeCoordType(newCoordIndex) {
 
 //Update mouse lat long coordinate display on mouse move
 function mouseLngLatMove(e) {
-    Coordinates.mouseLngLatRaw = [e.latlng.lng, e.latlng.lat]
-    Coordinates.mouseLngLat = [e.latlng.lng, e.latlng.lat]
+    // Normalize coordinates to -180/180 range using Leaflet's built-in method
+    const normalized = Map_.map.wrapLatLng(e.latlng)
+    Coordinates.mouseLngLatRaw = [normalized.lng, normalized.lat]
+    Coordinates.mouseLngLat = [normalized.lng, normalized.lat]
     if (
         L_.configData.coordinates &&
         L_.configData.coordinates.coordelev === true


### PR DESCRIPTION
## Purpose
Confusing for users to have a longitude value greater than 180 or less than -180. The purpose of this is to provide wraparound for the lat/lon visual display in the bottom right corner 
<img width="410" height="103" alt="Screenshot 2026-08-25 at 10 20 30 AM" src="https://github.com/user-attachments/assets/6ba6d80f-0930-435d-91aa-b09c1999c4d8" />

## Proposed Changes
- [CHANGE] Longitude wraps around in display using built in leaflet function 
## Issues
Discussed on slack 
## Testing
Tested locally going to the far left of the screen and the far right with and without "World Copy Jump" turned on (this is configured in the config -> User Interface page)
Confirmed that the longitude never goes over 180 or under -180